### PR TITLE
feat: Graph に edge_count / all_edges / reserve を追加し全辺走査を統一

### DIFF
--- a/lib/graph/graph.hpp
+++ b/lib/graph/graph.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <iostream>
+#include <ranges>
 #include <type_traits>
 #include <vector>
 
@@ -39,8 +40,8 @@ struct Graph {
   public:
     using edge_type = typename Graph<T>::_edge;
 
-    Graph() : _size(), edges() {}
-    explicit Graph(int v) : _size(v), edges(v) {}
+    Graph() : _size(), _edge_count(), edges() {}
+    explicit Graph(int v) : _size(v), _edge_count(), edges(v) {}
 
     const auto &operator[](int i) const { return edges[i]; }
     auto &operator[](int i) { return edges[i]; }
@@ -50,13 +51,28 @@ struct Graph {
     auto end() { return edges.end(); }
     constexpr int size() const { return _size; }
 
-    void add_edge(const edge_type &e) { edges[e.from()].emplace_back(e); }
+    /// @brief 辺数（有向辺として数える。無向辺は 2 本としてカウントされる）
+    constexpr int edge_count() const { return _edge_count; }
+
+    /// @brief 全辺を平坦に走査する view
+    auto all_edges() const { return edges | std::views::join; }
+    auto all_edges() { return edges | std::views::join; }
+
+    /// @brief 各頂点の隣接リストにまとめて容量を予約する
+    void reserve(int from, int degree) { edges[from].reserve(degree); }
+
+    void add_edge(const edge_type &e) {
+        edges[e.from()].emplace_back(e);
+        ++_edge_count;
+    }
     void add_edge(int from, int to, weight_type weight = weight_type(1)) {
         edges[from].emplace_back(from, to, weight);
+        ++_edge_count;
     }
     void add_edges(int from, int to, weight_type weight = weight_type(1)) {
         edges[from].emplace_back(from, to, weight);
         edges[to].emplace_back(to, from, weight);
+        _edge_count += 2;
     }
 
     void input_edge(int m, int base = 1) {
@@ -87,6 +103,6 @@ struct Graph {
     }
 
   private:
-    int _size;
+    int _size, _edge_count;
     std::vector<std::vector<edge_type>> edges;
 };

--- a/lib/graph/kruskal.hpp
+++ b/lib/graph/kruskal.hpp
@@ -11,9 +11,8 @@ std::vector<typename Graph<T>::edge_type> kruskal(const Graph<T> &g) {
     union_find uf(g.size());
     std::vector<_edge> res;
     std::vector<_edge> edge_list;
-    for (auto &v : g) {
-        for (auto &e : v) edge_list.emplace_back(e);
-    }
+    edge_list.reserve(g.edge_count());
+    for (auto &e : g.all_edges()) edge_list.emplace_back(e);
     std::sort(edge_list.begin(), edge_list.end());
     for (auto &e : edge_list) {
         if (uf.unite(e.from(), e.to())) res.emplace_back(e);

--- a/lib/graph/scc.hpp
+++ b/lib/graph/scc.hpp
@@ -12,9 +12,7 @@ std::vector<int> scc(const Graph<T> &g) {
     std::vector<bool> used(n);
 
     internal::graph_csr rg(n);
-    for (auto &es : g) {
-        for (auto &e : es) rg.add_edge(e.to(), e.from());
-    }
+    for (auto &e : g.all_edges()) rg.add_edge(e.to(), e.from());
     rg.build();
 
     auto dfs = [&](auto self, int index) {
@@ -76,11 +74,9 @@ std::vector<int> scc(const internal::graph_csr &g) {
 template <class T>
 Graph<T> make_directed_acyclic_graph(const Graph<T> &g, const std::vector<int> &v) {
     Graph<T> res(*std::max_element(v.begin(), v.end()) + 1);
-    for (auto &es : g) {
-        for (auto &e : es) {
-            int x = v[e.from()], y = v[e.to()];
-            if (x != y) res.add_edge(x, y, e.weight());
-        }
+    for (auto &e : g.all_edges()) {
+        int x = v[e.from()], y = v[e.to()];
+        if (x != y) res.add_edge(x, y, e.weight());
     }
     return res;
 }


### PR DESCRIPTION
## 概要

各グラフアルゴリズムに散在していた全辺走査の二重ループ `for (auto &es : g) for (auto &e : es)` を、`Graph` 側の API に集約しました。

## 追加した API

- **`int edge_count() const`** — 辺数を O(1) で返す。`add_edge` で +1、`add_edges`（無向）で +2 として計上
- **`auto all_edges()`（const / 非 const）** — 全隣接リストを平坦に走査する view（`std::views::join`）
- **`void reserve(int from, int degree)`** — 指定頂点の隣接リスト容量を予約

## 適用箇所（二重ループ → all_edges 置換）

- [lib/graph/kruskal.hpp](lib/graph/kruskal.hpp): 全辺収集を `all_edges()` 化し、`edge_count()` で `edge_list` を事前 reserve
- [lib/graph/scc.hpp](lib/graph/scc.hpp): 逆グラフ構築 と `make_directed_acyclic_graph` の二重ループを置換

`bellman_ford` は `dists[i]` を頂点インデックスで参照する構造のため対象外とし、従来どおり残しました。

## 検証

- `g++ -std=c++23 -I lib` で `Graph` を使う全 lib/test の**ハードエラー 0**
- ランダムテスト（2000 ケース、naive 二重ループ収集と突き合わせ）で確認:
  - `edge_count()` が正確
  - `all_edges()` が全辺を漏れ・重複なく走査（多重集合一致）
  - kruskal の MST コストが naive 実装と一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)