### PR TITLE
feat: add max_step to doubling for monotonic predicate search

### DIFF
--- a/lib/algorithm/doubling.hpp
+++ b/lib/algorithm/doubling.hpp
@@ -28,6 +28,30 @@ struct doubling {
         return std::make_pair(f, res);
     }
 
+    /// @brief check(M::op(init, accumulated)) が真である最大ステップ数を返す
+    /// @details check は単調 (真→偽に一度だけ変化) を仮定する
+    template <class F>
+    std::uint64_t max_step(int f, T init, F check) {
+        assert(-1 <= f && f < _size);
+        T acc = init;
+        std::uint64_t steps = 0;
+        for (int i = L - 1; i >= 0; --i) {
+            if (f == -1) break;
+            T next_acc = M::op(acc, data[i][f]);
+            if (check(next_acc)) {
+                acc = next_acc;
+                f = table[i][f];
+                steps |= std::uint64_t(1) << i;
+            }
+        }
+        return steps;
+    }
+
+    template <class F>
+    std::uint64_t max_step(int f, F check) {
+        return max_step(f, M::id(), check);
+    }
+
   private:
     int _size;
     std::vector<std::vector<int>> table;


### PR DESCRIPTION
## Summary
- `doubling` に、単調な述語 `check` を満たす最大ステップ数を求める `max_step` を追加
- 初期値 `init` を指定するオーバーロードと、`M::id()` を初期値とする簡易版を提供

## Test plan
- [ ] 既存テストが通ること
- [ ] `check` が常に真／常に偽のケースで境界が正しいこと
- [ ] `f = -1` 到達時に早期終了することの確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)