### PR TITLE
refactor: モノイドを concept で制約し、単位元のバグを修正

### DIFF
--- a/lib/data_structure/disjoint_sparse_table.hpp
+++ b/lib/data_structure/disjoint_sparse_table.hpp
@@ -2,9 +2,10 @@
 #include <bit>
 #include <cassert>
 #include <vector>
+#include "segtree/monoid.hpp"
 
 /// @brief Disjoint Sparse Table
-template <class M>
+template <monoid M>
 struct disjoint_sparse_table {
   private:
     using T = typename M::value_type;

--- a/lib/data_structure/dynamic_sequence.hpp
+++ b/lib/data_structure/dynamic_sequence.hpp
@@ -5,9 +5,11 @@
 #include <utility>
 #include <vector>
 #include "random/xoroshiro128.hpp"
+#include "segtree/monoid.hpp"
 
 /// @brief 動的配列
-template <class M, class UniformRandomBitGenerator = xoroshiro128>
+/// @tparam UniformRandomBitGenerator 平衡用の優先度を生成する乱数生成器
+template <monoid M, class UniformRandomBitGenerator = xoroshiro128>
 struct dynamic_sequence {
   private:
     using T = typename M::value_type;

--- a/lib/data_structure/linear_sparse_table.hpp
+++ b/lib/data_structure/linear_sparse_table.hpp
@@ -28,7 +28,7 @@ struct fixed_stack {
 }  // namespace internal
 
 /// @brief 線形 Sparse Table
-template <class M>
+template <monoid M>
 struct linear_sparse_table {
   private:
     using T = M::value_type;

--- a/lib/data_structure/sparse_table.hpp
+++ b/lib/data_structure/sparse_table.hpp
@@ -2,9 +2,10 @@
 #include <bit>
 #include <cassert>
 #include <vector>
+#include "segtree/monoid.hpp"
 
 /// @brief スパーステーブル
-template <class M>
+template <monoid M>
 struct sparse_table {
   private:
     using T = typename M::value_type;

--- a/lib/data_structure/swag.hpp
+++ b/lib/data_structure/swag.hpp
@@ -3,7 +3,7 @@
 #include "segtree/monoid.hpp"
 
 /// @brief Sliding Window Aggregation
-template <class M>
+template <monoid M>
 struct sliding_window_aggregation {
   private:
     using T = typename M::value_type;

--- a/lib/persistent_ds/persistent_dual_segment_tree.hpp
+++ b/lib/persistent_ds/persistent_dual_segment_tree.hpp
@@ -3,7 +3,7 @@
 #include "segtree/monoid.hpp"
 
 /// @brief 永続双対セグメント木
-template <class M>
+template <monoid M>
 struct persistent_dual_segment_tree {
   private:
     using T = typename M::value_type;

--- a/lib/persistent_ds/persistent_lazy_segment_tree.hpp
+++ b/lib/persistent_ds/persistent_lazy_segment_tree.hpp
@@ -4,7 +4,10 @@
 #include "segtree/monoid.hpp"
 
 /// @brief 永続遅延評価セグメント木
+/// @tparam S データのモノイド
+/// @tparam F 作用素モノイド（op が作用素の合成、f が値への作用）
 template <class S, class F>
+requires monoid<S> && monoid<F> && acts_on<F, typename S::value_type>
 struct persistent_lazy_segment_tree {
   private:
     using T = typename S::value_type;

--- a/lib/persistent_ds/persistent_segment_tree.hpp
+++ b/lib/persistent_ds/persistent_segment_tree.hpp
@@ -4,7 +4,7 @@
 #include "segtree/monoid.hpp"
 
 /// @brief 永続セグメント木
-template <class M>
+template <monoid M>
 struct persistent_segment_tree {
   private:
     using T = typename M::value_type;

--- a/lib/segtree/dual_segment_tree.hpp
+++ b/lib/segtree/dual_segment_tree.hpp
@@ -5,7 +5,7 @@
 #include "segtree/monoid.hpp"
 
 /// @brief 双対セグメント木
-template <class M>
+template <monoid M>
 struct dual_segment_tree {
   private:
     using T = typename M::value_type;

--- a/lib/segtree/dynamic_lazy_segment_tree.hpp
+++ b/lib/segtree/dynamic_lazy_segment_tree.hpp
@@ -7,7 +7,10 @@
 #include "segtree/monoid.hpp"
 
 /// @brief 動的遅延評価セグメント木
+/// @tparam S データのモノイド
+/// @tparam F 作用素モノイド（op が作用素の合成、f が値への作用）
 template <class S, class F>
+requires monoid<S> && monoid<F> && acts_on<F, typename S::value_type>
 struct dynamic_lazy_segment_tree {
   private:
     using T = typename S::value_type;

--- a/lib/segtree/dynamic_segment_tree.hpp
+++ b/lib/segtree/dynamic_segment_tree.hpp
@@ -6,12 +6,8 @@
 #include <vector>
 #include "segtree/monoid.hpp"
 
-/**
- * @brief 動的セグメント木
- *
- * @tparam M モノイド
- */
-template <class M>
+/// @brief 動的セグメント木
+template <monoid M>
 struct dynamic_segment_tree {
   private:
     using T = typename M::value_type;

--- a/lib/segtree/filtered_segment_tree.hpp
+++ b/lib/segtree/filtered_segment_tree.hpp
@@ -6,8 +6,8 @@
 #include "segtree/segment_tree.hpp"
 
 /// @brief 要素を特定のキー（条件）でフィルタリングして区間取得を行えるセグメント木
-/// @tparam M モノイド
-template <class K, class M>
+/// @tparam K フィルタリングに用いるキーの型
+template <class K, monoid M>
 struct filtered_segment_tree {
   private:
     using T = typename M::value_type;

--- a/lib/segtree/lazy_segment_tree.hpp
+++ b/lib/segtree/lazy_segment_tree.hpp
@@ -6,7 +6,10 @@
 
 /// @brief 遅延評価セグメント木
 /// @see https://github.com/atcoder/ac-library/blob/master/atcoder/lazysegtree.hpp
+/// @tparam S データのモノイド
+/// @tparam F 作用素モノイド（op が作用素の合成、f が値への作用）
 template <class S, class F>
+requires monoid<S> && monoid<F> && acts_on<F, typename S::value_type>
 struct lazy_segment_tree {
   private:
     using T = typename S::value_type;

--- a/lib/segtree/monoid.hpp
+++ b/lib/segtree/monoid.hpp
@@ -1,135 +1,191 @@
 #pragma once
 #include <algorithm>
+#include <concepts>
 #include <limits>
 #include <numeric>
 #include <utility>
 
+/// @brief モノイドの要件
+/// @details 値型 `value_type`、単位元 `id()`、二項演算 `op()` を持つこと。
+/// @tparam M 判定対象の型
+template <class M>
+concept monoid = requires {
+    typename M::value_type;
+    { M::id() } -> std::same_as<typename M::value_type>;
+    {
+        M::op(std::declval<const typename M::value_type &>(),
+              std::declval<const typename M::value_type &>())
+    } -> std::same_as<typename M::value_type>;
+};
+
+/// @brief 作用素モノイド M を値型 U に作用させられるか
+/// @details モノイドに加えて作用 `f(作用素, 値)` を持つこと。遅延セグ木では `op` が作用素の合成、
+///          `f` が値への作用を表す。`f` は関数テンプレートでも非テンプレートでもよい。
+/// @tparam M 作用素モノイド
+/// @tparam U 作用させる値の型
+template <class M, class U>
+concept acts_on = monoid<M> && requires(const typename M::value_type &m, const U &x) {
+    { M::f(m, x) } -> std::convertible_to<U>;
+};
+
+/// @brief 和モノイド
+/// @tparam T 要素の型
 template <class T>
 struct Add {
     using value_type = T;
-    static constexpr T id() { return T(); }
-    static constexpr T op(const T &lhs, const T &rhs) { return lhs + rhs; }
+    static constexpr T id() noexcept { return T(0); }
+    static constexpr T op(const T &lhs, const T &rhs) noexcept { return lhs + rhs; }
 
     template <class U>
-    static constexpr U f(T lhs, U rhs) {
+    static constexpr U f(const T &lhs, const U &rhs) noexcept {
         return lhs + rhs;
     }
 };
 
+/// @brief 積モノイド
+/// @tparam T 要素の型
 template <class T>
 struct Mul {
     using value_type = T;
-    static constexpr T id() { return T(1); }
-    static constexpr T op(const T &lhs, const T &rhs) { return lhs * rhs; }
+    static constexpr T id() noexcept { return T(1); }
+    static constexpr T op(const T &lhs, const T &rhs) noexcept { return lhs * rhs; }
 
     template <class U>
-    static constexpr U f(T lhs, U rhs) {
+    static constexpr U f(const T &lhs, const U &rhs) noexcept {
         return lhs * rhs;
     }
 };
 
+/// @brief ビット積モノイド
+/// @details 単位元は全ビットが 1 の値（符号付き型でも正しく動作する）。
+/// @tparam T 要素の型
 template <class T>
 struct And {
     using value_type = T;
-    static constexpr T id() { return std::numeric_limits<T>::max(); }
-    static constexpr T op(const T &lhs, const T &rhs) { return lhs & rhs; }
+    static constexpr T id() noexcept { return ~T(0); }
+    static constexpr T op(const T &lhs, const T &rhs) noexcept { return lhs & rhs; }
 
     template <class U>
-    static constexpr U f(T lhs, U rhs) {
+    static constexpr U f(const T &lhs, const U &rhs) noexcept {
         return lhs & rhs;
     }
 };
 
+/// @brief ビット和モノイド
+/// @tparam T 要素の型
 template <class T>
 struct Or {
     using value_type = T;
-    static constexpr T id() { return T(); }
-    static constexpr T op(const T &lhs, const T &rhs) { return lhs | rhs; }
+    static constexpr T id() noexcept { return T(0); }
+    static constexpr T op(const T &lhs, const T &rhs) noexcept { return lhs | rhs; }
 
     template <class U>
-    static constexpr U f(T lhs, U rhs) {
+    static constexpr U f(const T &lhs, const U &rhs) noexcept {
         return lhs | rhs;
     }
 };
 
+/// @brief ビット排他的論理和モノイド
+/// @tparam T 要素の型
 template <class T>
 struct Xor {
     using value_type = T;
-    static constexpr T id() { return T(); }
-    static constexpr T op(const T &lhs, const T &rhs) { return lhs ^ rhs; }
+    static constexpr T id() noexcept { return T(0); }
+    static constexpr T op(const T &lhs, const T &rhs) noexcept { return lhs ^ rhs; }
 
     template <class U>
-    static constexpr U f(T lhs, U rhs) {
+    static constexpr U f(const T &lhs, const U &rhs) noexcept {
         return lhs ^ rhs;
     }
 };
 
+/// @brief 最小値モノイド
+/// @details 単位元は型の最大値。
+/// @tparam T 要素の型
 template <class T>
 struct Min {
     using value_type = T;
-    static constexpr T id() { return std::numeric_limits<T>::max(); }
-    static constexpr T op(const T &lhs, const T &rhs) { return std::min(lhs, rhs); }
+    static constexpr T id() noexcept { return std::numeric_limits<T>::max(); }
+    static constexpr T op(const T &lhs, const T &rhs) noexcept { return std::min(lhs, rhs); }
 
     template <class U>
-    static constexpr U f(T lhs, U rhs) {
-        return std::min((U)lhs, rhs);
+    static constexpr U f(const T &lhs, const U &rhs) noexcept {
+        return std::min(U(lhs), rhs);
     }
 };
 
+/// @brief 最大値モノイド
+/// @details 単位元は型の最小値。
+/// @tparam T 要素の型
 template <class T>
 struct Max {
     using value_type = T;
-    static constexpr T id() { return std::numeric_limits<T>::lowest(); }
-    static constexpr T op(const T &lhs, const T &rhs) { return std::max(lhs, rhs); }
+    static constexpr T id() noexcept { return std::numeric_limits<T>::lowest(); }
+    static constexpr T op(const T &lhs, const T &rhs) noexcept { return std::max(lhs, rhs); }
 
     template <class U>
-    static constexpr U f(T lhs, U rhs) {
-        return std::max((U)lhs, rhs);
+    static constexpr U f(const T &lhs, const U &rhs) noexcept {
+        return std::max(U(lhs), rhs);
     }
 };
 
+/// @brief 最大公約数モノイド
+/// @details gcd(0, x) = x なので 0 が単位元。
+/// @tparam T 要素の型
 template <class T>
 struct Gcd {
     using value_type = T;
-    static constexpr T id() { return std::numeric_limits<T>::max(); }
-    static constexpr T op(const T &lhs, const T &rhs) {
-        return lhs == Gcd::id() ? rhs : (rhs == Gcd::id() ? lhs : std::gcd(lhs, rhs));
-    }
+    static constexpr T id() noexcept { return T(0); }
+    static constexpr T op(const T &lhs, const T &rhs) { return std::gcd(lhs, rhs); }
 };
 
+/// @brief 最小公倍数モノイド
+/// @details lcm(1, x) = x なので 1 が単位元。
+/// @tparam T 要素の型
 template <class T>
 struct Lcm {
     using value_type = T;
-    static constexpr T id() { return std::numeric_limits<T>::max(); }
-    static constexpr T op(const T &lhs, const T &rhs) {
-        return lhs == Lcm::id() ? rhs : (rhs == Lcm::id() ? lhs : std::lcm(lhs, rhs));
-    }
+    static constexpr T id() noexcept { return T(1); }
+    static constexpr T op(const T &lhs, const T &rhs) { return std::lcm(lhs, rhs); }
 };
 
+/// @brief 上書きモノイド（後勝ち）
+/// @details 「未設定」を表す番兵を単位元とする。値域にこの値を含めないこと。
+/// @tparam T 要素の型
 template <class T>
 struct Update {
     using value_type = T;
-    static constexpr T id() { return std::numeric_limits<T>::max(); }
-    static constexpr T op(const T &lhs, const T &rhs) { return lhs == Update::id() ? rhs : lhs; }
+    static constexpr T id() noexcept { return std::numeric_limits<T>::max(); }
+    static constexpr T op(const T &lhs, const T &rhs) noexcept {
+        return lhs == id() ? rhs : lhs;
+    }
 
     template <class U>
-    static constexpr U f(T lhs, U rhs) {
-        return lhs == Update::id() ? rhs : lhs;
+    static constexpr U f(const T &lhs, const U &rhs) noexcept {
+        return lhs == id() ? rhs : U(lhs);
     }
 };
 
+/// @brief アフィン変換モノイド
+/// @details f(x) = a * x + b を [a, b] で表す。op(g, h) は「先に g、次に h を適用」した合成。
+/// @tparam T 係数の型
 template <class T>
 struct Affine {
     using P = std::pair<T, T>;
     using value_type = P;
-    static constexpr P id() { return P(1, 0); }
-    static constexpr P op(P lhs, P rhs) { return {lhs.first * rhs.first, rhs.first * lhs.second + rhs.second}; }
+    static constexpr P id() { return P(T(1), T(0)); }
+    static constexpr P op(const P &lhs, const P &rhs) {
+        return {lhs.first * rhs.first, rhs.first * lhs.second + rhs.second};
+    }
 };
 
+/// @brief モノイドの演算順序を反転するアダプタ
+/// @tparam M 元となるモノイド
 template <class M>
 struct Rev {
-    using T = typename M::value_type;
-    using value_type = T;
-    static constexpr T id() { return M::id(); }
-    static constexpr T op(T lhs, T rhs) { return M::op(rhs, lhs); }
+    using value_type = typename M::value_type;
+    static constexpr value_type id() { return M::id(); }
+    static constexpr value_type op(const value_type &lhs, const value_type &rhs) {
+        return M::op(rhs, lhs);
+    }
 };

--- a/lib/segtree/segment_tree.hpp
+++ b/lib/segtree/segment_tree.hpp
@@ -6,7 +6,7 @@
 
 /// @brief セグメント木
 /// @see https://noshi91.hatenablog.com/entry/2020/04/22/212649
-template <class M>
+template <monoid M>
 struct segment_tree {
   private:
     using T = typename M::value_type;

--- a/lib/segtree/segment_tree_2d.hpp
+++ b/lib/segtree/segment_tree_2d.hpp
@@ -6,12 +6,8 @@
 #include <vector>
 #include "segtree/dynamic_segment_tree.hpp"
 
-/**
- * @brief 二次元セグメント木
- *
- * @tparam M モノイド
- */
-template <class M>
+/// @brief 二次元セグメント木
+template <monoid M>
 struct segment_tree_2d {
   private:
     using T = typename M::value_type;

--- a/lib/tree/euler_tour_tree.hpp
+++ b/lib/tree/euler_tour_tree.hpp
@@ -5,8 +5,8 @@
 #include <vector>
 #include "segtree/monoid.hpp"
 
-// Euler Tour Tree
-template <class M>
+/// @brief Euler Tour Tree
+template <monoid M>
 struct euler_tour_tree {
     using T = typename M::value_type;
 

--- a/lib/tree/link_cut_tree.hpp
+++ b/lib/tree/link_cut_tree.hpp
@@ -3,7 +3,7 @@
 #include "template/template.hpp"
 
 /// @brief Link-Cut Tree
-template <class M>
+template <monoid M>
 struct link_cut_tree {
   private:
     using T = typename M::value_type;

--- a/lib/tree/segment_tree_on_tree.hpp
+++ b/lib/tree/segment_tree_on_tree.hpp
@@ -5,10 +5,8 @@
 #include <vector>
 #include "segtree/segment_tree.hpp"
 
-/**
- * @brief Segment Tree on Tree
- */
-template <class M>
+/// @brief Segment Tree on Tree
+template <monoid M>
 struct segment_tree_on_tree {
   private:
     using T = typename M::value_type;

--- a/test/aoj/course/ALDS1_14_D.test.cpp
+++ b/test/aoj/course/ALDS1_14_D.test.cpp
@@ -3,14 +3,8 @@
 #include <string>
 #include "algorithm/binary_search.hpp"
 #include "data_structure/linear_sparse_table.hpp"
+#include "segtree/monoid.hpp"
 #include "string/suffix_array.hpp"
-
-template <class T>
-struct Min {
-    using value_type = T;
-    static constexpr T id() { return std::numeric_limits<T>::max(); }
-    static constexpr T op(const T &lhs, const T &rhs) { return std::min(lhs, rhs); }
-};
 
 int main(void) {
     std::string s;


### PR DESCRIPTION
## 概要

`lib/segtree/monoid.hpp` のモノイド実装を改善し、インターフェースを C++20 concept で明文化したうえで、モノイドを使う各データ構造のテンプレートパラメータに制約を付与しました。あわせて単位元のバグを修正しています。

## 変更内容

### `monoid.hpp`
- **concept の追加**: `monoid<M>`（`value_type`/`id()`/`op()` を要求）と `acts_on<M, U>`（作用素 `f(作用素, 値)` を要求）を定義。
- **単位元のバグ修正**:
  - `And::id()` を `numeric_limits<T>::max()` → `~T(0)` に。符号付き型でも全ビットが 1 の正しい単位元になる。
  - `Gcd::id()` を `0`（`gcd(0,x)=x`）、`Lcm::id()` を `1`（`lcm(1,x)=x`）に。値域に `max()` を含むケースで単位元と誤認する番兵方式を廃止。
  - `Add`/`Or`/`Xor` の単位元を `T()` → `T(0)` に明確化。
- **シグネチャ統一**: `op`/`f` の引数を `const&` に統一し、可能な箇所に `noexcept` を付与。`acts_on` は `M::f(m, x)` 呼び出し + `convertible_to` で判定し、テンプレート/非テンプレートの `f` 両方に対応。
- **Doxygen**: 全モノイドに `@brief` / `@tparam` を追加。

### 各データ構造への concept 制約
- 単一制約は型っぽく `template <monoid M>`、lazy 系の複合制約は `requires monoid<S> && monoid<F> && acts_on<F, typename S::value_type>` を付与。
- 対象: segment_tree / dual / dynamic / 2d / filtered / lazy / dynamic_lazy、persistent 系、swag、sparse_table 系、dynamic_sequence、euler_tour_tree、link_cut_tree、segment_tree_on_tree。
- `monoid.hpp` を include していなかった sparse_table 系・dynamic_sequence に include を追加。
- `rerooting.hpp` は `op`/`id` ではなく `f`/`g` の別インターフェースのため対象外。
- lazy 系の `@tparam S`/`F` など、型から読めない自明でないパラメータの Doxygen を整理。

### テスト
- `test/aoj/course/ALDS1_14_D`: ローカル定義の `Min` がライブラリの `Min` と重複するため、ライブラリ側を使うよう変更。

## 動作確認
- `test/` 配下の全 **217 テスト**を `g++ -std=c++20 -fsyntax-only` でコンパイル確認済み（全通過）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)