### PR TITLE
feat: centroid_decomposition をクラス化し各重心の集計コールバックに対応

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,8 @@ g++ -std=c++23 -I lib -Wall -Wextra -fsyntax-only <test_file>
 - **標準ヘッダは明示 include**（`<bits/stdc++.h>` や `template/template.hpp` に依存しない）。
 - **`namespace` は snake_case**。
 - C++20/23 機能を使う: SFINAE より **concept**、サイズは **`std::bit_ceil`**、円周率は **`std::numbers::pi`**。
-- Doxygen は **`///` 行コメント形式**。
+- コメントは **`///` 行コメント形式**で統一する。Doxygen も通常コメントも `///` を使い、
+  **`/** */` や `/* */` などのブロックコメントは使わない**。
 - 浮動小数点→整数の丸めは **`std::llround`**（`T(x + 0.5)` は負値で誤る）。
 
 ## 注意

--- a/lib/tree/centroid_decomposition.hpp
+++ b/lib/tree/centroid_decomposition.hpp
@@ -1,49 +1,161 @@
+#pragma once
+#include <algorithm>
+#include <cstddef>
+#include <functional>
+#include <vector>
 #include "graph/graph.hpp"
-#include "template/template.hpp"
 
-/**
- * @brief 重心分解
- *
- * @tparam T 辺の重みの型
- * @param g グラフ
- * @return std::vector<int> 親の頂点
- */
+/// @brief 重心分解
+/// @details 木を重心で再帰的に分解する。重心分解木の親配列を保持し、`run` で
+///          各重心ごとの集計コールバックを呼べる。
+///          - 重心分解木の再帰は深さ O(log n) なので再帰で実装する。
+///          - 連結成分の走査・部分木サイズ計算・距離計算は深さ n になりうるため
+///            すべて BFS 反復で行い、鎖状の木でもスタックオーバーフローしない。
+/// @tparam T 辺の重みの型（`void` で重みなし。距離は辺数で数える）
 template <class T>
