### PR TITLE
feat: Graph の頂点アクセス・辺追加に境界 assert を追加

### DIFF
--- a/lib/graph/graph.hpp
+++ b/lib/graph/graph.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cassert>
 #include <iostream>
 #include <ranges>
 #include <type_traits>
@@ -43,8 +44,14 @@ struct Graph {
     Graph() : _size(), _edge_count(), edges() {}
     explicit Graph(int v) : _size(v), _edge_count(), edges(v) {}
 
-    const auto &operator[](int i) const { return edges[i]; }
-    auto &operator[](int i) { return edges[i]; }
+    const auto &operator[](int i) const {
+        assert(0 <= i && i < _size);
+        return edges[i];
+    }
+    auto &operator[](int i) {
+        assert(0 <= i && i < _size);
+        return edges[i];
+    }
     auto begin() const { return edges.begin(); }
     auto begin() { return edges.begin(); }
     auto end() const { return edges.end(); }
@@ -59,17 +66,26 @@ struct Graph {
     auto all_edges() { return edges | std::views::join; }
 
     /// @brief 各頂点の隣接リストにまとめて容量を予約する
-    void reserve(int from, int degree) { edges[from].reserve(degree); }
+    void reserve(int from, int degree) {
+        assert(0 <= from && from < _size);
+        edges[from].reserve(degree);
+    }
 
     void add_edge(const edge_type &e) {
+        assert(0 <= e.from() && e.from() < _size);
+        assert(0 <= e.to() && e.to() < _size);
         edges[e.from()].emplace_back(e);
         ++_edge_count;
     }
     void add_edge(int from, int to, weight_type weight = weight_type(1)) {
+        assert(0 <= from && from < _size);
+        assert(0 <= to && to < _size);
         edges[from].emplace_back(from, to, weight);
         ++_edge_count;
     }
     void add_edges(int from, int to, weight_type weight = weight_type(1)) {
+        assert(0 <= from && from < _size);
+        assert(0 <= to && to < _size);
         edges[from].emplace_back(from, to, weight);
         edges[to].emplace_back(to, from, weight);
         _edge_count += 2;


### PR DESCRIPTION
## 概要

`Graph` の頂点インデックスを取る操作に範囲チェック `assert` を追加し、範囲外アクセスのバグをデバッグビルドで早期検出できるようにしました。`-DNDEBUG`（競プロ提出時の通常設定）では `assert` が消えるため、**実行速度には影響しません**。

## 変更点

`assert(0 <= idx && idx < _size)` を以下に追加:
- `operator[]`（const / 非 const）
- `add_edge(int from, int to, ...)` — from / to 両方
- `add_edge(const edge_type &e)` — `e.from()` / `e.to()` 両方
- `add_edges(...)` — from / to 両方
- `reserve(int from, int degree)`

`<cassert>` を明示 include（CLAUDE.md の「標準ヘッダは明示 include」規約に準拠）。

## 検証

- `g++ -std=c++23 -I lib` で `Graph` を使う全 lib/test の**ハードエラー 0**
- 動作テスト:
  - 正常系（範囲内アクセス）では assert 非発火
  - 範囲外 `add_edge(0, 3, ...)`（頂点数 3）で `SIGABRT` 発火を確認
  - `-DNDEBUG` で構文が通る（assert が消える）ことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)