### PR TITLE
feat: Graph に辺 ID を追加し ID⇔辺の双方向取得を可能に

### DIFF
--- a/lib/graph/graph.hpp
+++ b/lib/graph/graph.hpp
@@ -23,26 +23,27 @@ struct Graph {
     using weight_type = std::conditional_t<std::is_void_v<T>, Unweighted, T>;
 
     struct _edge {
-        constexpr _edge() : _from(), _to(), _weight() {}
-        constexpr _edge(int from, int to, weight_type weight)
-            : _from(from), _to(to), _weight(weight) {}
+        constexpr _edge() : _from(), _to(), _id(-1), _weight() {}
+        constexpr _edge(int from, int to, weight_type weight, int id = -1)
+            : _from(from), _to(to), _id(id), _weight(weight) {}
         constexpr bool operator<(const _edge &rhs) const { return weight() < rhs.weight(); }
         constexpr bool operator>(const _edge &rhs) const { return rhs < *this; }
 
         constexpr int from() const { return _from; }
         constexpr int to() const { return _to; }
+        constexpr int id() const { return _id; }
         constexpr weight_type weight() const { return _weight; }
 
       private:
-        int _from, _to;
+        int _from, _to, _id;
         [[no_unique_address]] weight_type _weight;
     };
 
   public:
     using edge_type = typename Graph<T>::_edge;
 
-    Graph() : _size(), _edge_count(), edges() {}
-    explicit Graph(int v) : _size(v), _edge_count(), edges(v) {}
+    Graph() : _size(), _edge_count(), _num_edges(), edges(), edge_list_() {}
+    explicit Graph(int v) : _size(v), _edge_count(), _num_edges(), edges(v), edge_list_() {}
 
     const auto &operator[](int i) const {
         assert(0 <= i && i < _size);
@@ -58,8 +59,17 @@ struct Graph {
     auto end() { return edges.end(); }
     constexpr int size() const { return _size; }
 
-    /// @brief 辺数（有向辺として数える。無向辺は 2 本としてカウントされる）
+    /// @brief 格納された有向辺数（無向辺は 2 本としてカウントされる）
     constexpr int edge_count() const { return _edge_count; }
+
+    /// @brief 辺 ID の個数（add_edge / add_edges の呼び出し回数）
+    constexpr int num_edges() const { return _num_edges; }
+
+    /// @brief ID から辺を取得する（無向辺は from→to 側を返す）
+    const edge_type &get_edge(int id) const {
+        assert(0 <= id && id < _num_edges);
+        return edge_list_[id];
+    }
 
     /// @brief 全辺を平坦に走査する view
     auto all_edges() const { return edges | std::views::join; }
@@ -71,23 +81,26 @@ struct Graph {
         edges[from].reserve(degree);
     }
 
-    void add_edge(const edge_type &e) {
-        assert(0 <= e.from() && e.from() < _size);
-        assert(0 <= e.to() && e.to() < _size);
-        edges[e.from()].emplace_back(e);
-        ++_edge_count;
-    }
+    /// @brief 有向辺を追加する。重みは e のものを使い、ID は新たに振り直す。
+    void add_edge(const edge_type &e) { add_edge(e.from(), e.to(), e.weight()); }
+    /// @brief 有向辺を追加する。
     void add_edge(int from, int to, weight_type weight = weight_type(1)) {
         assert(0 <= from && from < _size);
         assert(0 <= to && to < _size);
-        edges[from].emplace_back(from, to, weight);
+        int id = _num_edges++;
+        edge_type e(from, to, weight, id);
+        edges[from].emplace_back(e);
+        edge_list_.emplace_back(e);
         ++_edge_count;
     }
+    /// @brief 無向辺を追加する。往復 2 本には同じ ID を振る。
     void add_edges(int from, int to, weight_type weight = weight_type(1)) {
         assert(0 <= from && from < _size);
         assert(0 <= to && to < _size);
-        edges[from].emplace_back(from, to, weight);
-        edges[to].emplace_back(to, from, weight);
+        int id = _num_edges++;
+        edges[from].emplace_back(from, to, weight, id);
+        edges[to].emplace_back(to, from, weight, id);
+        edge_list_.emplace_back(from, to, weight, id);
         _edge_count += 2;
     }
 
@@ -119,6 +132,7 @@ struct Graph {
     }
 
   private:
-    int _size, _edge_count;
+    int _size, _edge_count, _num_edges;
     std::vector<std::vector<edge_type>> edges;
+    std::vector<edge_type> edge_list_;  // ID 順の辺リスト（ID→辺の逆引き）
 };


### PR DESCRIPTION
## 概要

「辺 ID を取得したい」「ID から辺を取得したい」という要望に応え、**辺 ⇔ ID の双方向マッピング**を `Graph` に追加しました。隣接リストのみだった構造に、ID 順の辺リストを併設します。

## 追加した API

- **`int e.id()`** — 辺 → ID（その辺が何番目の `add_edge`/`add_edges` で追加されたか）
- **`const edge_type &get_edge(int id)`** — ID → 辺（O(1) 逆引き）
- **`int num_edges()`** — 辺 ID の個数（`add_edge`/`add_edges` の呼び出し回数）

## 仕様

- **無向辺 `add_edges` の往復 2 本には同じ ID** を振る（「入力の i 本目の辺」の意味）。橋を入力辺番号で答える用途などに適合。`get_edge(id)` は `from→to` 側を代表として返す。
- **`add_edge(const edge_type &e)` は ID を振り直す**。`scc` の逆グラフ構築や `make_directed_acyclic_graph` の縮約で、新グラフ内の連番 ID になる（元 ID は引き継がない）。

## 互換性・コスト

- `_edge` の `id` は 4 引数目（デフォルト `-1`）で、既存の 3 引数コンストラクタ呼び出しは無改修。
- `id` を `_weight` の**前**に配置し、`Unweighted` の `[[no_unique_address]]` によるメモリ削減を維持。`sizeof(Graph<void>::edge_type) == 12`（`3*int`、重み 0 byte）を確認済み。
- `edge_count()`（格納された有向辺数）の意味は**変えず**、kruskal の `reserve` など既存利用と互換。
- `edge_list_` の併設で辺あたりのメモリは増えるが、ID→辺の O(1) 逆引きには不可避。

## 検証

- `g++ -std=c++23 -I lib` で `Graph` を使う全 lib/test の**ハードエラー 0**
- ランダムテスト（3000 ケース）:
  - `num_edges()` = 追加呼び出し回数
  - `get_edge(id)`（ID→辺）が naive と一致、`e.id() == id`
  - 隣接リストから得た `e.id()`（辺→ID）で `get_edge` を引くと端点・重みが整合（無向の逆向き含む）
- `add_edge(const edge_type&)` の ID 振り直し、`make_directed_acyclic_graph` 縮約後の新グラフ内連番 ID を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)