### PR TITLE
refactor(test): convolution テストの出力ループを簡潔化

### DIFF
--- a/test/yosupo/convolution/bitwise_and_convolution.test.cpp
+++ b/test/yosupo/convolution/bitwise_and_convolution.test.cpp
@@ -36,7 +36,7 @@ int main(void) {
     std::vector<Mint> c(n);
     for (int i = 0; i < n; ++i) c[i] = a[i] * b[i];
     ifwt(c);
-    for (int i = 0; i < n; ++i) std::cout << c[i] << (i == n - 1 ? '\n' : ' ');
+    for (int i = 0; i < n; ++i) std::cout << c[i] << " \n"[i == n - 1];
 
     return 0;
 }

--- a/test/yosupo/convolution/bitwise_xor_convolution.test.cpp
+++ b/test/yosupo/convolution/bitwise_xor_convolution.test.cpp
@@ -42,7 +42,7 @@ int main(void) {
     std::vector<Mint> c(n);
     for (int i = 0; i < n; ++i) c[i] = a[i] * b[i];
     ifwt(c);
-    for (int i = 0; i < n; ++i) std::cout << c[i] << (i == n - 1 ? '\n' : ' ');
+    for (int i = 0; i < n; ++i) std::cout << c[i] << " \n"[i == n - 1];
 
     return 0;
 }

--- a/test/yosupo/convolution/convolution.test.cpp
+++ b/test/yosupo/convolution/convolution.test.cpp
@@ -10,7 +10,7 @@ int main(void) {
     for (auto &e : a) std::cin >> e;
     for (auto &e : b) std::cin >> e;
     auto ans = convolution(a, b);
-    for (int i = 0; i < (int)ans.size(); ++i) std::cout << ans[i] << (i == (int)ans.size() - 1 ? '\n' : ' ');
+    for (int i = 0; i < n + m - 1; ++i) std::cout << ans[i] << " \n"[i == n + m - 2];
 
     return 0;
 }

--- a/test/yosupo/convolution/convolution_mod.test.cpp
+++ b/test/yosupo/convolution/convolution_mod.test.cpp
@@ -10,7 +10,7 @@ int main(void) {
     for (auto &e : a) std::cin >> e;
     for (auto &e : b) std::cin >> e;
     auto ans = convolution_mod<modint107::mod()>(a, b);
-    for (int i = 0; i < (int)ans.size(); ++i) std::cout << ans[i] << (i == (int)ans.size() - 1 ? '\n' : ' ');
+    for (int i = 0; i < n + m - 1; ++i) std::cout << ans[i] << " \n"[i == n + m - 2];
 
     return 0;
 }

--- a/test/yosupo/convolution/gcd_convolution.test.cpp
+++ b/test/yosupo/convolution/gcd_convolution.test.cpp
@@ -25,7 +25,7 @@ int main(void) {
         if (!pn.is_prime(p)) continue;
         for (int i = 1; i * p <= n; ++i) a[i] -= a[i * p];
     }
-    for (int i = 1; i <= n; ++i) std::cout << a[i] << (i == n ? '\n' : ' ');
+    for (int i = 1; i <= n; ++i) std::cout << a[i] << " \n"[i == n];
 
     return 0;
 }

--- a/test/yosupo/convolution/lcm_convolution.test.cpp
+++ b/test/yosupo/convolution/lcm_convolution.test.cpp
@@ -25,7 +25,7 @@ int main(void) {
         if (!pn.is_prime(p)) continue;
         for (int i = n / p; i >= 1; --i) a[i * p] -= a[i];
     }
-    for (int i = 1; i <= n; ++i) std::cout << a[i] << (i == n ? '\n' : ' ');
+    for (int i = 1; i <= n; ++i) std::cout << a[i] << " \n"[i == n];
 
     return 0;
 }

--- a/test/yosupo/convolution/min_plus_convolution_convex_arbitrary.test.cpp
+++ b/test/yosupo/convolution/min_plus_convolution_convex_arbitrary.test.cpp
@@ -10,8 +10,7 @@ int main(void) {
     for (auto &e : a) std::cin >> e;
     for (auto &e : b) std::cin >> e;
     auto ans = min_plus_convolution(b, a);
-    for (int i = 0; i < (int)ans.size(); ++i)
-        std::cout << ans[i] << (i == (int)ans.size() - 1 ? '\n' : ' ');
+    for (int i = 0; i < n + m - 1; ++i) std::cout << ans[i] << " \n"[i == n + m - 2];
 
     return 0;
 }

--- a/test/yosupo/convolution/min_plus_convolution_convex_convex.cpp
+++ b/test/yosupo/convolution/min_plus_convolution_convex_convex.cpp
@@ -10,8 +10,7 @@ int main(void) {
     for (auto &e : a) std::cin >> e;
     for (auto &e : b) std::cin >> e;
     auto ans = min_plus_convolution(b, a);
-    for (int i = 0; i < (int)ans.size(); ++i)
-        std::cout << ans[i] << (i == (int)ans.size() - 1 ? '\n' : ' ');
+    for (int i = 0; i < n + m - 1; ++i) std::cout << ans[i] << " \n"[i == n + m - 2];
 
     return 0;
 }


### PR DESCRIPTION
## 概要

`test/yosupo/convolution/` 配下 8 ファイルの出力ループをリファクタリング。**出力結果は従来と完全に一致**する純粋なスタイル変更。

## 変更内容

1. 区切り文字の出力を `(i == last ? '\n' : ' ')` から `" \n"[i == last]` に統一
   - `" \n"[false]` = `' '`、`" \n"[true]` = `'\n'` で三項演算子と等価
2. 出力長を `(int)ans.size()` から `n + m - 1` に置換（`convolution.test.cpp` / `convolution_mod.test.cpp` / `min_plus_convolution_*`）
   - 各畳み込み関数の返り値長は `a.size() + b.size() - 1`。本テストでは `a.size()=n`, `b.size()=m` なので `ans.size() == n + m - 1` で等価
   - `min_plus_convolution` も `monotone_minima_value(n + m - 1, ...)` を返すため長さは `n + m - 1`

## 動作不変の確認

- 8 ファイルすべて `g++ -std=c++23 -I lib -Wall -Wextra -fsyntax-only` を通過
- HEAD 版と作業ツリー版をビルドし、ランダム入力 150 ケース（各パターン代表 50 ケース）でバイト一致を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)