### PR TITLE
refactor: グラフ・木の O(N) 深さ再帰を非再帰化

### DIFF
--- a/lib/graph/cycle.hpp
+++ b/lib/graph/cycle.hpp
@@ -135,20 +135,31 @@ bool has_cycle(const Graph<T> &g) {
     std::vector<bool> seen(n), finished(n);
     bool res = false;
 
-    auto dfs = [&](auto self, int index) -> void {
-        if (finished[index]) return;
-        seen[index] = true;
-        for (auto &e : g[index]) {
-            if (res |= seen[e.to()]) return;
-            self(self, e.to());
+    // 反復 DFS（再帰だと深いグラフでスタックオーバーフローしうる）。
+    // seen はパス上（灰）を、finished は探索完了（黒）を表し、
+    // パス上の頂点へ戻る辺を見つけたら閉路あり。
+    std::vector<std::pair<int, int>> stk;
+    for (int i = 0; i < n && !res; ++i) {
+        if (finished[i] || seen[i]) continue;
+        seen[i] = true;
+        stk.emplace_back(i, 0);
+        while (!stk.empty() && !res) {
+            auto &[v, idx] = stk.back();
+            if (idx < (int)g[v].size()) {
+                int to = g[v][idx++].to();
+                if (seen[to]) {
+                    res = true;
+                } else if (!finished[to]) {
+                    seen[to] = true;
+                    stk.emplace_back(to, 0);
+                }
+            } else {
+                seen[v] = false;
+                finished[v] = true;
+                stk.pop_back();
+            }
         }
-        seen[index] = false;
-        finished[index] = true;
-    };
-
-    for (int i = 0; i < n; ++i) {
         if (res) break;
-        dfs(dfs, i);
     }
     return res;
 }

--- a/lib/graph/lowlink.hpp
+++ b/lib/graph/lowlink.hpp
@@ -27,29 +27,53 @@ struct low_link {
         // parent_edge_id: index に入ってきた辺の ID（根は -1）。
         // 親へ戻る辺は「同じ ID の辺」で除外する。多重辺は ID が異なるため
         // back edge として正しく扱われ、橋・関節点の誤判定を防ぐ。
-        auto dfs = [&](auto self, int index, int parent_edge_id) -> void {
-            used[index] = true;
-            ord[index] = number++;
-            low[index] = ord[index];
-            bool is_articulation_point = false;
-            int count = 0;
-            for (auto &e : g[index]) {
-                if (e.id() == parent_edge_id) continue;  // 親へ来た辺そのものは無視
-                if (!used[e.to()]) {
-                    ++count;
-                    self(self, e.to(), e.id());
-                    low[index] = std::min(low[index], low[e.to()]);
-                    is_articulation_point |= parent_edge_id != -1 && low[e.to()] >= ord[index];
-                    if (ord[index] < low[e.to()]) bridges.emplace_back(e.id());
+        //
+        // 反復 DFS（再帰だと深いグラフでスタックオーバーフローしうる）。
+        // 各フレームは頂点・親辺 ID・隣接走査位置・子の本数・関節点フラグを持つ。
+        // 子から戻った直後の処理（low の更新・橋/関節点判定）は、どの辺で
+        // 降りたかを覚えておき復帰時に行う。
+        struct frame {
+            int v, parent_edge_id, idx, count;
+            bool is_articulation;
+        };
+        std::vector<frame> stk;
+        for (int s = 0; s < g.size(); ++s) {
+            if (used[s]) continue;
+            used[s] = true;
+            ord[s] = low[s] = number++;
+            stk.push_back({s, -1, 0, 0, false});
+            while (!stk.empty()) {
+                frame &f = stk.back();
+                int v = f.v;
+                if (f.idx < (int)g[v].size()) {
+                    const auto &e = g[v][f.idx++];
+                    if (e.id() == f.parent_edge_id) continue;  // 親へ来た辺そのものは無視
+                    int to = e.to();
+                    if (!used[to]) {
+                        ++f.count;
+                        used[to] = true;
+                        ord[to] = low[to] = number++;
+                        // 復帰時に f.idx-1 の辺で子を処理するため、子フレームを積む
+                        stk.push_back({to, e.id(), 0, 0, false});
+                    } else {
+                        low[v] = std::min(low[v], ord[to]);
+                    }
                 } else {
-                    low[index] = std::min(low[index], ord[e.to()]);
+                    // v の探索完了。親フレームへ戻って子処理を反映する。
+                    bool is_art = f.is_articulation;
+                    is_art |= f.parent_edge_id == -1 && f.count > 1;
+                    if (is_art) articulation_points.emplace_back(v);
+                    int low_v = low[v], pe = f.parent_edge_id;
+                    stk.pop_back();
+                    if (!stk.empty()) {
+                        frame &pf = stk.back();
+                        int p = pf.v;
+                        low[p] = std::min(low[p], low_v);
+                        pf.is_articulation |= pf.parent_edge_id != -1 && low_v >= ord[p];
+                        if (ord[p] < low_v) bridges.emplace_back(pe);
+                    }
                 }
             }
-            is_articulation_point |= parent_edge_id == -1 && count > 1;
-            if (is_articulation_point) articulation_points.emplace_back(index);
-        };
-        for (int i = 0; i < g.size(); i++) {
-            if (!used[i]) dfs(dfs, i, -1);
         }
     }
 };

--- a/lib/graph/scc.hpp
+++ b/lib/graph/scc.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <algorithm>
+#include <utility>
 #include <vector>
 #include "graph/graph.hpp"
 #include "internal/internal_csr.hpp"
@@ -15,23 +16,47 @@ std::vector<int> scc(const Graph<T> &g) {
     for (auto &e : g.all_edges()) rg.add_edge(e.to(), e.from());
     rg.build();
 
-    auto dfs = [&](auto self, int index) {
-        if (used[index]) return;
-        used[index] = true;
-        for (auto &e : g[index]) self(self, e.to());
-        order.emplace_back(index);
-    };
-    auto rdfs = [&](auto self, int index, int count) {
-        if (~comp[index]) return;
-        comp[index] = count;
-        for (int u : rg[index]) self(self, u, count);
-    };
-
-    for (int i = 0; i < n; ++i) dfs(dfs, i);
+    // 反復 DFS（再帰だと深いグラフでスタックオーバーフローしうる）
+    // stk には頂点と隣接リストの走査位置を積む。子を処理し終えた後に
+    // order へ push することで、再帰版と同じ帰りがけ順を再現する。
+    std::vector<std::pair<int, int>> stk;
+    for (int s = 0; s < n; ++s) {
+        if (used[s]) continue;
+        used[s] = true;
+        stk.emplace_back(s, 0);
+        while (!stk.empty()) {
+            auto &[v, idx] = stk.back();
+            if (idx < (int)g[v].size()) {
+                int to = g[v][idx++].to();
+                if (!used[to]) {
+                    used[to] = true;
+                    stk.emplace_back(to, 0);
+                }
+            } else {
+                order.emplace_back(v);
+                stk.pop_back();
+            }
+        }
+    }
     std::reverse(order.begin(), order.end());
+
+    // 逆グラフ上の反復 DFS で連結成分番号を振る
+    std::vector<int> rstk;
     int ptr = 0;
     for (auto i : order) {
-        if (comp[i] == -1) rdfs(rdfs, i, ptr++);
+        if (~comp[i]) continue;
+        comp[i] = ptr;
+        rstk.emplace_back(i);
+        while (!rstk.empty()) {
+            int v = rstk.back();
+            rstk.pop_back();
+            for (int u : rg[v]) {
+                if (~comp[u]) continue;
+                comp[u] = ptr;
+                rstk.emplace_back(u);
+            }
+        }
+        ++ptr;
     }
 
     return comp;
@@ -48,23 +73,48 @@ std::vector<int> scc(const internal::graph_csr &g) {
     }
     rg.build();
 
-    auto dfs = [&](auto self, int index) {
-        if (used[index]) return;
-        used[index] = true;
-        for (int u : g[index]) self(self, u);
-        order.emplace_back(index);
-    };
-    auto rdfs = [&](auto self, int index, int count) {
-        if (~comp[index]) return;
-        comp[index] = count;
-        for (int u : rg[index]) self(self, u, count);
-    };
-
-    for (int i = 0; i < n; ++i) dfs(dfs, i);
+    // 反復 DFS（再帰だと深いグラフでスタックオーバーフローしうる）
+    // CSR は隣接リストの走査をイテレータで進める。子を処理し終えた後に
+    // order へ push することで、再帰版と同じ帰りがけ順を再現する。
+    using cit = std::vector<int>::const_iterator;
+    std::vector<std::pair<int, std::pair<cit, cit>>> stk;
+    for (int s = 0; s < n; ++s) {
+        if (used[s]) continue;
+        used[s] = true;
+        stk.emplace_back(s, std::make_pair(g[s].begin(), g[s].end()));
+        while (!stk.empty()) {
+            auto &[v, it] = stk.back();
+            if (it.first != it.second) {
+                int to = *it.first++;
+                if (!used[to]) {
+                    used[to] = true;
+                    stk.emplace_back(to, std::make_pair(g[to].begin(), g[to].end()));
+                }
+            } else {
+                order.emplace_back(v);
+                stk.pop_back();
+            }
+        }
+    }
     std::reverse(order.begin(), order.end());
+
+    // 逆グラフ上の反復 DFS で連結成分番号を振る
+    std::vector<int> rstk;
     int ptr = 0;
     for (auto i : order) {
-        if (comp[i] == -1) rdfs(rdfs, i, ptr++);
+        if (~comp[i]) continue;
+        comp[i] = ptr;
+        rstk.emplace_back(i);
+        while (!rstk.empty()) {
+            int v = rstk.back();
+            rstk.pop_back();
+            for (int u : rg[v]) {
+                if (~comp[u]) continue;
+                comp[u] = ptr;
+                rstk.emplace_back(u);
+            }
+        }
+        ++ptr;
     }
 
     return comp;

--- a/lib/graph/topological_sort.hpp
+++ b/lib/graph/topological_sort.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <algorithm>
+#include <utility>
 #include <vector>
 #include "graph/graph.hpp"
 
@@ -9,14 +10,27 @@ std::vector<int> topological_sort(const Graph<T> &g) {
     int n = g.size();
     std::vector<int> res;
     std::vector<bool> seen(n);
-    auto dfs = [&](auto self, int v) {
-        if (seen[v]) return;
-        seen[v] = true;
-        for (auto &e : g[v])
-            if (!seen[e.to()]) self(self, e.to());
-        res.emplace_back(v);
-    };
-    for (int i = 0; i < n; ++i) dfs(dfs, i);
+    // 反復 DFS（再帰だと深いグラフでスタックオーバーフローしうる）。
+    // 子を処理し終えた後に res へ push する帰りがけ順を再現し、最後に反転する。
+    std::vector<std::pair<int, int>> stk;
+    for (int i = 0; i < n; ++i) {
+        if (seen[i]) continue;
+        seen[i] = true;
+        stk.emplace_back(i, 0);
+        while (!stk.empty()) {
+            auto &[v, idx] = stk.back();
+            if (idx < (int)g[v].size()) {
+                int to = g[v][idx++].to();
+                if (!seen[to]) {
+                    seen[to] = true;
+                    stk.emplace_back(to, 0);
+                }
+            } else {
+                res.emplace_back(v);
+                stk.pop_back();
+            }
+        }
+    }
     std::reverse(res.begin(), res.end());
     return res;
 }

--- a/lib/tree/dsu_on_tree.hpp
+++ b/lib/tree/dsu_on_tree.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <cassert>
+#include <utility>
 #include <vector>
 #include "graph/graph.hpp"
 #include "template/template.hpp"
@@ -35,24 +36,53 @@ struct dsu_on_tree {
 
     template <class F, class G, class H>
     void solve(F &rem, G &clear, H &query) {
-        auto dsu = [&](auto self, int v) -> void {
-            int hp = heavy_path[v];
+        if (size == 0) return;
+        // 反復版（再帰だと深い木でスタックオーバーフローしうる）。
+        // 各フレームは light 子を走査する idx と heavy 再帰済みフラグ heavy_done を持つ。
+        // light 子から戻った直後に clear()、heavy 子から戻った後に query/rem を行い、
+        // 元の再帰と同じ呼び出し順序を再現する。
+        struct frame {
+            int v, idx;
+            bool heavy_done, pending_clear;
+        };
+        std::vector<frame> st;
+        st.push_back({root, 0, false, false});
+        while (!st.empty()) {
+            frame &f = st.back();
+            int v = f.v, hp = heavy_path[v];
             if (hp == -1) {
                 for (int i = left[v]; i < right[v]; ++i) query(query_order[i]);
                 rem(v);
-                return;
+                st.pop_back();
+                continue;
             }
-            for (auto &e : g[v]) {
-                if (e.to() == par[v] || e.to() == heavy_path[v]) continue;
-                self(self, e.to());
+            // 直前に light 子から戻っていれば、その都度 clear する
+            if (f.pending_clear) {
                 clear();
+                f.pending_clear = false;
             }
-            self(self, hp);
+            // light 子を順に処理（戻ってきたら上の pending_clear で clear）
+            bool descended = false;
+            while (f.idx < (int)g[v].size()) {
+                int u = g[v][f.idx++].to();
+                if (u == par[v] || u == hp) continue;
+                f.pending_clear = true;
+                st.push_back({u, 0, false, false});
+                descended = true;
+                break;
+            }
+            if (descended) continue;  // light 子の dsu へ降りる
+            if (!f.heavy_done) {
+                f.heavy_done = true;
+                st.push_back({hp, 0, false, false});
+                continue;
+            }
+            // heavy 子の処理完了後: 残り区間を query して rem
             for (int i = left[v]; i < left[hp]; ++i) query(query_order[i]);
             for (int i = right[hp]; i < right[v]; ++i) query(query_order[i]);
             rem(v);
-        };
-        dsu(dsu, root);
+            st.pop_back();
+        }
     }
 
   private:
@@ -60,33 +90,68 @@ struct dsu_on_tree {
     int size, root;
     std::vector<int> par, sub, euler, left, right, heavy_path, query_order, query_size;
 
+    // 反復 DFS（再帰だと深い木でスタックオーバーフローしうる）。
+    // 帰りがけに部分木サイズを集計し、最大の子を heavy_path に記録する。
     void dfs_sz(int v) {
-        int max_sub = 0;
-        for (auto &e : g[v]) {
-            int u = e.to();
-            if (u == par[v]) continue;
-            par[u] = v;
-            dfs_sz(u);
-            sub[v] += sub[u];
-            if (chmax(max_sub, sub[u])) heavy_path[v] = u;
+        std::vector<std::pair<int, int>> st;  // (頂点, 隣接走査位置)
+        std::vector<int> max_sub(size, 0);
+        st.emplace_back(v, 0);
+        while (!st.empty()) {
+            auto &[u, idx] = st.back();
+            if (idx < (int)g[u].size()) {
+                int w = g[u][idx++].to();
+                if (w == par[u]) continue;
+                par[w] = u;
+                st.emplace_back(w, 0);
+            } else {
+                int p = par[u];
+                st.pop_back();
+                if (p != -1) {
+                    sub[p] += sub[u];
+                    if (chmax(max_sub[p], sub[u])) heavy_path[p] = u;
+                }
+            }
         }
     }
 
+    // 反復 DFS（行きがけ順を保つ）。各頂点で heavy 子を先に、続いて light 子を
+    // 左から処理する。pos / len の更新は行きがけ時に行う。
     void dfs_hld(int v, int &pos, int &len) {
-        euler[pos++] = v;
-        left[v] = len;
-        right[v] = len + sub[v];
-        len += query_size[v];
-        int hp = heavy_path[v];
-        if (hp == -1) {
-            right[v] = len;
-            return;
-        }
-        dfs_hld(hp, pos, len);
-        for (auto &e : g[v]) {
-            int u = e.to();
-            if (u == par[v] || u == hp) continue;
-            dfs_hld(u, pos, len);
+        struct frame {
+            int v, idx;
+            bool entered;
+        };
+        std::vector<frame> st;
+        st.push_back({v, 0, false});
+        while (!st.empty()) {
+            frame &f = st.back();
+            int u = f.v;
+            if (!f.entered) {
+                f.entered = true;
+                euler[pos++] = u;
+                left[u] = len;
+                right[u] = len + sub[u];
+                len += query_size[u];
+                if (heavy_path[u] == -1) {
+                    right[u] = len;
+                    st.pop_back();
+                    continue;
+                }
+                // heavy 子を最初に処理する
+                st.push_back({heavy_path[u], 0, false});
+                continue;
+            }
+            // heavy 子の処理が終わった後、light 子を左から順に処理する
+            int hp = heavy_path[u];
+            bool descended = false;
+            while (f.idx < (int)g[u].size()) {
+                int w = g[u][f.idx++].to();
+                if (w == par[u] || w == hp) continue;
+                st.push_back({w, 0, false});
+                descended = true;
+                break;
+            }
+            if (!descended) st.pop_back();
         }
     }
 };

--- a/lib/tree/rerooting.hpp
+++ b/lib/tree/rerooting.hpp
@@ -29,36 +29,77 @@ struct ReRooting {
     std::vector<Value> values;
 
     void build() {
-        dfs(0);
-        bfs(0);
+        if ((int)graph.size() == 0) return;
+        dfs_iter();
+        bfs_iter();
     }
 
-    Value dfs(int v, int p = -1) {
-        Value res = M::id();
-        int deg = graph[v].size();
-        dp[v] = std::vector<Value>(deg, M::id());
-        for (int i = 0; i < deg; ++i) {
-            auto e = graph[v][i];
-            if (e.to() == p) continue;
-            dp[v][i] = M::f(dfs(e.to(), v), e.weight());
-            res = M::op(res, dp[v][i]);
+    // 反復版の dfs（再帰だと深い木でスタックオーバーフローしうる）。
+    // 帰りがけに各頂点の集約値 ret[v] = M::g(op(子のdp), data[v]) を確定し、
+    // 親側の dp[親][自分への辺] を更新する。
+    void dfs_iter() {
+        int n = graph.size();
+        std::vector<Value> ret(n, M::id());
+        std::vector<Value> res(n, M::id());  // 各頂点の子 dp の op 集約
+        std::vector<int> par(n, -1), pe(n, -1);  // 親と「親→自分」の辺添字
+        struct frame {
+            int v, p, idx;
+        };
+        std::vector<frame> st;
+        for (int i = 0; i < n; ++i) dp[i] = std::vector<Value>(graph[i].size(), M::id());
+        st.push_back({0, -1, 0});
+        while (!st.empty()) {
+            frame &f = st.back();
+            int v = f.v;
+            if (f.idx < (int)graph[v].size()) {
+                int i = f.idx++;
+                auto e = graph[v][i];
+                if (e.to() == f.p) continue;
+                par[e.to()] = v;
+                pe[e.to()] = i;
+                st.push_back({e.to(), v, 0});
+            } else {
+                ret[v] = M::g(res[v], data[v]);
+                int p = par[v];
+                st.pop_back();
+                if (p != -1) {
+                    dp[p][pe[v]] = M::f(ret[v], graph[p][pe[v]].weight());
+                    res[p] = M::op(res[p], dp[p][pe[v]]);
+                }
+            }
         }
-        return M::g(res, data[v]);
     }
-    void bfs(int v, int p = -1, Value dp_p = M::id()) {
-        int deg = graph[v].size();
-        std::vector<Value> dp_r(deg + 1, M::id());
-        for (int i = deg - 1; i >= 0; --i) {
-            auto e = graph[v][i];
-            if (e.to() == p) dp[v][i] = M::f(dp_p, e.weight());
-            dp_r[i] = M::op(dp[v][i], dp_r[i + 1]);
+
+    // 反復版の bfs（行きがけに親から伝播する dp_p を渡しながら values を確定）。
+    void bfs_iter() {
+        int n = graph.size();
+        std::vector<int> par(n, -1);
+        std::vector<Value> dp_p_of(n, M::id());  // 各頂点が親から受け取る dp_p
+        std::vector<int> st = {0};
+        // 行きがけ順に処理（スタックでも順序非依存: values は各頂点 1 回書く）
+        while (!st.empty()) {
+            int v = st.back();
+            st.pop_back();
+            int p = par[v];
+            Value dp_p = dp_p_of[v];
+            int deg = graph[v].size();
+            std::vector<Value> dp_r(deg + 1, M::id());
+            for (int i = deg - 1; i >= 0; --i) {
+                auto e = graph[v][i];
+                if (e.to() == p) dp[v][i] = M::f(dp_p, e.weight());
+                dp_r[i] = M::op(dp[v][i], dp_r[i + 1]);
+            }
+            Value dp_l = M::id();
+            for (int i = 0; i < deg; ++i) {
+                int u = graph[v][i].to();
+                if (u != p) {
+                    par[u] = v;
+                    dp_p_of[u] = M::g(M::op(dp_l, dp_r[i + 1]), data[v]);
+                    st.push_back(u);
+                }
+                dp_l = M::op(dp_l, dp[v][i]);
+            }
+            values[v] = M::g(dp_l, data[v]);
         }
-        Value dp_l = M::id();
-        for (int i = 0; i < deg; ++i) {
-            int u = graph[v][i].to();
-            if (u != p) bfs(u, v, M::g(M::op(dp_l, dp_r[i + 1]), data[v]));
-            dp_l = M::op(dp_l, dp[v][i]);
-        }
-        values[v] = M::g(dp_l, data[v]);
     }
 };

--- a/lib/tree/static_top_tree.hpp
+++ b/lib/tree/static_top_tree.hpp
@@ -38,21 +38,33 @@ struct static_top_tree {
         nodes.assign(n, {-1, -1, -1, Vertex});
         std::vector<int> par(n, -1), sz(n, 1), heavy(n, -1);
 
-        auto dfs_sz = [&](auto self, int u, int p) -> void {
-            par[u] = p;
-            int max_sub = 0;
-            for (auto &&e : g[u]) {
-                int v = get_to(e);
-                if (v == p) continue;
-                self(self, v, u);
-                sz[u] += sz[v];
-                if (max_sub < sz[v]) {
-                    max_sub = sz[v];
-                    heavy[u] = v;
+        // 反復 DFS（再帰だと深い木でスタックオーバーフローしうる）。
+        // 帰りがけに部分木サイズを集計し、最大の子を heavy に記録する。
+        {
+            std::vector<int> max_sub(n, 0);
+            std::vector<std::pair<int, int>> st;  // (頂点, 隣接走査位置)
+            par[_root] = -1;
+            st.emplace_back(_root, 0);
+            while (!st.empty()) {
+                auto &[u, idx] = st.back();
+                if (idx < (int)g[u].size()) {
+                    int v = get_to(g[u][idx++]);
+                    if (v == par[u]) continue;
+                    par[v] = u;
+                    st.emplace_back(v, 0);
+                } else {
+                    int p = par[u];
+                    st.pop_back();
+                    if (p != -1) {
+                        sz[p] += sz[u];
+                        if (max_sub[p] < sz[u]) {
+                            max_sub[p] = sz[u];
+                            heavy[p] = u;
+                        }
+                    }
                 }
             }
-        };
-        dfs_sz(dfs_sz, _root, -1);
+        }
 
         auto new_node = [&](int l, int r, Type type) -> int {
             int id = nodes.size();

--- a/lib/tree/tree_function.hpp
+++ b/lib/tree/tree_function.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <stack>
+#include <utility>
 #include <vector>
 #include "graph/graph.hpp"
 
@@ -38,14 +39,20 @@ std::vector<int> tree_bfs(const std::vector<int> &parents) {
 template <class T>
 std::vector<int> tree_dfs(const Graph<T> &g, int r = 0) {
     std::vector<int> res;
-    auto dfs = [&g, &res](auto self, int index, int parent) -> void {
+    // 反復 DFS（再帰だと深い木でスタックオーバーフローしうる）。
+    // 行きがけ順を保つため (頂点, 親) を積み、子は左から処理する。
+    std::stack<std::pair<int, int>> st;
+    st.emplace(r, -1);
+    while (!st.empty()) {
+        auto [index, parent] = st.top();
+        st.pop();
         res.emplace_back(index);
-        for (auto &e : g[index]) {
-            if (e.to() == parent) continue;
-            self(self, e.to(), index);
+        // 元の左→右の行きがけ順にするため逆順に積む
+        for (auto it = g[index].rbegin(); it != g[index].rend(); ++it) {
+            if (it->to() == parent) continue;
+            st.emplace(it->to(), index);
         }
-    };
-    dfs(dfs, r, -1);
+    }
     return res;
 }
 
@@ -92,14 +99,27 @@ std::vector<int> tree_parent(const Graph<T> &g, int r = 0) {
 template <class T>
 std::vector<int> tree_subtree(const Graph<T> &g, int r = 0) {
     std::vector<int> res(g.size());
-    auto dfs = [&g, &res](auto self, int index) -> int {
-        res[index] = 1;
-        for (auto &e : g[index]) {
-            if (res[e.to()] != 0) continue;
-            res[index] += self(self, e.to());
-        }
-        return res[index];
+    // 反復 DFS（再帰だと深い木でスタックオーバーフローしうる）。
+    // 各フレームは (頂点, 親, 隣接走査位置)。隣接の再走査を避けるため位置を保持し、
+    // 帰りがけに子の部分木サイズを親へ加算する。
+    struct frame {
+        int v, parent, idx;
     };
-    dfs(dfs, r);
+    std::stack<frame> st;
+    st.push({r, -1, 0});
+    res[r] = 1;
+    while (!st.empty()) {
+        frame &f = st.top();
+        if (f.idx < (int)g[f.v].size()) {
+            int to = g[f.v][f.idx++].to();
+            if (to == f.parent) continue;
+            res[to] = 1;
+            st.push({to, f.v, 0});
+        } else {
+            int v = f.v, p = f.parent;
+            st.pop();
+            if (p != -1) res[p] += res[v];
+        }
+    }
     return res;
 }


### PR DESCRIPTION
## 概要

深さが頂点数 `N` に比例しうる DFS 再帰を明示スタックに置き換え、大規模入力（`N` ~ 10^6 の深いチェーン・パス状グラフ）でのスタックオーバーフローを防ぎます。`dominator_tree` / `euler_tour` と同じ非再帰方針に揃えます。**出力順・挙動は元の再帰版と一致**させています。

## 対象（O(N) 深さの再帰のみ）

| ファイル | 内容 |
|---|---|
| `graph/scc.hpp` | 行きがけ DFS（帰りがけ順を保持）と逆グラフ DFS を反復化。`Graph<T>` / CSR 両オーバーロード対応 |
| `graph/lowlink.hpp` | 関節点・橋検出 DFS を反復化。子から戻った直後の `low` 更新・橋/関節点判定を復帰時に実施 |
| `graph/topological_sort.hpp` | 帰りがけ順 DFS を反復化 |
| `graph/cycle.hpp` | `has_cycle` の灰/黒彩色 DFS を反復化（`cycle_detection_*` は既に反復済み） |
| `tree/tree_function.hpp` | `tree_dfs`（行きがけ）/ `tree_subtree`（帰りがけ集計）を反復化 |
| `tree/dsu_on_tree.hpp` | `dfs_sz` / `dfs_hld` と `solve` の DSU 本体（light→clear→heavy→query→rem の順序を再現）を反復化 |
| `tree/rerooting.hpp` | 全方位木 DP の `dfs`（部分木集約）/ `bfs`（親からの伝播）を反復化 |
| `tree/static_top_tree.hpp` | 原木を辿る `dfs_sz` を反復化 |

### 対象外（深さが O(log N) で安全）

- `static_top_tree.hpp` の `build` / `merge` / `update_all`：light 辺は根→葉で O(log N) 本、top tree 自体も O(log N) 高さのため再帰深さは O(log N)。
- `centroid_decomposition.hpp`、`binary_tree/*` の build、`fft/monotone_minima.hpp` 等（既存・今回対象外）。

## 検証

各アルゴリズムについて、再帰版リファレンスまたはブルートフォースとランダム照合（いずれも一致）:

- **scc**: 連結成分の分割が再帰版と一致（30000 ケース）
- **lowlink**: 関節点・橋の集合が再帰版と一致（20000 ケース）
- **topological_sort**: 出力が常に妥当なトポロジカル順（30000 ケース）
- **has_cycle**: 再帰版と一致（30000 ケース）
- **tree_dfs / tree_subtree**: 再帰版と完全一致（30000 ケース）
- **dsu_on_tree**: 再帰版と完全一致（8000 ケース、n=1 含む）
- **rerooting**: 再帰版と完全一致（20000 ケースの重み付きランダム木）
- **static_top_tree**: path-composite-sum をブルートフォースと一致（3000 ケース、点更新含む）

関連 verify テスト **16 本**のコンパイルを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)