### PR TITLE
perf: DFS/BFS 作業スタックを std::stack から std::vector + reserve に統一

### DIFF
--- a/lib/graph/cycle.hpp
+++ b/lib/graph/cycle.hpp
@@ -139,6 +139,7 @@ bool has_cycle(const Graph<T> &g) {
     // seen はパス上（灰）を、finished は探索完了（黒）を表し、
     // パス上の頂点へ戻る辺を見つけたら閉路あり。
     std::vector<std::pair<int, int>> stk;
+    stk.reserve(n);
     for (int i = 0; i < n && !res; ++i) {
         if (finished[i] || seen[i]) continue;
         seen[i] = true;

--- a/lib/graph/lowlink.hpp
+++ b/lib/graph/lowlink.hpp
@@ -37,6 +37,7 @@ struct low_link {
             bool is_articulation;
         };
         std::vector<frame> stk;
+        stk.reserve(g.size());
         for (int s = 0; s < g.size(); ++s) {
             if (used[s]) continue;
             used[s] = true;

--- a/lib/graph/namori_graph.hpp
+++ b/lib/graph/namori_graph.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#include <stack>
 #include <vector>
 #include "graph/graph.hpp"
 
@@ -8,35 +7,36 @@ template <class T>
 std::vector<int> cycle_detection_on_namori_graph(const Graph<T> &g) {
     int n = g.size();
     std::vector<int> cnt(n);
-    std::stack<int> st;
+    std::vector<int> st;
+    st.reserve(n);
     for (int i = 0; i < n; ++i) {
         cnt[i] = g[i].size();
-        if (cnt[i] == 1) st.emplace(i);
+        if (cnt[i] == 1) st.emplace_back(i);
     }
     while (!st.empty()) {
-        int x = st.top();
-        st.pop();
+        int x = st.back();
+        st.pop_back();
         for (auto &e : g[x]) {
-            if ((--cnt[e.to()]) == 1) st.emplace(e.to());
+            if ((--cnt[e.to()]) == 1) st.emplace_back(e.to());
         }
     }
 
     std::vector<int> parent(n, -2);
-    st = std::stack<int>();
+    st.clear();
     for (int i = 0; i < n; ++i) {
         if (cnt[i] >= 2) {
             parent[i] = -1;
-            st.emplace(i);
+            st.emplace_back(i);
         }
     }
 
     while (!st.empty()) {
-        int x = st.top();
-        st.pop();
+        int x = st.back();
+        st.pop_back();
         for (auto &e : g[x]) {
             if (parent[e.to()] == -2) {
                 parent[e.to()] = x;
-                st.emplace(e.to());
+                st.emplace_back(e.to());
             }
         }
     }

--- a/lib/graph/scc.hpp
+++ b/lib/graph/scc.hpp
@@ -20,6 +20,7 @@ std::vector<int> scc(const Graph<T> &g) {
     // stk には頂点と隣接リストの走査位置を積む。子を処理し終えた後に
     // order へ push することで、再帰版と同じ帰りがけ順を再現する。
     std::vector<std::pair<int, int>> stk;
+    stk.reserve(n);
     for (int s = 0; s < n; ++s) {
         if (used[s]) continue;
         used[s] = true;
@@ -42,6 +43,7 @@ std::vector<int> scc(const Graph<T> &g) {
 
     // 逆グラフ上の反復 DFS で連結成分番号を振る
     std::vector<int> rstk;
+    rstk.reserve(n);
     int ptr = 0;
     for (auto i : order) {
         if (~comp[i]) continue;
@@ -78,6 +80,7 @@ std::vector<int> scc(const internal::graph_csr &g) {
     // order へ push することで、再帰版と同じ帰りがけ順を再現する。
     using cit = std::vector<int>::const_iterator;
     std::vector<std::pair<int, std::pair<cit, cit>>> stk;
+    stk.reserve(n);
     for (int s = 0; s < n; ++s) {
         if (used[s]) continue;
         used[s] = true;
@@ -100,6 +103,7 @@ std::vector<int> scc(const internal::graph_csr &g) {
 
     // 逆グラフ上の反復 DFS で連結成分番号を振る
     std::vector<int> rstk;
+    rstk.reserve(n);
     int ptr = 0;
     for (auto i : order) {
         if (~comp[i]) continue;

--- a/lib/graph/topological_sort.hpp
+++ b/lib/graph/topological_sort.hpp
@@ -13,6 +13,7 @@ std::vector<int> topological_sort(const Graph<T> &g) {
     // 反復 DFS（再帰だと深いグラフでスタックオーバーフローしうる）。
     // 子を処理し終えた後に res へ push する帰りがけ順を再現し、最後に反転する。
     std::vector<std::pair<int, int>> stk;
+    stk.reserve(n);
     for (int i = 0; i < n; ++i) {
         if (seen[i]) continue;
         seen[i] = true;

--- a/lib/tree/auxiliary_tree.hpp
+++ b/lib/tree/auxiliary_tree.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include <algorithm>
-#include <stack>
 #include <vector>
 #include "graph/graph.hpp"
 #include "tree/euler_tour.hpp"
@@ -47,11 +46,12 @@ struct auxiliary_tree {
 
         int m = ord.size();
         std::vector<int> par(m);
-        std::stack<int> st;
+        std::vector<int> st;
+        st.reserve(m);
         for (int i = 0; i < m; ++i) {
-            while (!st.empty() && et.right(ord[st.top()]) <= et.left(ord[i])) st.pop();
-            par[i] = (st.empty() ? -1 : st.top());
-            st.emplace(i);
+            while (!st.empty() && et.right(ord[st.back()]) <= et.left(ord[i])) st.pop_back();
+            par[i] = (st.empty() ? -1 : st.back());
+            st.emplace_back(i);
         }
         std::vector<bool> f(m);
         int x = 0;

--- a/lib/tree/auxiliary_tree.hpp
+++ b/lib/tree/auxiliary_tree.hpp
@@ -46,12 +46,12 @@ struct auxiliary_tree {
 
         int m = ord.size();
         std::vector<int> par(m);
-        std::vector<int> st;
-        st.reserve(m);
+        std::vector<int> stk;
+        stk.reserve(m);
         for (int i = 0; i < m; ++i) {
-            while (!st.empty() && et.right(ord[st.back()]) <= et.left(ord[i])) st.pop_back();
-            par[i] = (st.empty() ? -1 : st.back());
-            st.emplace_back(i);
+            while (!stk.empty() && et.right(ord[stk.back()]) <= et.left(ord[i])) stk.pop_back();
+            par[i] = (stk.empty() ? -1 : stk.back());
+            stk.emplace_back(i);
         }
         std::vector<bool> f(m);
         int x = 0;

--- a/lib/tree/cartesian_tree.hpp
+++ b/lib/tree/cartesian_tree.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#include <stack>
 #include <vector>
 
 /// @brief Cartesian Tree
@@ -7,16 +6,17 @@ template <typename T>
 std::vector<int> cartesian_tree(const std::vector<T> &v) {
     int n = v.size();
     std::vector<int> res(n, -1);
-    std::stack<T> st;
+    std::vector<int> st;
+    st.reserve(n);
     for (int i = 0; i < n; ++i) {
         int p = -1;
-        while (!st.empty() && v[i] < v[st.top()]) {
-            p = st.top();
-            st.pop();
+        while (!st.empty() && v[i] < v[st.back()]) {
+            p = st.back();
+            st.pop_back();
         }
         if (p != -1) res[p] = i;
-        if (!st.empty()) res[i] = st.top();
-        st.emplace(i);
+        if (!st.empty()) res[i] = st.back();
+        st.emplace_back(i);
     }
     return res;
 }
@@ -36,13 +36,14 @@ template <typename T>
 std::vector<internal::node_t> cartesian_tree_fully(const std::vector<T> &v) {
     int n = v.size();
     std::vector<internal::node_t> res(n);
-    std::stack<T> st;
+    std::vector<int> st;
+    st.reserve(n);
     for (int i = 0; i < n; ++i) {
         int p = -1;
-        while (!st.empty() && v[i] < v[st.top()]) p = st.top(), st.pop();
+        while (!st.empty() && v[i] < v[st.back()]) p = st.back(), st.pop_back();
         if (p != -1) res[p].parent = i, res[i].left = p;
-        if (!st.empty()) res[i].parent = st.top(), res[st.top()].right = i;
-        st.emplace(i);
+        if (!st.empty()) res[i].parent = st.back(), res[st.back()].right = i;
+        st.emplace_back(i);
     }
     return res;
 }

--- a/lib/tree/cartesian_tree.hpp
+++ b/lib/tree/cartesian_tree.hpp
@@ -6,17 +6,17 @@ template <typename T>
 std::vector<int> cartesian_tree(const std::vector<T> &v) {
     int n = v.size();
     std::vector<int> res(n, -1);
-    std::vector<int> st;
-    st.reserve(n);
+    std::vector<int> stk;
+    stk.reserve(n);
     for (int i = 0; i < n; ++i) {
         int p = -1;
-        while (!st.empty() && v[i] < v[st.back()]) {
-            p = st.back();
-            st.pop_back();
+        while (!stk.empty() && v[i] < v[stk.back()]) {
+            p = stk.back();
+            stk.pop_back();
         }
         if (p != -1) res[p] = i;
-        if (!st.empty()) res[i] = st.back();
-        st.emplace_back(i);
+        if (!stk.empty()) res[i] = stk.back();
+        stk.emplace_back(i);
     }
     return res;
 }
@@ -36,14 +36,14 @@ template <typename T>
 std::vector<internal::node_t> cartesian_tree_fully(const std::vector<T> &v) {
     int n = v.size();
     std::vector<internal::node_t> res(n);
-    std::vector<int> st;
-    st.reserve(n);
+    std::vector<int> stk;
+    stk.reserve(n);
     for (int i = 0; i < n; ++i) {
         int p = -1;
-        while (!st.empty() && v[i] < v[st.back()]) p = st.back(), st.pop_back();
+        while (!stk.empty() && v[i] < v[stk.back()]) p = stk.back(), stk.pop_back();
         if (p != -1) res[p].parent = i, res[i].left = p;
-        if (!st.empty()) res[i].parent = st.back(), res[st.back()].right = i;
-        st.emplace_back(i);
+        if (!stk.empty()) res[i].parent = stk.back(), res[stk.back()].right = i;
+        stk.emplace_back(i);
     }
     return res;
 }

--- a/lib/tree/dsu_on_tree.hpp
+++ b/lib/tree/dsu_on_tree.hpp
@@ -46,6 +46,7 @@ struct dsu_on_tree {
             bool heavy_done, pending_clear;
         };
         std::vector<frame> st;
+        st.reserve(size);
         st.push_back({root, 0, false, false});
         while (!st.empty()) {
             frame &f = st.back();
@@ -94,6 +95,7 @@ struct dsu_on_tree {
     // 帰りがけに部分木サイズを集計し、最大の子を heavy_path に記録する。
     void dfs_sz(int v) {
         std::vector<std::pair<int, int>> st;  // (頂点, 隣接走査位置)
+        st.reserve(size);
         std::vector<int> max_sub(size, 0);
         st.emplace_back(v, 0);
         while (!st.empty()) {
@@ -122,6 +124,7 @@ struct dsu_on_tree {
             bool entered;
         };
         std::vector<frame> st;
+        st.reserve(size);
         st.push_back({v, 0, false});
         while (!st.empty()) {
             frame &f = st.back();

--- a/lib/tree/dsu_on_tree.hpp
+++ b/lib/tree/dsu_on_tree.hpp
@@ -45,16 +45,16 @@ struct dsu_on_tree {
             int v, idx;
             bool heavy_done, pending_clear;
         };
-        std::vector<frame> st;
-        st.reserve(size);
-        st.push_back({root, 0, false, false});
-        while (!st.empty()) {
-            frame &f = st.back();
+        std::vector<frame> stk;
+        stk.reserve(size);
+        stk.push_back({root, 0, false, false});
+        while (!stk.empty()) {
+            frame &f = stk.back();
             int v = f.v, hp = heavy_path[v];
             if (hp == -1) {
                 for (int i = left[v]; i < right[v]; ++i) query(query_order[i]);
                 rem(v);
-                st.pop_back();
+                stk.pop_back();
                 continue;
             }
             // 直前に light 子から戻っていれば、その都度 clear する
@@ -68,21 +68,21 @@ struct dsu_on_tree {
                 int u = g[v][f.idx++].to();
                 if (u == par[v] || u == hp) continue;
                 f.pending_clear = true;
-                st.push_back({u, 0, false, false});
+                stk.push_back({u, 0, false, false});
                 descended = true;
                 break;
             }
             if (descended) continue;  // light 子の dsu へ降りる
             if (!f.heavy_done) {
                 f.heavy_done = true;
-                st.push_back({hp, 0, false, false});
+                stk.push_back({hp, 0, false, false});
                 continue;
             }
             // heavy 子の処理完了後: 残り区間を query して rem
             for (int i = left[v]; i < left[hp]; ++i) query(query_order[i]);
             for (int i = right[hp]; i < right[v]; ++i) query(query_order[i]);
             rem(v);
-            st.pop_back();
+            stk.pop_back();
         }
     }
 
@@ -94,20 +94,20 @@ struct dsu_on_tree {
     // 反復 DFS（再帰だと深い木でスタックオーバーフローしうる）。
     // 帰りがけに部分木サイズを集計し、最大の子を heavy_path に記録する。
     void dfs_sz(int v) {
-        std::vector<std::pair<int, int>> st;  // (頂点, 隣接走査位置)
-        st.reserve(size);
+        std::vector<std::pair<int, int>> stk;  // (頂点, 隣接走査位置)
+        stk.reserve(size);
         std::vector<int> max_sub(size, 0);
-        st.emplace_back(v, 0);
-        while (!st.empty()) {
-            auto &[u, idx] = st.back();
+        stk.emplace_back(v, 0);
+        while (!stk.empty()) {
+            auto &[u, idx] = stk.back();
             if (idx < (int)g[u].size()) {
                 int w = g[u][idx++].to();
                 if (w == par[u]) continue;
                 par[w] = u;
-                st.emplace_back(w, 0);
+                stk.emplace_back(w, 0);
             } else {
                 int p = par[u];
-                st.pop_back();
+                stk.pop_back();
                 if (p != -1) {
                     sub[p] += sub[u];
                     if (chmax(max_sub[p], sub[u])) heavy_path[p] = u;
@@ -123,11 +123,11 @@ struct dsu_on_tree {
             int v, idx;
             bool entered;
         };
-        std::vector<frame> st;
-        st.reserve(size);
-        st.push_back({v, 0, false});
-        while (!st.empty()) {
-            frame &f = st.back();
+        std::vector<frame> stk;
+        stk.reserve(size);
+        stk.push_back({v, 0, false});
+        while (!stk.empty()) {
+            frame &f = stk.back();
             int u = f.v;
             if (!f.entered) {
                 f.entered = true;
@@ -137,11 +137,11 @@ struct dsu_on_tree {
                 len += query_size[u];
                 if (heavy_path[u] == -1) {
                     right[u] = len;
-                    st.pop_back();
+                    stk.pop_back();
                     continue;
                 }
                 // heavy 子を最初に処理する
-                st.push_back({heavy_path[u], 0, false});
+                stk.push_back({heavy_path[u], 0, false});
                 continue;
             }
             // heavy 子の処理が終わった後、light 子を左から順に処理する
@@ -150,11 +150,11 @@ struct dsu_on_tree {
             while (f.idx < (int)g[u].size()) {
                 int w = g[u][f.idx++].to();
                 if (w == par[u] || w == hp) continue;
-                st.push_back({w, 0, false});
+                stk.push_back({w, 0, false});
                 descended = true;
                 break;
             }
-            if (!descended) st.pop_back();
+            if (!descended) stk.pop_back();
         }
     }
 };

--- a/lib/tree/euler_tour.hpp
+++ b/lib/tree/euler_tour.hpp
@@ -37,12 +37,12 @@ struct euler_tour {
     template <class G>
     euler_tour(const G &g, int n, int r) : _size(n), ord(n), ls(n, -1), rs(n) {
         int c = 0;
-        std::vector<int> st;
-        st.reserve(2 * n);
-        st.emplace_back(r);
-        while (!st.empty()) {
-            auto x = st.back();
-            st.pop_back();
+        std::vector<int> stk;
+        stk.reserve(2 * n);
+        stk.emplace_back(r);
+        while (!stk.empty()) {
+            auto x = stk.back();
+            stk.pop_back();
             if (x < 0) {
                 rs[~x] = c;
                 continue;
@@ -53,8 +53,8 @@ struct euler_tour {
             for (auto e : g[x]) {
                 int to = to_of(e);
                 if (ls[to] != -1) continue;
-                st.emplace_back(~x);
-                st.emplace_back(to);
+                stk.emplace_back(~x);
+                stk.emplace_back(to);
             }
         }
     }

--- a/lib/tree/euler_tour.hpp
+++ b/lib/tree/euler_tour.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#include <stack>
 #include <utility>
 #include <vector>
 #include "graph/graph.hpp"
@@ -38,11 +37,12 @@ struct euler_tour {
     template <class G>
     euler_tour(const G &g, int n, int r) : _size(n), ord(n), ls(n, -1), rs(n) {
         int c = 0;
-        std::stack<int> st;
-        st.emplace(r);
+        std::vector<int> st;
+        st.reserve(2 * n);
+        st.emplace_back(r);
         while (!st.empty()) {
-            auto x = st.top();
-            st.pop();
+            auto x = st.back();
+            st.pop_back();
             if (x < 0) {
                 rs[~x] = c;
                 continue;
@@ -53,8 +53,8 @@ struct euler_tour {
             for (auto e : g[x]) {
                 int to = to_of(e);
                 if (ls[to] != -1) continue;
-                st.emplace(~x);
-                st.emplace(to);
+                st.emplace_back(~x);
+                st.emplace_back(to);
             }
         }
     }

--- a/lib/tree/hld.hpp
+++ b/lib/tree/hld.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <stack>
+#include <vector>
 #include "graph/graph.hpp"
 #include "internal/internal_csr.hpp"
 
@@ -10,17 +10,18 @@ struct heavy_light_decomposition {
     template <class T>
     heavy_light_decomposition(const Graph<T> &g, int r = 0) : heavy_light_decomposition(g.size()) {
         std::vector<int> heavy_path(_size, -1);
-        std::stack<int> st;
-        st.emplace(r);
+        std::vector<int> st;
+        st.reserve(_size);
+        st.emplace_back(r);
         int pos = 0;
         while (!st.empty()) {
-            int v = st.top();
-            st.pop();
+            int v = st.back();
+            st.pop_back();
             vid[pos++] = v;
             for (auto &e : g[v]) {
                 int u = e.to();
                 if (u == par[v]) continue;
-                par[u] = v, dep[u] = dep[v] + 1, st.emplace(u);
+                par[u] = v, dep[u] = dep[v] + 1, st.emplace_back(u);
             }
         }
         for (int i = _size - 1; i >= 0; --i) {
@@ -35,35 +36,36 @@ struct heavy_light_decomposition {
         }
         nxt[r] = r;
         pos = 0;
-        st.emplace(r);
+        st.emplace_back(r);
         while (!st.empty()) {
-            int v = st.top();
-            st.pop();
+            int v = st.back();
+            st.pop_back();
             vid[v] = pos++;
             inv[vid[v]] = v;
             int hp = heavy_path[v];
             for (auto &e : g[v]) {
                 int u = e.to();
                 if (u == par[v] || u == hp) continue;
-                nxt[u] = u, st.emplace(u);
+                nxt[u] = u, st.emplace_back(u);
             }
-            if (hp != -1) nxt[hp] = nxt[v], st.emplace(hp);
+            if (hp != -1) nxt[hp] = nxt[v], st.emplace_back(hp);
         }
     }
 
     heavy_light_decomposition(const internal::graph_csr &g, int r = 0)
         : heavy_light_decomposition(g.size()) {
         std::vector<int> heavy_path(_size, -1);
-        std::stack<int> st;
-        st.emplace(r);
+        std::vector<int> st;
+        st.reserve(_size);
+        st.emplace_back(r);
         int pos = 0;
         while (!st.empty()) {
-            int v = st.top();
-            st.pop();
+            int v = st.back();
+            st.pop_back();
             vid[pos++] = v;
             for (int u : g[v]) {
                 if (u == par[v]) continue;
-                par[u] = v, dep[u] = dep[v] + 1, st.emplace(u);
+                par[u] = v, dep[u] = dep[v] + 1, st.emplace_back(u);
             }
         }
         for (int i = _size - 1; i >= 0; --i) {
@@ -77,18 +79,18 @@ struct heavy_light_decomposition {
         }
         nxt[r] = r;
         pos = 0;
-        st.emplace(r);
+        st.emplace_back(r);
         while (!st.empty()) {
-            int v = st.top();
-            st.pop();
+            int v = st.back();
+            st.pop_back();
             vid[v] = pos++;
             inv[vid[v]] = v;
             int hp = heavy_path[v];
             for (int u : g[v]) {
                 if (u == par[v] || u == hp) continue;
-                nxt[u] = u, st.emplace(u);
+                nxt[u] = u, st.emplace_back(u);
             }
-            if (hp != -1) nxt[hp] = nxt[v], st.emplace(hp);
+            if (hp != -1) nxt[hp] = nxt[v], st.emplace_back(hp);
         }
     }
 

--- a/lib/tree/hld.hpp
+++ b/lib/tree/hld.hpp
@@ -10,18 +10,18 @@ struct heavy_light_decomposition {
     template <class T>
     heavy_light_decomposition(const Graph<T> &g, int r = 0) : heavy_light_decomposition(g.size()) {
         std::vector<int> heavy_path(_size, -1);
-        std::vector<int> st;
-        st.reserve(_size);
-        st.emplace_back(r);
+        std::vector<int> stk;
+        stk.reserve(_size);
+        stk.emplace_back(r);
         int pos = 0;
-        while (!st.empty()) {
-            int v = st.back();
-            st.pop_back();
+        while (!stk.empty()) {
+            int v = stk.back();
+            stk.pop_back();
             vid[pos++] = v;
             for (auto &e : g[v]) {
                 int u = e.to();
                 if (u == par[v]) continue;
-                par[u] = v, dep[u] = dep[v] + 1, st.emplace_back(u);
+                par[u] = v, dep[u] = dep[v] + 1, stk.emplace_back(u);
             }
         }
         for (int i = _size - 1; i >= 0; --i) {
@@ -36,36 +36,36 @@ struct heavy_light_decomposition {
         }
         nxt[r] = r;
         pos = 0;
-        st.emplace_back(r);
-        while (!st.empty()) {
-            int v = st.back();
-            st.pop_back();
+        stk.emplace_back(r);
+        while (!stk.empty()) {
+            int v = stk.back();
+            stk.pop_back();
             vid[v] = pos++;
             inv[vid[v]] = v;
             int hp = heavy_path[v];
             for (auto &e : g[v]) {
                 int u = e.to();
                 if (u == par[v] || u == hp) continue;
-                nxt[u] = u, st.emplace_back(u);
+                nxt[u] = u, stk.emplace_back(u);
             }
-            if (hp != -1) nxt[hp] = nxt[v], st.emplace_back(hp);
+            if (hp != -1) nxt[hp] = nxt[v], stk.emplace_back(hp);
         }
     }
 
     heavy_light_decomposition(const internal::graph_csr &g, int r = 0)
         : heavy_light_decomposition(g.size()) {
         std::vector<int> heavy_path(_size, -1);
-        std::vector<int> st;
-        st.reserve(_size);
-        st.emplace_back(r);
+        std::vector<int> stk;
+        stk.reserve(_size);
+        stk.emplace_back(r);
         int pos = 0;
-        while (!st.empty()) {
-            int v = st.back();
-            st.pop_back();
+        while (!stk.empty()) {
+            int v = stk.back();
+            stk.pop_back();
             vid[pos++] = v;
             for (int u : g[v]) {
                 if (u == par[v]) continue;
-                par[u] = v, dep[u] = dep[v] + 1, st.emplace_back(u);
+                par[u] = v, dep[u] = dep[v] + 1, stk.emplace_back(u);
             }
         }
         for (int i = _size - 1; i >= 0; --i) {
@@ -79,18 +79,18 @@ struct heavy_light_decomposition {
         }
         nxt[r] = r;
         pos = 0;
-        st.emplace_back(r);
-        while (!st.empty()) {
-            int v = st.back();
-            st.pop_back();
+        stk.emplace_back(r);
+        while (!stk.empty()) {
+            int v = stk.back();
+            stk.pop_back();
             vid[v] = pos++;
             inv[vid[v]] = v;
             int hp = heavy_path[v];
             for (int u : g[v]) {
                 if (u == par[v] || u == hp) continue;
-                nxt[u] = u, st.emplace_back(u);
+                nxt[u] = u, stk.emplace_back(u);
             }
-            if (hp != -1) nxt[hp] = nxt[v], st.emplace_back(hp);
+            if (hp != -1) nxt[hp] = nxt[v], stk.emplace_back(hp);
         }
     }
 

--- a/lib/tree/linear_lca.hpp
+++ b/lib/tree/linear_lca.hpp
@@ -1,7 +1,6 @@
 #pragma once
 #include <algorithm>
 #include <limits>
-#include <stack>
 #include <utility>
 #include <vector>
 #include "data_structure/linear_sparse_table.hpp"
@@ -27,11 +26,12 @@ struct linear_lca {
     template <class T>
     linear_lca(const Graph<T> &g, int r = 0) : ord(g.size(), -1), lst() {
         std::vector<S> v;
-        std::stack<std::pair<int, int>> st;
-        st.emplace(r, 0);
+        std::vector<std::pair<int, int>> st;
+        st.reserve(2 * g.size());
+        st.emplace_back(r, 0);
         while (!st.empty()) {
-            auto [x, d] = st.top();
-            st.pop();
+            auto [x, d] = st.back();
+            st.pop_back();
             if (x < 0) {
                 v.emplace_back(d, ~x);
                 continue;
@@ -40,19 +40,20 @@ struct linear_lca {
             v.emplace_back(d, x);
             for (auto e : g[x]) {
                 if (ord[e.to()] != -1) continue;
-                st.emplace(~x, d);
-                st.emplace(e.to(), d + 1);
+                st.emplace_back(~x, d);
+                st.emplace_back(e.to(), d + 1);
             }
         }
         lst = linear_sparse_table<M>(v);
     }
     linear_lca(const internal::graph_csr &g, int r = 0) : ord(g.size(), -1), lst() {
         std::vector<S> v;
-        std::stack<std::pair<int, int>> st;
-        st.emplace(r, 0);
+        std::vector<std::pair<int, int>> st;
+        st.reserve(2 * g.size());
+        st.emplace_back(r, 0);
         while (!st.empty()) {
-            auto [x, d] = st.top();
-            st.pop();
+            auto [x, d] = st.back();
+            st.pop_back();
             if (x < 0) {
                 v.emplace_back(d, ~x);
                 continue;
@@ -61,8 +62,8 @@ struct linear_lca {
             v.emplace_back(d, x);
             for (int y : g[x]) {
                 if (ord[y] != -1) continue;
-                st.emplace(~x, d);
-                st.emplace(y, d + 1);
+                st.emplace_back(~x, d);
+                st.emplace_back(y, d + 1);
             }
         }
         lst = linear_sparse_table<M>(v);

--- a/lib/tree/linear_lca.hpp
+++ b/lib/tree/linear_lca.hpp
@@ -26,12 +26,12 @@ struct linear_lca {
     template <class T>
     linear_lca(const Graph<T> &g, int r = 0) : ord(g.size(), -1), lst() {
         std::vector<S> v;
-        std::vector<std::pair<int, int>> st;
-        st.reserve(2 * g.size());
-        st.emplace_back(r, 0);
-        while (!st.empty()) {
-            auto [x, d] = st.back();
-            st.pop_back();
+        std::vector<std::pair<int, int>> stk;
+        stk.reserve(2 * g.size());
+        stk.emplace_back(r, 0);
+        while (!stk.empty()) {
+            auto [x, d] = stk.back();
+            stk.pop_back();
             if (x < 0) {
                 v.emplace_back(d, ~x);
                 continue;
@@ -40,20 +40,20 @@ struct linear_lca {
             v.emplace_back(d, x);
             for (auto e : g[x]) {
                 if (ord[e.to()] != -1) continue;
-                st.emplace_back(~x, d);
-                st.emplace_back(e.to(), d + 1);
+                stk.emplace_back(~x, d);
+                stk.emplace_back(e.to(), d + 1);
             }
         }
         lst = linear_sparse_table<M>(v);
     }
     linear_lca(const internal::graph_csr &g, int r = 0) : ord(g.size(), -1), lst() {
         std::vector<S> v;
-        std::vector<std::pair<int, int>> st;
-        st.reserve(2 * g.size());
-        st.emplace_back(r, 0);
-        while (!st.empty()) {
-            auto [x, d] = st.back();
-            st.pop_back();
+        std::vector<std::pair<int, int>> stk;
+        stk.reserve(2 * g.size());
+        stk.emplace_back(r, 0);
+        while (!stk.empty()) {
+            auto [x, d] = stk.back();
+            stk.pop_back();
             if (x < 0) {
                 v.emplace_back(d, ~x);
                 continue;
@@ -62,8 +62,8 @@ struct linear_lca {
             v.emplace_back(d, x);
             for (int y : g[x]) {
                 if (ord[y] != -1) continue;
-                st.emplace_back(~x, d);
-                st.emplace_back(y, d + 1);
+                stk.emplace_back(~x, d);
+                stk.emplace_back(y, d + 1);
             }
         }
         lst = linear_sparse_table<M>(v);

--- a/lib/tree/rerooting.hpp
+++ b/lib/tree/rerooting.hpp
@@ -45,12 +45,12 @@ struct ReRooting {
         struct frame {
             int v, p, idx;
         };
-        std::vector<frame> st;
-        st.reserve(n);
+        std::vector<frame> stk;
+        stk.reserve(n);
         for (int i = 0; i < n; ++i) dp[i] = std::vector<Value>(graph[i].size(), M::id());
-        st.push_back({0, -1, 0});
-        while (!st.empty()) {
-            frame &f = st.back();
+        stk.push_back({0, -1, 0});
+        while (!stk.empty()) {
+            frame &f = stk.back();
             int v = f.v;
             if (f.idx < (int)graph[v].size()) {
                 int i = f.idx++;
@@ -58,11 +58,11 @@ struct ReRooting {
                 if (e.to() == f.p) continue;
                 par[e.to()] = v;
                 pe[e.to()] = i;
-                st.push_back({e.to(), v, 0});
+                stk.push_back({e.to(), v, 0});
             } else {
                 ret[v] = M::g(res[v], data[v]);
                 int p = par[v];
-                st.pop_back();
+                stk.pop_back();
                 if (p != -1) {
                     dp[p][pe[v]] = M::f(ret[v], graph[p][pe[v]].weight());
                     res[p] = M::op(res[p], dp[p][pe[v]]);
@@ -76,13 +76,13 @@ struct ReRooting {
         int n = graph.size();
         std::vector<int> par(n, -1);
         std::vector<Value> dp_p_of(n, M::id());  // 各頂点が親から受け取る dp_p
-        std::vector<int> st;
-        st.reserve(n);
-        st.push_back(0);
+        std::vector<int> stk;
+        stk.reserve(n);
+        stk.push_back(0);
         // 行きがけ順に処理（スタックでも順序非依存: values は各頂点 1 回書く）
-        while (!st.empty()) {
-            int v = st.back();
-            st.pop_back();
+        while (!stk.empty()) {
+            int v = stk.back();
+            stk.pop_back();
             int p = par[v];
             Value dp_p = dp_p_of[v];
             int deg = graph[v].size();
@@ -98,7 +98,7 @@ struct ReRooting {
                 if (u != p) {
                     par[u] = v;
                     dp_p_of[u] = M::g(M::op(dp_l, dp_r[i + 1]), data[v]);
-                    st.push_back(u);
+                    stk.push_back(u);
                 }
                 dp_l = M::op(dp_l, dp[v][i]);
             }

--- a/lib/tree/rerooting.hpp
+++ b/lib/tree/rerooting.hpp
@@ -46,6 +46,7 @@ struct ReRooting {
             int v, p, idx;
         };
         std::vector<frame> st;
+        st.reserve(n);
         for (int i = 0; i < n; ++i) dp[i] = std::vector<Value>(graph[i].size(), M::id());
         st.push_back({0, -1, 0});
         while (!st.empty()) {
@@ -75,7 +76,9 @@ struct ReRooting {
         int n = graph.size();
         std::vector<int> par(n, -1);
         std::vector<Value> dp_p_of(n, M::id());  // 各頂点が親から受け取る dp_p
-        std::vector<int> st = {0};
+        std::vector<int> st;
+        st.reserve(n);
+        st.push_back(0);
         // 行きがけ順に処理（スタックでも順序非依存: values は各頂点 1 回書く）
         while (!st.empty()) {
             int v = st.back();

--- a/lib/tree/segment_tree_on_tree.hpp
+++ b/lib/tree/segment_tree_on_tree.hpp
@@ -33,17 +33,17 @@ struct segment_tree_on_tree {
     void build(int r = 0) {
         if (_n == 0) return;
         std::vector<int> heavy_path(_n, -1), sub_size(_n, 1), par(_n, -1), dep(_n, 0);
-        std::vector<int> s;
-        s.reserve(_n);
-        s.emplace_back(r);
+        std::vector<int> stk;
+        stk.reserve(_n);
+        stk.emplace_back(r);
         int pos = 0;
-        while (!s.empty()) {
-            int v = s.back();
-            s.pop_back();
+        while (!stk.empty()) {
+            int v = stk.back();
+            stk.pop_back();
             vid[pos++] = v;
             for (int u : g[v]) {
                 if (u == par[v]) continue;
-                par[u] = v, dep[u] = dep[v] + 1, s.emplace_back(u);
+                par[u] = v, dep[u] = dep[v] + 1, stk.emplace_back(u);
             }
         }
         for (int i = _n - 1; i >= 0; --i) {
@@ -57,17 +57,17 @@ struct segment_tree_on_tree {
         }
         nxt[r] = r;
         pos = 0;
-        s.emplace_back(r);
-        while (!s.empty()) {
-            int v = s.back();
-            s.pop_back();
+        stk.emplace_back(r);
+        while (!stk.empty()) {
+            int v = stk.back();
+            stk.pop_back();
             vid[v] = pos++;
             int hp = heavy_path[v];
             for (int u : g[v]) {
                 if (u == par[v] || u == hp) continue;
-                nxt[u] = u, s.emplace_back(u);
+                nxt[u] = u, stk.emplace_back(u);
             }
-            if (hp != -1) nxt[hp] = nxt[v], s.emplace_back(hp);
+            if (hp != -1) nxt[hp] = nxt[v], stk.emplace_back(hp);
         }
 
         head_par.resize(_n);

--- a/lib/tree/segment_tree_on_tree.hpp
+++ b/lib/tree/segment_tree_on_tree.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include <algorithm>
-#include <stack>
 #include <utility>
 #include <vector>
 #include "segtree/segment_tree.hpp"
@@ -34,16 +33,17 @@ struct segment_tree_on_tree {
     void build(int r = 0) {
         if (_n == 0) return;
         std::vector<int> heavy_path(_n, -1), sub_size(_n, 1), par(_n, -1), dep(_n, 0);
-        std::stack<int> s;
-        s.emplace(r);
+        std::vector<int> s;
+        s.reserve(_n);
+        s.emplace_back(r);
         int pos = 0;
         while (!s.empty()) {
-            int v = s.top();
-            s.pop();
+            int v = s.back();
+            s.pop_back();
             vid[pos++] = v;
             for (int u : g[v]) {
                 if (u == par[v]) continue;
-                par[u] = v, dep[u] = dep[v] + 1, s.emplace(u);
+                par[u] = v, dep[u] = dep[v] + 1, s.emplace_back(u);
             }
         }
         for (int i = _n - 1; i >= 0; --i) {
@@ -57,17 +57,17 @@ struct segment_tree_on_tree {
         }
         nxt[r] = r;
         pos = 0;
-        s.emplace(r);
+        s.emplace_back(r);
         while (!s.empty()) {
-            int v = s.top();
-            s.pop();
+            int v = s.back();
+            s.pop_back();
             vid[v] = pos++;
             int hp = heavy_path[v];
             for (int u : g[v]) {
                 if (u == par[v] || u == hp) continue;
-                nxt[u] = u, s.emplace(u);
+                nxt[u] = u, s.emplace_back(u);
             }
-            if (hp != -1) nxt[hp] = nxt[v], s.emplace(hp);
+            if (hp != -1) nxt[hp] = nxt[v], s.emplace_back(hp);
         }
 
         head_par.resize(_n);

--- a/lib/tree/static_top_tree.hpp
+++ b/lib/tree/static_top_tree.hpp
@@ -43,6 +43,7 @@ struct static_top_tree {
         {
             std::vector<int> max_sub(n, 0);
             std::vector<std::pair<int, int>> st;  // (頂点, 隣接走査位置)
+            st.reserve(n);
             par[_root] = -1;
             st.emplace_back(_root, 0);
             while (!st.empty()) {

--- a/lib/tree/static_top_tree.hpp
+++ b/lib/tree/static_top_tree.hpp
@@ -42,20 +42,20 @@ struct static_top_tree {
         // 帰りがけに部分木サイズを集計し、最大の子を heavy に記録する。
         {
             std::vector<int> max_sub(n, 0);
-            std::vector<std::pair<int, int>> st;  // (頂点, 隣接走査位置)
-            st.reserve(n);
+            std::vector<std::pair<int, int>> stk;  // (頂点, 隣接走査位置)
+            stk.reserve(n);
             par[_root] = -1;
-            st.emplace_back(_root, 0);
-            while (!st.empty()) {
-                auto &[u, idx] = st.back();
+            stk.emplace_back(_root, 0);
+            while (!stk.empty()) {
+                auto &[u, idx] = stk.back();
                 if (idx < (int)g[u].size()) {
                     int v = get_to(g[u][idx++]);
                     if (v == par[u]) continue;
                     par[v] = u;
-                    st.emplace_back(v, 0);
+                    stk.emplace_back(v, 0);
                 } else {
                     int p = par[u];
-                    st.pop_back();
+                    stk.pop_back();
                     if (p != -1) {
                         sz[p] += sz[u];
                         if (max_sub[p] < sz[u]) {

--- a/lib/tree/tree_function.hpp
+++ b/lib/tree/tree_function.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#include <stack>
 #include <utility>
 #include <vector>
 #include "graph/graph.hpp"
@@ -41,16 +40,17 @@ std::vector<int> tree_dfs(const Graph<T> &g, int r = 0) {
     std::vector<int> res;
     // 反復 DFS（再帰だと深い木でスタックオーバーフローしうる）。
     // 行きがけ順を保つため (頂点, 親) を積み、子は左から処理する。
-    std::stack<std::pair<int, int>> st;
-    st.emplace(r, -1);
+    std::vector<std::pair<int, int>> st;
+    st.reserve(g.size());
+    st.emplace_back(r, -1);
     while (!st.empty()) {
-        auto [index, parent] = st.top();
-        st.pop();
+        auto [index, parent] = st.back();
+        st.pop_back();
         res.emplace_back(index);
         // 元の左→右の行きがけ順にするため逆順に積む
         for (auto it = g[index].rbegin(); it != g[index].rend(); ++it) {
             if (it->to() == parent) continue;
-            st.emplace(it->to(), index);
+            st.emplace_back(it->to(), index);
         }
     }
     return res;
@@ -60,16 +60,17 @@ std::vector<int> tree_dfs(const Graph<T> &g, int r = 0) {
 template <class T, class U = T>
 std::vector<U> tree_dist(const Graph<T> &g, int r = 0) {
     std::vector<U> res(g.size(), -1);
-    std::stack<int> st;
+    std::vector<int> st;
+    st.reserve(g.size());
     res[r] = 0;
-    st.emplace(r);
+    st.emplace_back(r);
     while (!st.empty()) {
-        auto index = st.top();
-        st.pop();
+        auto index = st.back();
+        st.pop_back();
         for (auto &e : g[index]) {
             if (res[e.to()] != -1) continue;
             res[e.to()] = res[index] + e.weight();
-            st.emplace(e.to());
+            st.emplace_back(e.to());
         }
     }
     return res;
@@ -79,16 +80,17 @@ std::vector<U> tree_dist(const Graph<T> &g, int r = 0) {
 template <class T>
 std::vector<int> tree_parent(const Graph<T> &g, int r = 0) {
     std::vector<int> res(g.size(), -1);
-    std::stack<int> st;
+    std::vector<int> st;
+    st.reserve(g.size());
     res[r] = r;
-    st.emplace(r);
+    st.emplace_back(r);
     while (!st.empty()) {
-        auto index = st.top();
-        st.pop();
+        auto index = st.back();
+        st.pop_back();
         for (auto &e : g[index]) {
             if (res[e.to()] != -1) continue;
             res[e.to()] = index;
-            st.emplace(e.to());
+            st.emplace_back(e.to());
         }
     }
     res[r] = -1;
@@ -105,19 +107,20 @@ std::vector<int> tree_subtree(const Graph<T> &g, int r = 0) {
     struct frame {
         int v, parent, idx;
     };
-    std::stack<frame> st;
-    st.push({r, -1, 0});
+    std::vector<frame> st;
+    st.reserve(g.size());
+    st.push_back({r, -1, 0});
     res[r] = 1;
     while (!st.empty()) {
-        frame &f = st.top();
+        frame &f = st.back();
         if (f.idx < (int)g[f.v].size()) {
             int to = g[f.v][f.idx++].to();
             if (to == f.parent) continue;
             res[to] = 1;
-            st.push({to, f.v, 0});
+            st.push_back({to, f.v, 0});
         } else {
             int v = f.v, p = f.parent;
-            st.pop();
+            st.pop_back();
             if (p != -1) res[p] += res[v];
         }
     }

--- a/lib/tree/tree_function.hpp
+++ b/lib/tree/tree_function.hpp
@@ -40,17 +40,17 @@ std::vector<int> tree_dfs(const Graph<T> &g, int r = 0) {
     std::vector<int> res;
     // 反復 DFS（再帰だと深い木でスタックオーバーフローしうる）。
     // 行きがけ順を保つため (頂点, 親) を積み、子は左から処理する。
-    std::vector<std::pair<int, int>> st;
-    st.reserve(g.size());
-    st.emplace_back(r, -1);
-    while (!st.empty()) {
-        auto [index, parent] = st.back();
-        st.pop_back();
+    std::vector<std::pair<int, int>> stk;
+    stk.reserve(g.size());
+    stk.emplace_back(r, -1);
+    while (!stk.empty()) {
+        auto [index, parent] = stk.back();
+        stk.pop_back();
         res.emplace_back(index);
         // 元の左→右の行きがけ順にするため逆順に積む
         for (auto it = g[index].rbegin(); it != g[index].rend(); ++it) {
             if (it->to() == parent) continue;
-            st.emplace_back(it->to(), index);
+            stk.emplace_back(it->to(), index);
         }
     }
     return res;
@@ -60,17 +60,17 @@ std::vector<int> tree_dfs(const Graph<T> &g, int r = 0) {
 template <class T, class U = T>
 std::vector<U> tree_dist(const Graph<T> &g, int r = 0) {
     std::vector<U> res(g.size(), -1);
-    std::vector<int> st;
-    st.reserve(g.size());
+    std::vector<int> stk;
+    stk.reserve(g.size());
     res[r] = 0;
-    st.emplace_back(r);
-    while (!st.empty()) {
-        auto index = st.back();
-        st.pop_back();
+    stk.emplace_back(r);
+    while (!stk.empty()) {
+        auto index = stk.back();
+        stk.pop_back();
         for (auto &e : g[index]) {
             if (res[e.to()] != -1) continue;
             res[e.to()] = res[index] + e.weight();
-            st.emplace_back(e.to());
+            stk.emplace_back(e.to());
         }
     }
     return res;
@@ -80,17 +80,17 @@ std::vector<U> tree_dist(const Graph<T> &g, int r = 0) {
 template <class T>
 std::vector<int> tree_parent(const Graph<T> &g, int r = 0) {
     std::vector<int> res(g.size(), -1);
-    std::vector<int> st;
-    st.reserve(g.size());
+    std::vector<int> stk;
+    stk.reserve(g.size());
     res[r] = r;
-    st.emplace_back(r);
-    while (!st.empty()) {
-        auto index = st.back();
-        st.pop_back();
+    stk.emplace_back(r);
+    while (!stk.empty()) {
+        auto index = stk.back();
+        stk.pop_back();
         for (auto &e : g[index]) {
             if (res[e.to()] != -1) continue;
             res[e.to()] = index;
-            st.emplace_back(e.to());
+            stk.emplace_back(e.to());
         }
     }
     res[r] = -1;
@@ -107,20 +107,20 @@ std::vector<int> tree_subtree(const Graph<T> &g, int r = 0) {
     struct frame {
         int v, parent, idx;
     };
-    std::vector<frame> st;
-    st.reserve(g.size());
-    st.push_back({r, -1, 0});
+    std::vector<frame> stk;
+    stk.reserve(g.size());
+    stk.push_back({r, -1, 0});
     res[r] = 1;
-    while (!st.empty()) {
-        frame &f = st.back();
+    while (!stk.empty()) {
+        frame &f = stk.back();
         if (f.idx < (int)g[f.v].size()) {
             int to = g[f.v][f.idx++].to();
             if (to == f.parent) continue;
             res[to] = 1;
-            st.push_back({to, f.v, 0});
+            stk.push_back({to, f.v, 0});
         } else {
             int v = f.v, p = f.parent;
-            st.pop_back();
+            stk.pop_back();
             if (p != -1) res[p] += res[v];
         }
     }


### PR DESCRIPTION
## 概要

DFS/BFS/単調スタックの**作業用 `std::stack` を `std::vector`** に統一し、push 回数の上限が頂点数で分かる箇所に `reserve` を付けます。

- `std::stack` の既定内部コンテナ `std::deque` よりも `std::vector` の方がキャッシュ局所性が良い。
- `reserve(頂点数)` で push 時の再確保が無くなる。
- `back()` / `pop_back()` / `emplace_back()` を使うため **LIFO の取り出し順は不変**で、各アルゴリズムの挙動は維持。

「速度に効くなら型による LIFO 表明より速度を優先する」という方針に基づき、**作業スタック**を対象にしています。一方、**undo 履歴（`undo_union_find` / `undo_deque`）や SWAG のように LIFO がデータ構造の本質である箇所は `std::stack` のまま据え置き**ました（速度のボトルネックでなく、型で意図を表す価値の方が高いため）。

## 変更内容

| ファイル | 内容 |
|---|---|
| `graph/scc.hpp`, `graph/topological_sort.hpp`, `graph/cycle.hpp`, `graph/lowlink.hpp`, `tree/dsu_on_tree.hpp`, `tree/rerooting.hpp`, `tree/static_top_tree.hpp` | 先に非再帰化済みの `vector` スタックに `reserve` を追加 |
| `graph/namori_graph.hpp` | 2 本の作業スタックを `vector` 化（`st = std::stack<int>()` のリセットは `st.clear()` に） |
| `tree/hld.hpp`, `tree/segment_tree_on_tree.hpp` | HLD 構築の BFS/DFS スタック（計6本） |
| `tree/euler_tour.hpp`, `tree/linear_lca.hpp` | 再入マーカー付き DFS スタック（`reserve(2n)`） |
| `tree/auxiliary_tree.hpp`, `tree/cartesian_tree.hpp` | 単調スタック |
| `tree/tree_function.hpp` | `tree_dfs` / `tree_subtree` / `tree_dist` / `tree_parent` |

`cartesian_tree.hpp` は元々 `std::stack<T>` にインデックス(`int`)を積んでいた型の不整合も `std::vector<int>` に正しています。

## 対象外（据え置き）

- `data_structure/undo_union_find.hpp`, `data_structure/undo_deque.hpp` の undo 履歴
- `data_structure/swag.hpp` の 2 本のスタック（SWAG のアルゴリズムそのもの）

## 検証

ランダムテストで参照実装・ブルートフォースと照合（いずれも一致）:

- **linear_lca / hld**: 素朴な LCA・距離と一致（5000 ケース）
- **euler_tour**: 部分木の `[l, r)` 包含判定が祖先関係と一致（5000 ケース）
- **cartesian_tree**: min-heap 性質・根の一意性（5000 ケース）
- **auxiliary_tree**: ノード集合が指定頂点の LCA 閉包と一致、親が原木の祖先（3000 ケース）
- **namori_graph**: `std::queue` 版参照と同じ閉路根を導出（5000 ケース）
- **scc / has_cycle / topological_sort**: `reserve` 追加後も再帰版と一致（40000 ケース）

関連 verify テスト **32 本**のコンパイルを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)