### PR TITLE
feat: euler_tour を CSR グラフ (internal::graph_csr) に対応

### DIFF
--- a/lib/tree/euler_tour.hpp
+++ b/lib/tree/euler_tour.hpp
@@ -3,11 +3,13 @@
 #include <utility>
 #include <vector>
 #include "graph/graph.hpp"
+#include "internal/internal_csr.hpp"
 
 /// @brief オイラーツアー
 struct euler_tour {
     template <class T>
     euler_tour(const Graph<T> &g, int r = 0) : euler_tour(g, g.size(), r) {}
+    euler_tour(const internal::graph_csr &g, int r = 0) : euler_tour(g, g.size(), r) {}
 
     std::pair<int, int> operator[](int i) const { return std::make_pair(ls[i], rs[i]); }
 
@@ -26,8 +28,15 @@ struct euler_tour {
     int _size;
     std::vector<int> ord, ls, rs;
 
-    template <class T>
-    euler_tour(const Graph<T> &g, int n, int r) : _size(n), ord(n), ls(n, -1), rs(n) {
+    /// 隣接要素から行き先頂点を取り出す: Graph<T> の辺は e.to()、CSR は int をそのまま使う。
+    static int to_of(int e) { return e; }
+    template <class E>
+    static int to_of(const E &e) {
+        return e.to();
+    }
+
+    template <class G>
+    euler_tour(const G &g, int n, int r) : _size(n), ord(n), ls(n, -1), rs(n) {
         int c = 0;
         std::stack<int> st;
         st.emplace(r);
@@ -42,9 +51,10 @@ struct euler_tour {
             ord[x] = c++;
             rs[x] = c;
             for (auto e : g[x]) {
-                if (ls[e.to()] != -1) continue;
+                int to = to_of(e);
+                if (ls[to] != -1) continue;
                 st.emplace(~x);
-                st.emplace(e.to());
+                st.emplace(to);
             }
         }
     }


### PR DESCRIPTION
## 概要

`euler_tour` を `internal::graph_csr` から構築できるようにしました。これまで `Graph<T>` 専用だったため、CSR 形式のグラフを渡せませんでした。

## 変更点

- `internal::graph_csr` を受けるコンストラクタをオーバーロード追加
- 内部コンストラクタを `template <class T> (const Graph<T>&)` から `template <class G>` に一般化
- 隣接要素から行き先頂点を取り出すヘルパ `to_of` を追加
  - CSR の `operator[]` は `int` を直接返す → そのまま使う
  - `Graph<T>` の辺は `e.to()` を使う

既存の `Graph<T>` 版コンストラクタはオーバーロードで温存しているため、API は後方互換です。

## 動機

CSR は隣接辺を `start[]` + `elist[]` の連続配列に格納するため、`Graph<void>` の `vector<vector<edge_type>>` と比べてメモリが小さくキャッシュ効率が良い。木の euler tour を取る用途で CSR を使えるようにする。

## テスト

`euler_tour` を直接・間接 (`auxiliary_tree` 経由) に使う既存テストの構文チェックが通ることを確認:

- `test/aoj/challenge/2871.test.cpp`
- `test/yosupo/tree/vertex_add_subtree_sum.test.cpp`
- `test/yukicoder/2020.2.test.cpp`
- `test/yukicoder/0901.test.cpp` (auxiliary_tree 経由)

CSR からの構築は手元の検証コードで `Graph<void>` 版と同一の euler 順・部分木区間を返すことを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)