### PR TITLE
ci: cache test cases, revert misdiagnosed -flto removal

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -77,12 +77,13 @@ jobs:
     needs: [setup]
     env:
       # SPLIT_SIZE must equal the number of matrix indices below.
-      SPLIT_SIZE: "10"
+      SPLIT_SIZE: "20"
     strategy:
       matrix:
         # prettier-ignore
         index:
-          ["00", "01", "02", "03", "04", "05", "06", "07", "08", "09"]
+          ["00", "01", "02", "03", "04", "05", "06", "07", "08", "09",
+           "10", "11", "12", "13", "14", "15", "16", "17", "18", "19"]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -103,6 +104,21 @@ jobs:
             ${{ runner.os }}-verify-result-main-
             ${{ runner.os }}-verify-result-
 
+      # Cache downloaded test cases (and compiled binaries) under
+      # .competitive-verifier/cache. Re-verifying a heavy test otherwise
+      # re-downloads its cases from the judge, which dominated wall-clock
+      # (~107s of download for a single yosupo test on a recent run).
+      # Per-shard key because each split downloads a different set of problems;
+      # a single shared key would let the last shard's save clobber the rest.
+      - name: Restore problem cache
+        uses: actions/cache/restore@v5
+        id: restore-problem-cache
+        with:
+          path: ${{github.workspace}}/.competitive-verifier/cache
+          key: ${{ runner.os }}-verify-problems-${{ matrix.index }}-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-verify-problems-${{ matrix.index }}-
+
       - name: Download verify_files.json
         uses: competitive-verifier/actions/download-verify-artifact@v2
 
@@ -121,6 +137,16 @@ jobs:
           prev-result: ${{ steps.restore-cached-results.outputs.cache-hit && 'merged-result.json' || ''}}
         env:
           YUKICODER_TOKEN: ${{secrets.YUKICODER_TOKEN}}
+
+      # Always save (even if Verify failed) so a partial download cache still
+      # carries forward. run_id in the key makes each save a fresh immutable
+      # entry that the next run picks up via the restore-keys prefix.
+      - name: Save problem cache
+        if: always()
+        uses: actions/cache/save@v5
+        with:
+          path: ${{github.workspace}}/.competitive-verifier/cache
+          key: ${{ runner.os }}-verify-problems-${{ matrix.index }}-${{ github.run_id }}
 
       - name: Upload result artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -109,6 +109,10 @@ jobs:
       # (~107s of download for a single yosupo test on a recent run).
       # Per-shard key because each split downloads a different set of problems;
       # a single shared key would let the last shard's save clobber the rest.
+      # run_id makes every save a new immutable entry (caches can't be
+      # overwritten), so entries accumulate over time. That's intentional: we
+      # rely on GitHub's per-repo 10GB LRU eviction to retire old generations
+      # rather than deleting them explicitly.
       - name: Restore problem cache
         uses: actions/cache/restore@v5
         id: restore-problem-cache

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -77,13 +77,12 @@ jobs:
     needs: [setup]
     env:
       # SPLIT_SIZE must equal the number of matrix indices below.
-      SPLIT_SIZE: "20"
+      SPLIT_SIZE: "10"
     strategy:
       matrix:
         # prettier-ignore
         index:
-          ["00", "01", "02", "03", "04", "05", "06", "07", "08", "09",
-           "10", "11", "12", "13", "14", "15", "16", "17", "18", "19"]
+          ["00", "01", "02", "03", "04", "05", "06", "07", "08", "09"]
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.verify-helper/config.toml
+++ b/.verify-helper/config.toml
@@ -7,10 +7,7 @@ CXXFLAGS = [
     "-fconstexpr-depth=1024",
     "-fconstexpr-loop-limit=524288",
     "-fconstexpr-ops-limit=2097152",
-    # LTO is omitted intentionally: it dominated CI compile time (e.g. the
-    # pow-of-FPS test took ~107s to compile vs ~19s to run) while adding no
-    # value for correctness verification. -O2 is kept so TLE judgments stay
-    # representative of real submissions.
+    "-flto=auto",
     "-march=native",
     "--std=gnu++23",
     "-I./lib",


### PR DESCRIPTION
## 概要

#255 (merged) のフォローアップ。#255 は誤診に基づくコミットがマージされてしまったため、それを訂正しつつ真のボトルネックへの施策を入れる。

## 背景：#255 の診断は誤りだった

#255 では「重いテストの g++ コンパイルが ~107s で律速」と診断し、`-flto=auto` を削除した。これは誤りで：

- 速く見えた検証 run は**検証ファイルが 0 件**だっただけ（全件 `doesn't need verification`）。
- 重いテスト (`pow_of_formal_power_series`) はローカルで LTO あり/なし問わず**約1秒**でコンパイルできる。
- CI の ~107s の実体は **judge (yosupo) からのテストケース 37 件のダウンロード**だった。

その結果、現在の main は「コンパイル律速という誤診のまま LTO を外した状態」になっている。

## このPRの変更

- **`-flto=auto` を復活** — コンパイルは律速ではなく、LTO ありの方が実行最適化も効きローカルでもコンパイルは速い。#255 の削除を撤回する。
- **テストケースキャッシュの追加** — `.competitive-verifier/cache`（DL 済みテストケース + コンパイル済みバイナリ）を shard ごとにキャッシュし、重いテスト再検証時の judge からの再ダウンロードを回避（**真のボトルネック対策**）。
  - キーに `run_id` を含むためエントリは run ごとに増えるが、GitHub の 10GB/repo LRU 自動削除に委ねる設計（コメントで明記）。
- 分割数は 10 を維持（固定費削減）。

## 検証

テストケースキャッシュの効果は「重いテストを再検証する run」でしか顕在化しない。初回は cold cache で従来どおり、2 回目以降の同 shard で再ダウンロードが消えることを確認する必要がある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)