### PR TITLE
chore: verify の CXXFLAGS に -pthread を追加し --std を -std に統一

### DIFF
--- a/.verify-helper/config.toml
+++ b/.verify-helper/config.toml
@@ -9,6 +9,7 @@ CXXFLAGS = [
     "-fconstexpr-ops-limit=2097152",
     "-flto=auto",
     "-march=native",
-    "--std=gnu++23",
+    "-pthread",
+    "-std=gnu++23",
     "-I./lib",
 ]


### PR DESCRIPTION
## 概要

`.verify-helper/config.toml` の `CXXFLAGS` を 2 点変更する。

- `-pthread` を追加: スレッドを使うテスト/実装のコンパイル・リンクに対応。
- `--std=gnu++23` → `-std=gnu++23`: 一般的な短いオプション形に統一。

## 変更内容

```diff
     "-fconstexpr-ops-limit=2097152",
     "-flto=auto",
     "-march=native",
-    "--std=gnu++23",
+    "-pthread",
+    "-std=gnu++23",
     "-I./lib",
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)