### PR TITLE
feat: Berlekamp-Massey 法で線形漸化式を復元する berlekamp_massey を追加

### DIFF
--- a/lib/math/berlekamp_massey.hpp
+++ b/lib/math/berlekamp_massey.hpp
@@ -1,0 +1,45 @@
+#pragma once
+#include <utility>
+#include <vector>
+
+/// @brief Berlekamp-Massey 法
+/// 数列 s と矛盾しない最小位数の線形漸化式の係数 c を求める
+/// s_i = \sum_{j=1}^{L} c_{j-1} s_{i-j} (i >= L) を満たす
+template <class T>
+std::vector<T> berlekamp_massey(const std::vector<T> &s) {
+    const int n = s.size();
+    // c: 現在の漸化式の係数 (c[0] = 1)、b: 前回更新時の係数
+    std::vector<T> c{T(1)}, b{T(1)};
+    // m: 前回 c を更新してからの経過、d_b: 前回の差分
+    int len = 0, m = 1;
+    T d_b = T(1);
+    for (int i = 0; i < n; ++i) {
+        // 差分 d = \sum_{j=0}^{len} c[j] s_{i-j} を計算
+        T d = s[i];
+        for (int j = 1; j <= len; ++j) d += c[j] * s[i - j];
+        if (d == T(0)) {
+            ++m;
+            continue;
+        }
+        const T coef = d / d_b;
+        if (2 * len <= i) {
+            // 位数が増える更新。c を退避してから b と合成する
+            std::vector<T> tmp = c;
+            c.resize(std::max<int>(c.size(), b.size() + m), T(0));
+            for (int j = 0; j < (int)b.size(); ++j) c[j + m] -= coef * b[j];
+            len = i + 1 - len;
+            b = std::move(tmp);
+            d_b = d;
+            m = 1;
+        } else {
+            // 位数は変えず c のみ修正する
+            c.resize(std::max<int>(c.size(), b.size() + m), T(0));
+            for (int j = 0; j < (int)b.size(); ++j) c[j + m] -= coef * b[j];
+            ++m;
+        }
+    }
+    // c = [1, -c_1, ..., -c_L] の形なので漸化式係数 [c_1, ..., c_L] に変換する
+    std::vector<T> res(len);
+    for (int i = 0; i < len; ++i) res[i] = -c[i + 1];
+    return res;
+}

--- a/test/yosupo/math/find_linear_recurrence.test.cpp
+++ b/test/yosupo/math/find_linear_recurrence.test.cpp
@@ -1,0 +1,20 @@
+// competitive-verifier: PROBLEM https://judge.yosupo.jp/problem/find_linear_recurrence
+#include "math/berlekamp_massey.hpp"
+#include <iostream>
+#include <vector>
+#include "math/modint.hpp"
+
+using Mint = modint998;
+
+int main() {
+    int n;
+    std::cin >> n;
+    std::vector<Mint> a(n);
+    for (int i = 0; i < n; ++i) std::cin >> a[i];
+    auto c = berlekamp_massey(a);
+    const int d = c.size();
+    std::cout << d << '\n';
+    for (int i = 0; i < d; ++i) std::cout << c[i] << " \n"[i + 1 == d];
+    if (d == 0) std::cout << '\n';
+    return 0;
+}


### PR DESCRIPTION
数列から矛盾しない最小位数の線形漸化式の係数を O(N^2) で復元する。
bostan_mori/kitamasa が「漸化式から第 N 項」を求めるのに対し、本実装は
逆向きに「数列から漸化式」を求める。Library Checker の
find_linear_recurrence で verify。

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
