### PR TITLE
refactor: unify static/dynamic modint via CRTP and concepts

### DIFF
--- a/lib/algorithm/offline_binomial_sum.hpp
+++ b/lib/algorithm/offline_binomial_sum.hpp
@@ -1,12 +1,10 @@
 #pragma once
-#include <concepts>
 #include <vector>
 #include "algorithm/mo.hpp"
 #include "math/combination.hpp"
 #include "math/modint.hpp"
 
-template <class mint = modint998>
-requires(std::derived_from<mint, internal::modint_base>)
+template <internal::modint mint = modint998>
 std::vector<mint> offline_binomial_sum(const std::vector<std::pair<int, int>> &queries) {
     std::vector<mint> res(queries.size());
     if (queries.empty()) return res;

--- a/lib/fft/formal_power_series.hpp
+++ b/lib/fft/formal_power_series.hpp
@@ -9,7 +9,7 @@
 
 namespace fps {
 
-template <class mint, internal::is_static_modint_t<mint> * = nullptr>
+template <internal::static_modint_c mint>
 std::vector<mint> plus(const std::vector<mint> &f, const std::vector<mint> &g) {
     int n = f.size(), m = g.size();
     int s = std::max(n, m);
@@ -19,7 +19,7 @@ std::vector<mint> plus(const std::vector<mint> &f, const std::vector<mint> &g) {
     return res;
 }
 
-template <class mint, internal::is_static_modint_t<mint> * = nullptr>
+template <internal::static_modint_c mint>
 std::vector<mint> inv(const std::vector<mint> &h, int deg) {
     assert(!h.empty() && h[0] != mint(0));
     std::vector<mint> res(deg);
@@ -45,12 +45,12 @@ std::vector<mint> inv(const std::vector<mint> &h, int deg) {
     return res;
 }
 
-template <class mint, internal::is_static_modint_t<mint> * = nullptr>
+template <internal::static_modint_c mint>
 std::vector<mint> inv(const std::vector<mint> &h) {
     return inv(h, h.size());
 }
 
-template <class mint, internal::is_static_modint_t<mint> * = nullptr>
+template <internal::static_modint_c mint>
 std::vector<mint> log(const std::vector<mint> &h, int deg) {
     assert(!h.empty() && h[0] == 1);
     std::vector<mint> f(h.size() - 1);
@@ -62,12 +62,12 @@ std::vector<mint> log(const std::vector<mint> &h, int deg) {
     return f;
 }
 
-template <class mint, internal::is_static_modint_t<mint> * = nullptr>
+template <internal::static_modint_c mint>
 std::vector<mint> log(const std::vector<mint> &h) {
     return log(h, h.size());
 }
 
-template <class mint, internal::is_static_modint_t<mint> * = nullptr>
+template <internal::static_modint_c mint>
 std::vector<mint> exp(const std::vector<mint> &h, int deg) {
     std::vector<mint> f(deg), g(deg);
     f[0] = 1;
@@ -111,12 +111,12 @@ std::vector<mint> exp(const std::vector<mint> &h, int deg) {
     return f;
 }
 
-template <class mint, internal::is_static_modint_t<mint> * = nullptr>
+template <internal::static_modint_c mint>
 std::vector<mint> exp(const std::vector<mint> &h) {
     return exp(h, h.size());
 }
 
-template <class mint, internal::is_static_modint_t<mint> * = nullptr>
+template <internal::static_modint_c mint>
 std::vector<mint> pow(const std::vector<mint> &h, std::int64_t m, int deg) {
     if (m == 0) {
         std::vector<mint> res(deg, 0);
@@ -144,12 +144,12 @@ std::vector<mint> pow(const std::vector<mint> &h, std::int64_t m, int deg) {
     return res;
 }
 
-template <class mint, internal::is_static_modint_t<mint> * = nullptr>
+template <internal::static_modint_c mint>
 std::vector<mint> pow(const std::vector<mint> &h, std::int64_t m) {
     return pow(h, m, h.size());
 }
 
-template <class mint, internal::is_static_modint_t<mint> * = nullptr>
+template <internal::static_modint_c mint>
 std::pair<std::vector<mint>, std::vector<mint>> div_mod(std::vector<mint> f, std::vector<mint> g) {
     while (!f.empty() && f.back() == mint()) f.pop_back();
     while (!g.empty() && g.back() == mint()) g.pop_back();
@@ -172,17 +172,17 @@ std::pair<std::vector<mint>, std::vector<mint>> div_mod(std::vector<mint> f, std
     return {q, r};
 }
 
-template <class mint, internal::is_static_modint_t<mint> * = nullptr>
+template <internal::static_modint_c mint>
 std::vector<mint> div(const std::vector<mint> &f, const std::vector<mint> &g) {
     return div_mod(f, g).first;
 }
 
-template <class mint, internal::is_static_modint_t<mint> * = nullptr>
+template <internal::static_modint_c mint>
 std::vector<mint> mod(const std::vector<mint> &f, const std::vector<mint> &g) {
     return div_mod(f, g).second;
 }
 
-template <class mint, internal::is_static_modint_t<mint> * = nullptr>
+template <internal::static_modint_c mint>
 std::vector<mint> multipoint_evaluation(const std::vector<mint> &f, const std::vector<mint> &x) {
     int n = x.size();
     int m = std::bit_ceil<unsigned>(n);
@@ -199,7 +199,7 @@ std::vector<mint> multipoint_evaluation(const std::vector<mint> &f, const std::v
     return res;
 }
 
-template <class mint, internal::is_static_modint_t<mint> * = nullptr>
+template <internal::static_modint_c mint>
 std::vector<mint> polynomial_interpolation(const std::vector<mint> &x, const std::vector<mint> &y) {
     int n = x.size();
     int m = std::bit_ceil<unsigned>(n);
@@ -219,7 +219,7 @@ std::vector<mint> polynomial_interpolation(const std::vector<mint> &x, const std
     return g[1];
 }
 
-template <class mint, internal::is_static_modint_t<mint> * = nullptr>
+template <internal::static_modint_c mint>
 std::vector<mint> taylor_shift(std::vector<mint> f, mint c) {
     int n = f.size();
     static Combination<mint> comb;

--- a/lib/fft/ntt.hpp
+++ b/lib/fft/ntt.hpp
@@ -15,7 +15,7 @@
  * @param b
  * @return std::vector<mint>
  */
-template <class mint, internal::is_static_modint_t<mint> * = nullptr>
+template <internal::static_modint_c mint>
 std::vector<mint> convolution(std::vector<mint> &&a, std::vector<mint> &&b) {
     int n = int(a.size()), m = int(b.size());
     if (!n || !m) return {};
@@ -26,7 +26,7 @@ std::vector<mint> convolution(std::vector<mint> &&a, std::vector<mint> &&b) {
     if (std::min(n, m) <= 60) return convolution_naive(a, b);
     return internal::convolution_fft(a, b);
 }
-template <class mint, internal::is_static_modint_t<mint> * = nullptr>
+template <internal::static_modint_c mint>
 std::vector<mint> convolution(const std::vector<mint> &a, const std::vector<mint> &b) {
     int n = int(a.size()), m = int(b.size());
     if (!n || !m) return {};

--- a/lib/internal/internal_fft.hpp
+++ b/lib/internal/internal_fft.hpp
@@ -12,7 +12,7 @@
 
 namespace internal {
 
-template <class mint, int g = internal::primitive_root<mint::mod()>, internal::is_static_modint_t<mint> * = nullptr>
+template <internal::static_modint_c mint, int g = internal::primitive_root<mint::mod()>>
 struct fft_info {
     static constexpr int rank2 = std::countr_zero<unsigned>(mint::mod() - 1);
     std::array<mint, rank2 + 1> root, iroot;
@@ -48,7 +48,7 @@ struct fft_info {
     }
 };
 
-template <class mint, internal::is_static_modint_t<mint> * = nullptr>
+template <internal::static_modint_c mint>
 void butterfly(std::vector<mint> &a) {
     int n = int(a.size());
     int h = std::countr_zero<unsigned>(n);
@@ -94,7 +94,7 @@ void butterfly(std::vector<mint> &a) {
     }
 }
 
-template <class mint, internal::is_static_modint_t<mint> * = nullptr>
+template <internal::static_modint_c mint>
 void butterfly_inv(std::vector<mint> &a) {
     int n = int(a.size());
     int h = std::countr_zero<unsigned>(n);
@@ -139,7 +139,7 @@ void butterfly_inv(std::vector<mint> &a) {
     }
 }
 
-template <class mint, internal::is_static_modint_t<mint> * = nullptr>
+template <internal::static_modint_c mint>
 std::vector<mint> convolution_naive(const std::vector<mint> &a, const std::vector<mint> &b) {
     int n = int(a.size()), m = int(b.size());
     std::vector<mint> ans(n + m - 1);
@@ -155,7 +155,7 @@ std::vector<mint> convolution_naive(const std::vector<mint> &a, const std::vecto
     return ans;
 }
 
-template <class mint, internal::is_static_modint_t<mint> * = nullptr>
+template <internal::static_modint_c mint>
 std::vector<mint> convolution_fft(std::vector<mint> a, std::vector<mint> b) {
     int n = int(a.size()), m = int(b.size());
     int z = std::bit_ceil<unsigned>(n + m - 1);

--- a/lib/math/bell.hpp
+++ b/lib/math/bell.hpp
@@ -2,7 +2,7 @@
 #include <vector>
 #include "fft/formal_power_series.hpp"
 
-template <class mint, internal::is_static_modint_t<mint> * = nullptr>
+template <internal::static_modint_c mint>
 std::vector<mint> bell(int n) {
     if (n == 0) return std::vector<mint>(1, mint(1));
     std::vector<mint> res(n + 1);

--- a/lib/math/combination.hpp
+++ b/lib/math/combination.hpp
@@ -1,12 +1,10 @@
 #pragma once
 #include <cassert>
-#include <concepts>
 #include <vector>
 #include "math/modint.hpp"
 
 /// @brief 二項係数
-template <class mint = modint998>
-requires(std::derived_from<mint, internal::modint_base>)
+template <internal::modint mint = modint998>
 struct Combination {
     Combination() : _fact(), _inv(), _finv() {}
 

--- a/lib/math/enumeration.hpp
+++ b/lib/math/enumeration.hpp
@@ -1,11 +1,9 @@
 #pragma once
-#include <concepts>
 #include <vector>
 #include "math/combination.hpp"
 #include "math/modint.hpp"
 
-template <class mint = modint998>
-requires(std::derived_from<mint, internal::modint_base>)
+template <internal::modint mint = modint998>
 struct Enumeration {
     Enumeration() : _binom(), _data() {}
 

--- a/lib/math/modint.hpp
+++ b/lib/math/modint.hpp
@@ -9,87 +9,65 @@
 namespace internal {
 
 struct modint_base {};
-struct static_modint_base : modint_base {};
+struct static_modint_base {};
 
 template <class T>
-using is_modint = std::is_base_of<modint_base, T>;
-template <class T>
-using is_modint_t = std::enable_if_t<is_modint<T>::value>;
+concept modint = std::is_base_of_v<modint_base, T>;
 
-}  // namespace internal
-
-template <int m>
-requires(m >= 1)
-struct static_modint : internal::static_modint_base {
-    using mint = static_modint;
-
-  public:
-    static constexpr int mod() { return m; }
-    static constexpr mint raw(int v) {
-        mint x;
-        x._v = v;
-        return x;
-    }
-
-    constexpr static_modint() : _v(0) {}
-    template <std::integral T>
-    constexpr static_modint(T v) : _v(0) {
-        std::int64_t x = (std::int64_t)(v % (std::int64_t)(umod()));
-        if (x < 0) x += umod();
-        _v = (unsigned int)(x);
-    }
-    template <std::unsigned_integral T>
-    constexpr static_modint(T v) : _v(0) {
-        _v = (unsigned int)(v % umod());
-    }
+/// CRTP base sharing operator logic between static_modint and dynamic_modint.
+/// Derived must provide:
+///   static {constexpr} unsigned int umod();
+///   static {constexpr} unsigned int mul(unsigned int a, unsigned int b);
+///   static {constexpr} bool is_prime_mod();
+template <class Derived>
+struct modint_common : modint_base {
+    using mint = Derived;
 
     constexpr unsigned int val() const { return _v; }
 
     constexpr mint &operator++() {
-        _v++;
-        if (_v == umod()) _v = 0;
-        return *this;
+        ++_v;
+        if (_v == Derived::umod()) _v = 0;
+        return derived();
     }
     constexpr mint &operator--() {
-        if (_v == 0) _v = umod();
-        _v--;
-        return *this;
+        if (_v == 0) _v = Derived::umod();
+        --_v;
+        return derived();
     }
     constexpr mint operator++(int) {
-        mint result = *this;
+        mint result = derived();
         ++*this;
         return result;
     }
     constexpr mint operator--(int) {
-        mint result = *this;
+        mint result = derived();
         --*this;
         return result;
     }
 
     constexpr mint &operator+=(const mint &rhs) {
         _v += rhs._v;
-        if (_v >= umod()) _v -= umod();
-        return *this;
+        if (_v >= Derived::umod()) _v -= Derived::umod();
+        return derived();
     }
     constexpr mint &operator-=(const mint &rhs) {
-        _v -= rhs._v;
-        if (_v >= umod()) _v += umod();
-        return *this;
+        _v += Derived::umod() - rhs._v;
+        if (_v >= Derived::umod()) _v -= Derived::umod();
+        return derived();
     }
     constexpr mint &operator*=(const mint &rhs) {
-        std::uint64_t z = _v;
-        z *= rhs._v;
-        _v = (unsigned int)(z % umod());
-        return *this;
+        _v = Derived::mul(_v, rhs._v);
+        return derived();
     }
     constexpr mint &operator/=(const mint &rhs) { return *this *= rhs.inv(); }
 
-    constexpr mint operator+() const { return *this; }
-    constexpr mint operator-() const { return mint() - *this; }
+    constexpr mint operator+() const { return derived(); }
+    constexpr mint operator-() const { return mint() - derived(); }
 
     constexpr mint pow(std::int64_t n) const {
         assert(0 <= n);
-        mint x = *this, r = 1;
+        mint x = derived(), r = 1;
         while (n) {
             if (n & 1) r *= x;
             x *= x;
@@ -98,11 +76,11 @@ struct static_modint : internal::static_modint_base {
         return r;
     }
     constexpr mint inv() const {
-        if (prime) {
+        if (Derived::is_prime_mod()) {
             assert(_v);
-            return pow(umod() - 2);
+            return pow(Derived::umod() - 2);
         } else {
-            auto eg = internal::inv_gcd(_v, m);
+            auto eg = internal::inv_gcd(_v, Derived::umod());
             assert(eg.first == 1);
             return eg.second;
         }
@@ -120,19 +98,63 @@ struct static_modint : internal::static_modint_base {
         rhs = mint(t);
         return is;
     }
-    friend constexpr std::ostream &operator<<(std::ostream &os, const mint &rhs) { return os << rhs._v; }
+    friend std::ostream &operator<<(std::ostream &os, const mint &rhs) { return os << rhs._v; }
+
+  protected:
+    unsigned int _v = 0;
 
   private:
-    unsigned int _v;
+    constexpr mint &derived() { return *static_cast<mint *>(this); }
+    constexpr const mint &derived() const { return *static_cast<const mint *>(this); }
+};
+
+}  // namespace internal
+
+template <int m>
+requires(m >= 1)
+struct static_modint : internal::static_modint_base, internal::modint_common<static_modint<m>> {
+    using mint = static_modint;
+    using base = internal::modint_common<static_modint>;
+    using base::_v;
+
+  public:
     static constexpr unsigned int umod() { return m; }
-    static constexpr bool prime = internal::is_prime<m>;
+    static constexpr bool is_prime_mod() { return internal::is_prime<m>; }
+    static constexpr unsigned int mul(unsigned int a, unsigned int b) {
+        return (unsigned int)((std::uint64_t)a * b % umod());
+    }
+
+    static constexpr int mod() { return m; }
+    static constexpr mint raw(int v) {
+        mint x;
+        x._v = v;
+        return x;
+    }
+
+    constexpr static_modint() = default;
+    template <std::integral T>
+    constexpr static_modint(T v) {
+        std::int64_t x = (std::int64_t)(v % (std::int64_t)(umod()));
+        if (x < 0) x += umod();
+        _v = (unsigned int)(x);
+    }
+    template <std::unsigned_integral T>
+    constexpr static_modint(T v) {
+        _v = (unsigned int)(v % umod());
+    }
 };
 
 template <int id>
-struct dynamic_modint : internal::modint_base {
+struct dynamic_modint : internal::modint_common<dynamic_modint<id>> {
     using mint = dynamic_modint;
+    using base = internal::modint_common<dynamic_modint>;
+    using base::_v;
 
   public:
+    static unsigned int umod() { return bt.umod(); }
+    static bool is_prime_mod() { return false; }
+    static unsigned int mul(unsigned int a, unsigned int b) { return bt.mul(a, b); }
+
     static int mod() { return (int)(bt.umod()); }
     static void set_mod(int m) {
         assert(1 <= m);
@@ -144,7 +166,7 @@ struct dynamic_modint : internal::modint_base {
         return x;
     }
 
-    dynamic_modint() : _v(0) {}
+    dynamic_modint() = default;
     template <std::integral T>
     dynamic_modint(T v) {
         std::int64_t x = (std::int64_t)(v % (std::int64_t)(mod()));
@@ -156,82 +178,8 @@ struct dynamic_modint : internal::modint_base {
         _v = (unsigned int)(v % mod());
     }
 
-    unsigned int val() const { return _v; }
-
-    mint &operator++() {
-        _v++;
-        if (_v == umod()) _v = 0;
-        return *this;
-    }
-    mint &operator--() {
-        if (_v == 0) _v = umod();
-        _v--;
-        return *this;
-    }
-    mint operator++(int) {
-        mint result = *this;
-        ++*this;
-        return result;
-    }
-    mint operator--(int) {
-        mint result = *this;
-        --*this;
-        return result;
-    }
-
-    mint &operator+=(const mint &rhs) {
-        _v += rhs._v;
-        if (_v >= umod()) _v -= umod();
-        return *this;
-    }
-    mint &operator-=(const mint &rhs) {
-        _v += mod() - rhs._v;
-        if (_v >= umod()) _v -= umod();
-        return *this;
-    }
-    mint &operator*=(const mint &rhs) {
-        _v = bt.mul(_v, rhs._v);
-        return *this;
-    }
-    mint &operator/=(const mint &rhs) { return *this *= rhs.inv(); }
-
-    mint operator+() const { return *this; }
-    mint operator-() const { return mint() - *this; }
-
-    mint pow(std::int64_t n) const {
-        assert(0 <= n);
-        mint x = *this, r = 1;
-        while (n) {
-            if (n & 1) r *= x;
-            x *= x;
-            n >>= 1;
-        }
-        return r;
-    }
-    mint inv() const {
-        auto eg = internal::inv_gcd(_v, mod());
-        assert(eg.first == 1);
-        return eg.second;
-    }
-
-    friend mint operator+(const mint &lhs, const mint &rhs) { return mint(lhs) += rhs; }
-    friend mint operator-(const mint &lhs, const mint &rhs) { return mint(lhs) -= rhs; }
-    friend mint operator*(const mint &lhs, const mint &rhs) { return mint(lhs) *= rhs; }
-    friend mint operator/(const mint &lhs, const mint &rhs) { return mint(lhs) /= rhs; }
-    friend bool operator==(const mint &lhs, const mint &rhs) { return lhs._v == rhs._v; }
-    friend bool operator!=(const mint &lhs, const mint &rhs) { return lhs._v != rhs._v; }
-    friend std::istream &operator>>(std::istream &is, mint &rhs) {
-        std::int64_t t;
-        is >> t;
-        rhs = mint(t);
-        return is;
-    }
-    friend constexpr std::ostream &operator<<(std::ostream &os, const mint &rhs) { return os << rhs._v; }
-
   private:
-    unsigned int _v;
     static internal::barrett bt;
-    static unsigned int umod() { return bt.umod(); }
 };
 template <int id>
 internal::barrett dynamic_modint<id>::bt(998244353);
@@ -243,17 +191,14 @@ using modint = dynamic_modint<-1>;
 namespace internal {
 
 template <class T>
-using is_static_modint = std::is_base_of<internal::static_modint_base, T>;
-
-template <class T>
-using is_static_modint_t = std::enable_if_t<is_static_modint<T>::value>;
+concept static_modint_c = std::is_base_of_v<static_modint_base, T>;
 
 template <class>
-struct is_dynamic_modint : public std::false_type {};
+inline constexpr bool is_dynamic_modint_v = false;
 template <int id>
-struct is_dynamic_modint<dynamic_modint<id>> : public std::true_type {};
+inline constexpr bool is_dynamic_modint_v<dynamic_modint<id>> = true;
 
 template <class T>
-using is_dynamic_modint_t = std::enable_if_t<is_dynamic_modint<T>::value>;
+concept dynamic_modint_c = is_dynamic_modint_v<T>;
 
 }  // namespace internal

--- a/lib/math/sqrt.hpp
+++ b/lib/math/sqrt.hpp
@@ -1,15 +1,12 @@
 #pragma once
-#include <concepts>
 #include "math/modint.hpp"
 
-template <class mint>
-requires(std::derived_from<mint, internal::modint_base>)
+template <internal::modint mint>
 bool has_sqrt_mod(mint x) {
     return x == 0 || x.pow(mint::mod() / 2) == 1;
 }
 
-template <class mint>
-requires(std::derived_from<mint, internal::modint_base>)
+template <internal::modint mint>
 mint sqrt_mod(mint x) {
     const int p = mint::mod();
     if (x == 0 || x == 1) return x;


### PR DESCRIPTION
## Summary
- Introduce `internal::modint_common<Derived>` CRTP base that holds the shared operator logic for `static_modint` and `dynamic_modint`. Each derived type only supplies `umod()`, `mul()`, and `is_prime_mod()`, eliminating duplicated `+=/-=/*=/pow/inv/++/--/I-O` code.
- Replace the SFINAE-style `is_*_modint_t<T>* = nullptr` constraints with C++20 concepts: `internal::modint`, `internal::static_modint_c`, `internal::dynamic_modint_c`. All callers in `combination`, `enumeration`, `sqrt`, `bell`, `offline_binomial_sum`, `ntt`, `formal_power_series`, and `internal_fft` now use the cleaner `template <internal::static_modint_c mint>` form.
- Net change: -64 lines, no behavioral difference (`dynamic_modint` operations remain non-constexpr by design — barrett reduction relies on a static member).

## Test plan
- [ ] CI verify (existing test suite covers all touched headers — 38 affected test files compile cleanly locally with `g++ -std=c++20 -fsyntax-only`)
- [ ] Smoke test confirms `static_modint` constexpr evaluation and `dynamic_modint` runtime ops produce identical output to pre-refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)