### PR TITLE
docs: コメント規約を Doxygen=/// と通常コメント=// に明確化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,8 +20,9 @@ g++ -std=c++23 -I lib -Wall -Wextra -fsyntax-only <test_file>
 - **標準ヘッダは明示 include**（`<bits/stdc++.h>` や `template/template.hpp` に依存しない）。
 - **`namespace` は snake_case**。
 - C++20/23 機能を使う: SFINAE より **concept**、サイズは **`std::bit_ceil`**、円周率は **`std::numbers::pi`**。
-- コメントは **`///` 行コメント形式**で統一する。Doxygen も通常コメントも `///` を使い、
-  **`/** */` や `/* */` などのブロックコメントは使わない**。
+- コメントは行コメントで統一し、**ブロックコメント（`/** */` や `/* */`）は使わない**。
+  - **Doxygen ドキュメントコメントは `///`**（`@brief` などを付ける説明）。
+  - **通常の実装コメントは `//`**。
 - 浮動小数点→整数の丸めは **`std::llround`**（`T(x + 0.5)` は負値で誤る）。
 
 ## 注意


### PR DESCRIPTION
## 概要

CLAUDE.md のコメント規約を、**Doxygen ドキュメントコメントは `///`、通常の実装コメントは `//`** と区別する形に更新しました。

直前の PR #269 では「Doxygen も通常コメントも `///`」としていましたが、Doxygen と通常コメントを行頭の `///` / `//` で見分けられる方が読みやすいため、方針を変更します。ブロックコメント（`/** */` や `/* */`）を使わない方針は維持します。

## 変更内容

```diff
- コメントは **`///` 行コメント形式**で統一する。Doxygen も通常コメントも `///` を使い、
  **`/** */` や `/* */` などのブロックコメントは使わない**。
+ コメントは行コメントで統一し、**ブロックコメント（`/** */` や `/* */`）は使わない**。
+   - **Doxygen ドキュメントコメントは `///`**（`@brief` などを付ける説明）。
+   - **通常の実装コメントは `//`**。
```

## 備考

`lib/tree/centroid_decomposition.hpp`（PR #269 でマージ済み）は既にこの新方針に準拠しています（`@brief` 等の説明は `///`、実装コメントは `//`）。そのためコード側の修正は不要で、本 PR は CLAUDE.md のみの変更です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)