### PR TITLE
test: verify Trie with yukicoder No.2020 (LCP sum)

### DIFF
--- a/lib/string/trie.hpp
+++ b/lib/string/trie.hpp
@@ -21,6 +21,20 @@ struct Trie {
 
     int size() const { return nodes.size(); }
 
+    /// @brief ノード node_id の子 ch をたどる。無ければ新規作成する。
+    /// @return 子ノードの id
+    int add(int node_id, char ch) {
+        assert(0 <= node_id && node_id < (int)nodes.size());
+        int c = ch - base;
+        assert(0 <= c && c < char_size);
+        int &next_id = nodes[node_id].next_node[c];
+        if (next_id == -1) {
+            next_id = nodes.size();
+            nodes.emplace_back();
+        }
+        return next_id;
+    }
+
     std::vector<int> insert(const std::string &word) {
         std::vector<int> res;
         int node_id = 0;

--- a/test/yukicoder/2020.2.test.cpp
+++ b/test/yukicoder/2020.2.test.cpp
@@ -1,0 +1,75 @@
+// competitive-verifier: PROBLEM https://yukicoder.me/problems/no/2020
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <vector>
+#include "binary_tree/fenwick_tree.hpp"
+#include "graph/graph.hpp"
+#include "string/trie.hpp"
+#include "tree/euler_tour.hpp"
+
+int main() {
+    int n;
+    std::cin >> n;
+
+    Trie<26, 'a'> trie;
+    std::vector<int> pos(n);
+    std::vector<std::vector<int>> init_path(n);
+    for (int i = 0; i < n; ++i) {
+        std::string s;
+        std::cin >> s;
+        init_path[i] = trie.insert(s);
+        pos[i] = init_path[i].empty() ? 0 : init_path[i].back();
+    }
+
+    int q;
+    std::cin >> q;
+    std::vector<int> qtype(q), qx(q), qadd(q, -1);
+    for (int i = 0; i < q; ++i) {
+        std::cin >> qtype[i] >> qx[i];
+        --qx[i];
+        if (qtype[i] == 1) {
+            char c;
+            std::cin >> c;
+            int nid = trie.add(pos[qx[i]], c);
+            qadd[i] = nid;
+            pos[qx[i]] = nid;
+        }
+    }
+
+    int m = trie.size();
+    Graph<int> g(m);
+    for (int v = 0; v < m; ++v) {
+        const auto node = trie.get_node(v);
+        for (int c = 0; c < 26; ++c) {
+            int u = node.next_node[c];
+            if (u != -1) g.add_edge(v, u);
+        }
+    }
+    euler_tour et(g, 0);
+
+    fenwick_tree<std::int64_t> bit(m);
+    auto mark = [&](int v) {
+        et.query(v, [&](int l, int r) {
+            bit.add(l, 1);
+            if (r < m) bit.add(r, -1);
+        });
+    };
+    auto query = [&](int v) { return bit.sum(0, et.left(v) + 1); };
+
+    std::vector<int> cur(n);
+    for (int i = 0; i < n; ++i) {
+        for (int v : init_path[i]) mark(v);
+        cur[i] = init_path[i].empty() ? 0 : init_path[i].back();
+    }
+
+    for (int i = 0; i < q; ++i) {
+        if (qtype[i] == 1) {
+            mark(qadd[i]);
+            cur[qx[i]] = qadd[i];
+        } else {
+            std::cout << query(cur[qx[i]]) << '\n';
+        }
+    }
+    return 0;
+}

--- a/test/yukicoder/2020.test.cpp
+++ b/test/yukicoder/2020.test.cpp
@@ -1,0 +1,75 @@
+// competitive-verifier: PROBLEM https://yukicoder.me/problems/no/2020
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <vector>
+#include "binary_tree/fenwick_tree.hpp"
+#include "graph/graph.hpp"
+#include "string/trie.hpp"
+#include "tree/hld.hpp"
+
+int main() {
+    int n;
+    std::cin >> n;
+
+    Trie<26, 'a'> trie;
+    std::vector<int> pos(n);
+    std::vector<std::vector<int>> init_path(n);
+    for (int i = 0; i < n; ++i) {
+        std::string s;
+        std::cin >> s;
+        init_path[i] = trie.insert(s);
+        pos[i] = init_path[i].empty() ? 0 : init_path[i].back();
+    }
+
+    int q;
+    std::cin >> q;
+    std::vector<int> qtype(q), qx(q), qadd(q, -1);
+    for (int i = 0; i < q; ++i) {
+        std::cin >> qtype[i] >> qx[i];
+        --qx[i];
+        if (qtype[i] == 1) {
+            char c;
+            std::cin >> c;
+            int nid = trie.add(pos[qx[i]], c);
+            qadd[i] = nid;
+            pos[qx[i]] = nid;
+        }
+    }
+
+    int m = trie.size();
+    Graph<int> g(m);
+    for (int v = 0; v < m; ++v) {
+        const auto node = trie.get_node(v);
+        for (int c = 0; c < 26; ++c) {
+            int u = node.next_node[c];
+            if (u != -1) g.add_edges(v, u);
+        }
+    }
+    heavy_light_decomposition hld(g, 0);
+
+    fenwick_tree<std::int64_t> bit(m);
+    auto point_add = [&](int v, int x) { bit.add(hld.get(v), x); };
+    auto path_sum = [&](int v) {
+        std::int64_t res = 0;
+        hld.for_each(0, v, [&](int l, int r) { res += bit.sum(l, r); });
+        res -= bit[hld.get(0)];
+        return res;
+    };
+
+    std::vector<int> cur(n);
+    for (int i = 0; i < n; ++i) {
+        for (int v : init_path[i]) point_add(v, 1);
+        cur[i] = init_path[i].empty() ? 0 : init_path[i].back();
+    }
+
+    for (int i = 0; i < q; ++i) {
+        if (qtype[i] == 1) {
+            point_add(qadd[i], 1);
+            cur[qx[i]] = qadd[i];
+        } else {
+            std::cout << path_sum(cur[qx[i]]) << '\n';
+        }
+    }
+    return 0;
+}


### PR DESCRIPTION
## 概要

`lib/string/trie.hpp` の `Trie` を verify するため、yukicoder No.2020「Sum of Common Prefix Length」（最長共通接頭辞長の総和）のテストを追加します。これまで `Trie` には verify テストがありませんでした。

## 変更内容

### `lib/string/trie.hpp`
- 1 文字ずつ子ノードをたどる（無ければ生成する）`add(node_id, ch)` を追加。末尾追加クエリの実装に使う。既存 API（`insert` / `search_id` / `get_node` / `size`）の挙動は不変。

### `test/yukicoder/2020.test.cpp` — HLD 版
- 「木上の一点加算 + root→pos_x のパス和」に帰着。HL 分解でパス和を取り、計算量 O((L+Q) log²)。

### `test/yukicoder/2020.2.test.cpp` — オイラーツアー版（別解）
- 各文字列の通過ノードをすべてフェニック木に記録（`add(left,+1); add(right,-1)`）。クエリは prefix sum 1 回で `Σ_k depth(LCA(pos_x, pos_k))` を得る。計算量 O((L+Q) log)。

`answer(x) = Σ_{v∈path(x)} cnt(v) = Σ_k depth(LCA(pos_x, pos_k))`。末尾追加・全ノードの確定のためクエリを先読みするオフライン処理を行う。

## 検証

- 公式サンプル一致（両版とも `8 / 11`）
- naive（全 S_k と直接 LCP 計算）とのランダム突き合わせで一致（文字種・長さを変えて複数セット）
- `g++ -std=c++23 -I lib -Wall -Wextra -fsyntax-only` pass
- 最悪寄りの連鎖ケース（深さ 2e5）でも両版 0.1 秒未満

最終的な AC 判定は competitive-verifier (CI) で確認されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)