### PR TITLE
perf(bigint): 乗算を 2素数/3素数 NTT の適応型にし除算を約1.37x高速化

### DIFF
--- a/lib/data_structure/bigint.hpp
+++ b/lib/data_structure/bigint.hpp
@@ -21,6 +21,10 @@ struct BigInt {
     static constexpr int BASE_DIGITS = 6;
     /// 除数がこの桁数以下なら Burnikel-Ziegler 再帰をやめて古典除算に切り替える。
     static constexpr int BZ_THRESHOLD = 64;
+    /// 乗算で 2 素数 NTT (convolution_ll2) を使える最大畳み込み長。
+    /// 係数積は高々 (BASE-1)^2 * len なので、これが MOD1*MOD3 (約 3.5e17) 未満となる
+    /// len の上限。これを超える巨大乗算のみ 3 素数版 (convolution_ll) へ落とす。
+    static constexpr int MUL_2PRIME_MAX_LEN = 354659;
 
     BigInt() : data(1, 0), sign(false) {}
     explicit BigInt(std::int64_t x) : data(), sign(x < 0) {
@@ -187,14 +191,18 @@ struct BigInt {
         }
         trim(a);
     }
-    /// a *= b (絶対値同士の乗算)。畳み込みは真値を返す convolution_ll を使う。
+    /// a *= b (絶対値同士の乗算)。畳み込みは真値を返す convolution を使う。
+    /// 畳み込み長が MUL_2PRIME_MAX_LEN 以下なら 2 素数版 (convolution_ll2) で十分速く、
+    /// それを超える巨大乗算のみ 3 素数版 (convolution_ll) へフォールバックする。
     static void mul(std::vector<int> &a, const std::vector<int> &b) {
         if ((a.size() == 1 && a[0] == 0) || (b.size() == 1 && b[0] == 0)) {
             a.assign(1, 0);
             return;
         }
         std::vector<std::int64_t> x(a.begin(), a.end()), y(b.begin(), b.end());
-        std::vector<std::int64_t> c = convolution_ll(x, y);
+        std::vector<std::int64_t> c = (x.size() + y.size() <= MUL_2PRIME_MAX_LEN)
+                                          ? convolution_ll2(x, y)
+                                          : convolution_ll(x, y);
         std::int64_t carry = 0;
         a.assign(c.size() + 1, 0);
         for (int i = 0; i < (int)c.size(); ++i) {

--- a/lib/fft/ntt.hpp
+++ b/lib/fft/ntt.hpp
@@ -89,6 +89,42 @@ std::vector<std::int64_t> convolution_ll(const std::vector<std::int64_t> &a, con
     return c;
 }
 
+/// @brief 係数積が小さいときの畳み込み (2 つの NTT + CRT)
+/// @details MOD1 (= 754974721) と MOD3 (= 469762049) の 2 素数だけで畳み込み、
+///          CRT で復元する。NTT が 1 回少ない分 convolution_ll より速い。
+/// @warning 真値が MOD1 * MOD3 (約 3.5e17) 未満であること。畳み込み長 L について
+///          各係数は高々 (max|a_i|)*(max|b_j|)*L になるので、これがこの上限を超えない
+///          範囲でのみ使う (例: 各係数が 10^5 未満なら長さ 2^24 まで安全)。
+///          係数は非負であること (CRT 復元は [0, MOD1*MOD3) を返す)。
+/// @note 畳み込み後の長さは 2^24 (約 1.6e7) 以下でなければならない。
+/// @param a 入力多項式の係数列
+/// @param b 入力多項式の係数列
+/// @return std::vector<std::int64_t> a と b の畳み込み (長さ a.size() + b.size() - 1)
+std::vector<std::int64_t> convolution_ll2(const std::vector<std::int64_t> &a, const std::vector<std::int64_t> &b) {
+    int n = int(a.size()), m = int(b.size());
+    if (!n || !m) return {};
+
+    using C = internal::convolution_mod_constants;
+    assert(n + m - 1 <= (1 << C::MAX_AB_BIT));
+    // MOD3 を法とした MOD1 の逆元 (CRT 復元用)。
+    static constexpr std::int64_t inv1 = internal::inv_gcd(C::MOD1, C::MOD3).second;
+
+    auto c1 = convolution<C::MOD1>(a, b);
+    auto c3 = convolution<C::MOD3>(a, b);
+
+    std::vector<std::int64_t> c(n + m - 1);
+    for (int i = 0; i < n + m - 1; i++) {
+        // x ≡ c1 (mod MOD1), x ≡ c3 (mod MOD3) を満たす [0, MOD1*MOD3) の値を求める。
+        // x = c1 + MOD1 * t, t = (c3 - c1) * inv1 mod MOD3。
+        std::int64_t t = (c3[i] - c1[i]) % (std::int64_t)C::MOD3;
+        if (t < 0) t += (std::int64_t)C::MOD3;
+        t = (std::int64_t)((__int128)t * inv1 % (std::int64_t)C::MOD3);
+        c[i] = c1[i] + (std::int64_t)C::MOD1 * t;
+    }
+
+    return c;
+}
+
 /// @brief 任意 mod 畳み込み (3 つの NTT + Garner 法)
 /// @details 3 つの NTT-friendly 素数で畳み込み、Garner 法で復元した値を mod で取る。
 ///          mod は NTT-friendly でなくてもよい。


### PR DESCRIPTION
## 概要

`BigInt` の乗算の畳み込みを、**畳み込み長に応じて 2 素数 NTT と 3 素数 NTT を切り替える適応型**にする。Burnikel-Ziegler 除算は内部で多数の乗算を行うため、乗算が速くなると除算も一様に高速化する。

## 背景・設計判断

当初は `BASE` を 10^6 → 10^5 に下げて係数積を小さくし 2 素数化する案を検証したが、**公式テストデータで不均衡除算 (`length_ratio_integer`) が退行**した。プロファイリングの結果、退行の本質は「桁数 1.2× 増による線形コスト」が NTT 節約を食い潰すことだと判明（ループ最適化・閾値調整でも回収できず）。

そこで **`BASE=10^6` を維持して桁数を増やさず**、係数積が `MOD1*MOD3 (≈3.5e17)` に収まる範囲（畳み込み長 ≤ `MUL_2PRIME_MAX_LEN = 354659`）でのみ 2 素数 NTT を使い、それを超える巨大乗算のみ従来の 3 素数版へフォールバックする方式に変更した。線形コストの増加ゼロで NTT 節約だけを得られる。

## 変更内容

- `lib/fft/ntt.hpp`: 2 素数 (MOD1, MOD3) + CRT で厳密復元する `convolution_ll2` を追加
- `lib/data_structure/bigint.hpp`: `mul` を適応型に変更し、安全上限定数 `MUL_2PRIME_MAX_LEN = 354659` を追加

## 性能

yosupo [division_of_big_integers](https://judge.yosupo.jp/problem/division_of_big_integers) の公式 26 ケース・複数回測定最良値。

| | 変更前 | 変更後 | 倍率 |
|---|---|---|---|
| **ワーストケース**（AC 決定） | 1273ms | **927ms** | **1.37×** |
| 全 26 ケース合計 | 12.8s | 9.6s | 1.34× |
| 均衡除算 `a_max_b_random` | 904ms | 624ms | 1.46× |
| 不均衡除算 `length_ratio_integer` | 1273ms | 927ms | 1.37× |

**全 26 ケースで退行なし**、**全ケース公式 checker で AC**。

## 正しさの確認

- 実ライブラリで Python 任意精度をオラクルに `+,-,*,/,%` を **7589 件突き合わせ・不一致 0**（2M 桁付近＝3 素数フォールバックまで含む）
- **2 素数 / 3 素数の切替境界**を全桁 9 の最悪係数で厳密検証（`len=MAX` で 2 素数、`len>MAX` で 3 素数、いずれも一致）
- 上限定数 354659 が `(BASE-1)^2 * len < MOD1*MOD3` の正確な上限であることを確認（354660 は不可）
- bigint 依存テスト 9 本すべて `-Wall -Wextra` でコンパイル通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)