### PR TITLE
refactor: auxiliary_tree を1クラスに統合し API 名を統一

### DIFF
--- a/lib/tree/auxiliary_tree.hpp
+++ b/lib/tree/auxiliary_tree.hpp
@@ -6,29 +6,37 @@
 #include "tree/euler_tour.hpp"
 #include "tree/linear_lca.hpp"
 
-struct auxiliary_tree : public Graph<void> {
-    auxiliary_tree(const std::vector<int> &_ord, const std::vector<int> &_par,
-                   const std::vector<bool> &_f)
-        : Graph::Graph(_par.size()), ord(_ord), f(_f) {
-        int n = _par.size();
-        for (int i = 0; i < n; ++i) {
-            if (_par[i] != -1) add_edges(_par[i], i);
+/// @brief auxiliary tree（補助木 / virtual tree）
+/// @details コンストラクタで LCA・Euler tour を前計算し、build(vs) で指定頂点集合に対する
+///          圧縮木を何度でも構築できる。Σ|vs| が小さければ各 build は O(|vs| log N)。
+struct auxiliary_tree {
+    /// @brief build が返す圧縮木。元の木の頂点番号・親・指定頂点フラグを保持する。
+    struct tree : public Graph<void> {
+        tree(const std::vector<int> &_ord, const std::vector<int> &_par, const std::vector<bool> &_f)
+            : Graph::Graph(_par.size()), ord(_ord), par(_par), f(_f) {
+            int n = _par.size();
+            for (int i = 0; i < n; ++i) {
+                if (par[i] != -1) add_edges(par[i], i);
+            }
         }
-    }
 
-    int vertex(int x) const { return ord[x]; }
-    bool contains(int x) const { return f[x]; }
+        /// @brief 補助木ノード x に対応する元の木の頂点番号
+        int get_vertex(int x) const { return ord[x]; }
+        /// @brief 補助木ノード x の親ノード番号。根は -1。
+        int get_parent(int x) const { return par[x]; }
+        /// @brief 補助木ノード x が指定頂点（LCA で補われた頂点でない）か
+        bool is_specified(int x) const { return f[x]; }
 
-  private:
-    std::vector<int> ord;
-    std::vector<bool> f;
-};
+      private:
+        std::vector<int> ord, par;
+        std::vector<bool> f;
+    };
 
-struct auxiliary_tree_builder {
     template <class T>
-    auxiliary_tree_builder(const Graph<T> &g, int r = 0) : lca(g, r), et(g, r) {}
+    auxiliary_tree(const Graph<T> &g, int r = 0) : lca(g, r), et(g, r) {}
 
-    auxiliary_tree build(std::vector<int> v) {
+    /// @brief 指定頂点集合 v に対する圧縮木を構築する。
+    tree build(std::vector<int> v) {
         std::sort(v.begin(), v.end(), [&](int x, int y) { return et.order(x) < et.order(y); });
         v.erase(std::unique(v.begin(), v.end()), v.end());
         std::vector<int> ord = v;
@@ -53,7 +61,7 @@ struct auxiliary_tree_builder {
                 ++x;
             }
         }
-        return auxiliary_tree{ord, par, f};
+        return tree{ord, par, f};
     }
 
   private:

--- a/lib/tree/hld.hpp
+++ b/lib/tree/hld.hpp
@@ -3,10 +3,8 @@
 #include "graph/graph.hpp"
 #include "internal/internal_csr.hpp"
 
-/**
- * @brief HL分解
- * @see https://beet-aizu.github.io/library/tree/heavylightdecomposition.cpp
- */
+/// @brief HL分解
+/// @see https://beet-aizu.github.io/library/tree/heavylightdecomposition.cpp
 struct heavy_light_decomposition {
     heavy_light_decomposition() = default;
     template <class T>

--- a/test/yukicoder/0901.test.cpp
+++ b/test/yukicoder/0901.test.cpp
@@ -23,7 +23,7 @@ int main(void) {
     };
     f(f, 0, -1);
 
-    auxiliary_tree_builder at(g);
+    auxiliary_tree at(g);
     int q;
     std::cin >> q;
     while (q--) {
@@ -37,7 +37,7 @@ int main(void) {
         auto dfs = [&](auto self, int v, int p) -> void {
             for (auto e : tr[v]) {
                 if (e.to() == p) continue;
-                hld.for_each_edge(tr.vertex(v), tr.vertex(e.to()), g);
+                hld.for_each_edge(tr.get_vertex(v), tr.get_vertex(e.to()), g);
                 self(self, e.to(), v);
             }
         };


### PR DESCRIPTION
## 概要

`auxiliary_tree`（補助木 / virtual tree）の API を整理する。あわせて `hld` のコメント規約違反を修正する。

## 動機

`auxiliary_tree_builder`（前計算保持＆構築役）+ `auxiliary_tree`（結果の圧縮木）の2クラス構成だったが、

- `_builder` サフィックスは競プロライブラリの慣習として一般的でない（KACTL `compressTree`、beet/suisen/sotanishy の `AuxiliaryTree` など、調べた主要ライブラリはいずれも `_builder` を使わず1クラスに統合している）。
- 本リポジトリの既存「前計算を保持して何度も問い合わせる」クラス（`centroid_decomposition`・`euler_tour`・`linear_lca`）とも流儀が揃っていなかった。

## 変更内容

### `lib/tree/auxiliary_tree.hpp` — builder 廃止・1クラス統合
- `auxiliary_tree_builder` を廃し、前計算を保持して何度でも `build(vs)` する1クラス `auxiliary_tree` に統合。
- 結果の圧縮木はネスト型 `auxiliary_tree::tree` に切り出し（`centroid_decomposition::component` に倣い、外部名前空間を汚さない）。
- API 名を `hld` 系に統一:
  - `vertex(x)` → `get_vertex(x)`
  - 新たに `get_parent(x)` を公開（従来は親配列を保持せず、利用側が DFS で再構成する必要があった）
  - `contains(x)` → `is_specified(x)`（実体は「補助木ノードが指定頂点か」なので正名）

### `lib/tree/hld.hpp` — コメント規約修正
- 先頭の `/** */` ブロックコメントを `///` に修正（CLAUDE.md の規約準拠）。

### `test/yukicoder/0901.test.cpp`
- 新 API（`auxiliary_tree` / `get_vertex`）へ追従。

## 動作確認

- 変更ヘッダ単体・`auxiliary_tree`/`hld` を使う関連テスト全本を `g++ -std=c++23 -I lib -Wall -Wextra -fsyntax-only` で確認（OK）。
- `test/yukicoder/0901` は competitive-verifier 用検証ファイルで、API 追従のみ・ロジック不変。

## 破壊的変更

`auxiliary_tree_builder` / `auxiliary_tree::vertex` / `auxiliary_tree::contains` を直接参照していた外部コードは追従が必要（本リポジトリ内の参照は本 PR で更新済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)