-std::vector<int> centroid_decomposition(const Graph<T> &g) {
-    int n = g.size();
-    std::vector<int> par(n, -1), size(n), size_par(n, -2);
-    std::vector<bool> used(n, false);
-    auto dfs = [&](auto self, int x, int p) -> int {
-        if (size_par[x] == p) return size[x];
-        int sum = 1;
-        for (auto e : g[x]) {
-            if (used[e.to()] || e.to() == p) continue;
-            sum += self(self, e.to(), x);
-        }
-        size_par[x] = p;
-        return size[x] = sum;
+struct centroid_decomposition {
+    /// @brief ある重心 `c` の回で渡される連結成分の情報。
+    /// @details いずれの配列も頂点番号で添字付けされる。`order` に現れない頂点
+    ///          （別成分や `used` 済み）の成分は未定義なので参照しないこと。
+    struct component {
+        int centroid;                   ///< この回の重心
+        const std::vector<int> &order;  ///< 重心を根とする連結成分の頂点列（BFS 行きがけ順、先頭は重心）
+        const std::vector<int> &par;    ///< 連結成分内で重心を根とした親（重心は -1）
+        const std::vector<int> &dep;    ///< 重心からの距離（辺数。重心は 0）
+        const std::vector<int> &top;    ///< 重心直下の子部分木 ID（その頂点が属する重心直下の子。重心は -1）
+        const std::vector<int> &sub;    ///< 連結成分内での部分木サイズ
     };
-    auto build = [&](auto self, int x, int p) -> void {
-        int sz = dfs(dfs, x, p);
-        bool is_centroid = false;
-        while (!is_centroid) {
-            is_centroid = true;
-            for (auto e : g[x]) {
-                if (size[e.to()] > size[x] || size[e.to()] * 2 <= sz) continue;
-                x = e.to();
-                is_centroid = false;
-                break;
+
+    /// @brief 重心分解を実行する。
+    /// @param g 木（無向辺で構築されていること）
+    explicit centroid_decomposition(const Graph<T> &g)
+        : g_(g), n_(g.size()), par_(n_, -1), used_(n_, false), comp_par_(n_), comp_dep_(n_), comp_top_(n_),
+          comp_sub_(n_) {
+        order_.reserve(n_);
+        if (n_ > 0) build(0, -1);
+    }
+
+    /// @brief 重心分解木における各頂点の親（根は -1）。
+    const std::vector<int> &par() const { return par_; }
+
+    /// @brief 各重心ごとに集計コールバックを呼ぶ。
+    /// @details 分解木の根（全体の重心）から順に、各重心 `c` について
+    ///          `f(component)` を 1 回ずつ呼ぶ。`component` 内の配列は呼び出しごとに
+    ///          使い回されるので、必要なら呼び出し中にコピーすること。
+    /// @param f `void(const component &)` 互換の呼び出し可能オブジェクト
+    template <class F>
+    void run(F f) {
+        std::fill(used_.begin(), used_.end(), false);
+        if (n_ > 0) run_dfs(0, std::ref(f));
+    }
+
+  private:
+    const Graph<T> &g_;
+    int n_;
+    std::vector<int> par_;
+    std::vector<bool> used_;
+    std::vector<int> order_;                                      // 連結成分の BFS 行きがけ順（作業領域）
+    std::vector<int> comp_par_, comp_dep_, comp_top_, comp_sub_;  // component 用作業領域
+
+    /// @brief root を含む連結成分（used を除く）を BFS 順に order_ へ並べ、par/dep を記録する。
+    /// @param root 走査の起点（この回はこれを根とみなす）
+    /// @return 連結成分のサイズ
+    int traverse(int root) {
+        order_.clear();
+        comp_par_[root] = -1;
+        comp_dep_[root] = 0;
+        order_.push_back(root);
+        for (std::size_t i = 0; i < order_.size(); ++i) {
+            int x = order_[i];
+            for (auto e : g_[x]) {
+                if (used_[e.to()] || e.to() == comp_par_[x]) continue;
+                comp_par_[e.to()] = x;
+                comp_dep_[e.to()] = comp_dep_[x] + 1;
+                order_.push_back(e.to());
             }
         }
-        par[x] = p;
-        used[x] = true;
-        for (auto e : g[x]) {
-            if (used[e.to()]) continue;
-            self(self, e.to(), x);
+        return int(order_.size());
+    }
+
+    /// @brief order_（traverse 済み）から重心を求め、used に登録する。
+    /// @details BFS 逆順に部分木サイズを comp_sub_ へ集計し（子は親より後ろにいるので 1 パス）、
+    ///          起点から「過半数を占める子」へ降り続けて重心へ着く。降下経路は重心への一本道
+    ///          だけを辿るので全頂点は見ない。降下中は comp_sub_/comp_par_ を現在地基準に書き換える。
+    /// @param total 連結成分のサイズ
+    /// @return 重心の頂点番号
+    int find_centroid(int total) {
+        for (auto it = order_.rbegin(); it != order_.rend(); ++it) {
+            int x = *it;
+            comp_sub_[x] = 1;
+            for (auto e : g_[x]) {
+                if (used_[e.to()] || e.to() == comp_par_[x]) continue;
+                comp_sub_[x] += comp_sub_[e.to()];
+            }
         }
-    };
+        int c = order_[0];
+        while (true) {
+            int next = -1;
+            for (auto e : g_[c]) {
+                if (used_[e.to()] || e.to() == comp_par_[c]) continue;
+                if (comp_sub_[e.to()] * 2 > total) {
+                    next = e.to();
+                    break;
+                }
+            }
+            if (next == -1) break;
+            comp_sub_[c] = total - comp_sub_[next];  // 反対側のサイズに更新してから降りる
+            comp_par_[next] = c;
+            c = next;
+        }
+        used_[c] = true;
+        return c;
+    }
 
-    build(build, 0, -1);
+    /// @brief 重心分解木を構築する（par_ を埋める）。重心の再帰のみ再帰。
+    /// @details 親配列だけ必要なので連結成分のスキャンは traverse + find_centroid の 1 回で済む。
+    void build(int root, int p) {
+        int total = traverse(root);
+        int c = find_centroid(total);
+        par_[c] = p;
+        for (auto e : g_[c]) {
+            if (used_[e.to()]) continue;
+            build(e.to(), c);
+        }
+    }
 
-    return par;
+    /// @brief 各重心で component を組み立てて f を呼びながら再帰する。重心の再帰のみ再帰。
+    /// @details component には c を根とした dep/top/sub が要るので、重心 c を見つけた後に
+    ///          c を根として traverse + find_centroid をやり直す（連結成分を計 2 回スキャン）。
+    template <class F>
+    void run_dfs(int root, F f) {
+        int total = traverse(root);
+        int c = find_centroid(total);
+
+        // 重心 c を根に取り直して BFS し、c からの距離（comp_dep_）と部分木サイズを確定する。
+        traverse(c);
+        find_centroid(total);  // comp_sub_ を c 基準で埋め直す（戻り値の重心は c に一致、再 used は無害）
+
+        // top[x] = x が属する c 直下の子。BFS 順なので親から伝播できる。
+        comp_top_[c] = -1;
+        for (int x : order_) {
+            if (x == c) continue;
+            comp_top_[x] = (comp_par_[x] == c) ? x : comp_top_[comp_par_[x]];
+        }
+
+        component info{c, order_, comp_par_, comp_dep_, comp_top_, comp_sub_};
+        f(info);
+
+        for (auto e : g_[c]) {
+            if (used_[e.to()]) continue;
+            run_dfs(e.to(), f);
+        }
+    }
+};
+
+/// @brief 重心分解木の親配列だけを返す簡易版。
+/// @param g 木
+/// @return std::vector<int> 重心分解木における各頂点の親（根は -1）
+template <class T>
+std::vector<int> centroid_decomposition_par(const Graph<T> &g) {
+    return centroid_decomposition<T>(g).par();
 }

--- a/test/yosupo/tree/frequency_table_of_tree_distance.test.cpp
+++ b/test/yosupo/tree/frequency_table_of_tree_distance.test.cpp
@@ -1,0 +1,58 @@
+// competitive-verifier: PROBLEM https://judge.yosupo.jp/problem/frequency_table_of_tree_distance
+#include <cstdint>
+#include <iostream>
+#include <vector>
+#include "fft/fft.hpp"
+#include "graph/graph.hpp"
+#include "tree/centroid_decomposition.hpp"
+
+int main(void) {
+    int n;
+    std::cin >> n;
+    Graph<void> g(n);
+    g.input_edges(n - 1, 0);
+
+    std::vector<std::int64_t> ans(n, 0);  // ans[d] = 距離 d の頂点対 (順序付き) の総数
+
+    // dist の自己畳み込みを ans へ sign 倍して足し込む (conv[k] = 距離 k の順序付きペア数)。
+    auto add_self_conv = [&](const std::vector<std::int64_t> &dist, int sign) {
+        if (dist.empty()) return;
+        auto conv = fft::convolution(dist, dist);
+        for (int k = 1; k < (int)conv.size() && k < n; ++k) ans[k] += sign * conv[k];
+    };
+
+    std::vector<int> child_idx(n, -1);  // c 直下の子 -> dists の添字 (使用後に -1 へ戻す)
+    centroid_decomposition<void> cd(g);
+    cd.run([&](const centroid_decomposition<void>::component &c) {
+        // c を通る同じ子部分木のパスは二重計上なので、各子部分木の距離分布を引く。
+        // c 全体の距離分布 (c は depth 0) を足す。
+        std::vector<std::int64_t> whole = {1};  // 重心自身 (depth 0)
+        std::vector<std::vector<std::int64_t>> dists;
+        std::vector<int> children;  // c 直下の子 (child_idx のリセット対象)
+        for (int x : c.order) {
+            if (x == c.centroid) continue;
+            int t = c.top[x];  // x が属する c 直下の子
+            if (child_idx[t] == -1) {
+                child_idx[t] = (int)dists.size();
+                dists.emplace_back();
+                children.push_back(t);
+            }
+            auto &d = dists[child_idx[t]];
+            int dx = c.dep[x];
+            if (dx >= (int)d.size()) d.resize(dx + 1, 0);
+            ++d[dx];
+        }
+        for (int t : children) child_idx[t] = -1;  // O(degree) でリセット
+        for (auto &d : dists) {
+            add_self_conv(d, -1);
+            if (d.size() > whole.size()) whole.resize(d.size(), 0);
+            for (int i = 0; i < (int)d.size(); ++i) whole[i] += d[i];
+        }
+        add_self_conv(whole, +1);
+    });
+
+    for (int d = 1; d < n; ++d) std::cout << ans[d] / 2 << (d == n - 1 ? '\n' : ' ');
+    if (n == 1) std::cout << '\n';
+
+    return 0;
+}


### PR DESCRIPTION
## 概要

重心分解木の親配列を返すだけだった `centroid_decomposition` を構造体化し、各重心ごとに連結成分の情報を受け取れる集計コールバック `run()` を追加しました。距離数え上げなどの典型的な用途に、分解ロジックを自前で書かずに直接使えるようになります。

## 変更内容

### `lib/tree/centroid_decomposition.hpp`
- `centroid_decomposition<T>` を構造体化。
  - `par()`: 重心分解木の親配列（従来の戻り値相当）。
  - `run(f)`: 各重心 `c` について `f(component)` を 1 回ずつ呼ぶ。`component` は重心 `c`・連結成分の頂点列 `order`（BFS 順）・`c` を根とした親 `par`・距離 `dep`・直下子部分木 ID `top`・部分木サイズ `sub` を持つ。
- **再帰は重心分解木の再帰のみ**（深さ O(log n) で安全）。連結成分の走査・部分木サイズ計算・距離計算はすべて BFS 反復にしてあり、鎖状の木（n=2×10⁵ のパス）でもスタックオーバーフローしません。
- 親配列だけ必要な従来用途のために `centroid_decomposition_par(g)` を用意。

### `test/yosupo/tree/frequency_table_of_tree_distance.test.cpp`（新規）
- [Frequency Table of Tree Distance](https://judge.yosupo.jp/problem/frequency_table_of_tree_distance) を新 API で記述。分解ロジックはライブラリに委譲し、各重心での距離分布構築と FFT 畳み込みだけを行う。

### `CLAUDE.md`
- コメントは `///` 行コメント形式で統一し、`/** */` などのブロックコメントは使わない旨を明記。

## 検証

- 構文チェック: `g++ -std=c++23 -I lib -Wall -Wextra -fsyntax-only`（OK）
- 正しさ: `frequency_table_of_tree_distance` を新 API で解いた結果を、全頂点対距離を数える O(n²) BFS naive と **ランダム木 2000 個で完全一致**（n=1 のエッジケース含む）。
- スタック安全性: n=2×10⁵ のパスで `run` まで完走、重心分解木の根がちょうど 1 つであることを確認。

## 備考

高速化（スキャン回数削減）も検討しましたが、実測で効果がない（むしろ遅くなる）ことが分かったため、最速だった降下方式を維持しています。実効性能をさらに上げるなら CSR グラフ化が候補ですが、本 PR には含めていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)