### PR TITLE
style: clang-format 一括整形 + field concept/pre-commit フック復元

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,0 +1,4 @@
+# template/ は AtCoder 提出用テンプレート。include 順が load-bearing
+# （template.hpp が <bits/stdc++.h> を引くので macro.hpp 等より前に来る必要がある）で、
+# clang-format の include ソート（IncludeBlocks: Merge）が並べ替えると壊れるため除外する。
+lib/template/*

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,29 @@
+#!/bin/sh
+# ステージされた C++ ファイル（.hpp / .cpp）を clang-format で整形してから
+# コミットする。整形結果を再 stage するので、コミットには整形後の内容が入る。
+#
+# clang-format は mise.toml の [tools] で管理。フックからでも確実に解決できるよう
+# `mise exec` 経由で呼ぶ（PATH に shim が無い環境でも動く）。
+#
+# 有効化: git config core.hooksPath .githooks（mise run setup でも設定される）
+
+set -e
+
+# ステージ済みで追加/変更/コピー/リネームされた C++ ファイルのみ対象（削除は除外）。
+files=$(git diff --cached --name-only --diff-filter=ACMR -- '*.cpp' '*.hpp')
+[ -z "$files" ] && exit 0
+
+if command -v mise > /dev/null 2>&1; then
+    fmt="mise exec -- clang-format"
+elif command -v clang-format > /dev/null 2>&1; then
+    fmt="clang-format"
+else
+    echo "pre-commit: clang-format が見つかりません（mise install を実行してください）。" >&2
+    exit 1
+fi
+
+echo "$files" | while IFS= read -r f; do
+    [ -f "$f" ] || continue
+    $fmt -i -- "$f"
+    git add -- "$f"
+done

--- a/lib/algorithm/partition.hpp
+++ b/lib/algorithm/partition.hpp
@@ -67,8 +67,8 @@ void enumerate_k(int n, int k, F f) {
             return;
         }
         // この位置の値 v を大きい順に試す。残り left - 1 個へは各 1 以上 v 以下で配る。
-        int hi = std::min(mx, rem - (left - 1));            // 残りを 1 ずつ確保
-        int lo = std::max(1, (rem + left - 1) / left);      // 残りが v*(left-1) 以下になる下限
+        int hi = std::min(mx, rem - (left - 1));        // 残りを 1 ずつ確保
+        int lo = std::max(1, (rem + left - 1) / left);  // 残りが v*(left-1) 以下になる下限
         for (int v = hi; v >= lo; --v) {
             part[idx] = v;
             self(self, idx + 1, rem - v, v);

--- a/lib/data_structure/bigint.hpp
+++ b/lib/data_structure/bigint.hpp
@@ -200,9 +200,8 @@ struct BigInt {
             return;
         }
         std::vector<std::int64_t> x(a.begin(), a.end()), y(b.begin(), b.end());
-        std::vector<std::int64_t> c = (x.size() + y.size() <= MUL_2PRIME_MAX_LEN)
-                                          ? convolution_ll2(x, y)
-                                          : convolution_ll(x, y);
+        std::vector<std::int64_t> c =
+            (x.size() + y.size() <= MUL_2PRIME_MAX_LEN) ? convolution_ll2(x, y) : convolution_ll(x, y);
         std::int64_t carry = 0;
         a.assign(c.size() + 1, 0);
         for (int i = 0; i < (int)c.size(); ++i) {
@@ -272,8 +271,8 @@ struct BigInt {
 
     /// 古典筆算除算 (Knuth Algorithm D)。(商, 余り) を絶対値で返す。
     /// lhs >= rhs > 0 を前提とする (呼び出し側で短絡済み)。
-    static std::pair<std::vector<int>, std::vector<int>>
-    divmod_classic(const std::vector<int> &lhs, const std::vector<int> &rhs) {
+    static std::pair<std::vector<int>, std::vector<int>> divmod_classic(const std::vector<int> &lhs,
+                                                                        const std::vector<int> &rhs) {
         // 正規化: 最上位桁が BASE/2 以上になるよう両者を同じ係数倍する。
         std::vector<int> u = lhs, v = rhs;
         int norm = BASE / (v.back() + 1);
@@ -288,8 +287,7 @@ struct BigInt {
             std::int64_t num = (std::int64_t)u[j + n] * BASE + u[j + n - 1];
             std::int64_t qhat = num / v[n - 1];
             std::int64_t rhat = num % v[n - 1];
-            while (qhat >= BASE ||
-                   (n >= 2 && qhat * v[n - 2] > rhat * BASE + u[j + n - 2])) {
+            while (qhat >= BASE || (n >= 2 && qhat * v[n - 2] > rhat * BASE + u[j + n - 2])) {
                 --qhat;
                 rhat += v[n - 1];
                 if (rhat >= BASE) break;
@@ -353,8 +351,8 @@ struct BigInt {
     /// Burnikel-Ziegler の再帰除算。lhs >= rhs > 0、|rhs| > BZ_THRESHOLD を前提とする。
     /// 除数をブロック幅 blk (再帰の各段で偶数長になる) ちょうどに正規化し、被除数を
     /// blk 桁ブロックに分けて 2n/1n 除算を繰り返す。
-    static std::pair<std::vector<int>, std::vector<int>>
-    divmod_bz(const std::vector<int> &lhs, const std::vector<int> &rhs) {
+    static std::pair<std::vector<int>, std::vector<int>> divmod_bz(const std::vector<int> &lhs,
+                                                                   const std::vector<int> &rhs) {
         int n = (int)rhs.size();
         // ブロック幅 blk: 各再帰段で偶数長を保つため BZ_THRESHOLD*2^k 以上へ切り上げる。
         int m = 1;
@@ -392,27 +390,27 @@ struct BigInt {
     }
 
     /// a (高々 2n 桁) を b (n 桁、正規化済み・n は偶数) で割る。商 < BASE^n を前提。
-    static std::pair<std::vector<int>, std::vector<int>>
-    div_2n_1n(const std::vector<int> &a, const std::vector<int> &b) {
+    static std::pair<std::vector<int>, std::vector<int>> div_2n_1n(const std::vector<int> &a,
+                                                                   const std::vector<int> &b) {
         int n = (int)b.size();
         if (n <= BZ_THRESHOLD || (int)a.size() <= n) return divmod_classic(a, b);
         // 上位・下位 n/2 桁に分け、div_3n_2n を 2 回適用する (n は偶数)。
         int s = n / 2;
-        std::vector<int> a_lo = slice(a, 0, s);                    // 下位 s 桁
-        std::vector<int> a_hi = slice(a, s, (int)a.size() - s);    // 上位
+        std::vector<int> a_lo = slice(a, 0, s);                  // 下位 s 桁
+        std::vector<int> a_hi = slice(a, s, (int)a.size() - s);  // 上位
         auto [q1, r1] = div_3n_2n(a_hi, b, s);
-        std::vector<int> mid = combine(a_lo, r1, s);               // r1*BASE^s + a_lo
+        std::vector<int> mid = combine(a_lo, r1, s);  // r1*BASE^s + a_lo
         auto [q2, r2] = div_3n_2n(mid, b, s);
-        std::vector<int> q = combine(q2, q1, s);                   // q1*BASE^s + q2
+        std::vector<int> q = combine(q2, q1, s);  // q1*BASE^s + q2
         return {q, r2};
     }
 
     /// a (高々 3s 桁) を b (= 2s 桁) で割る。商 < BASE^s を前提とする。
     /// b = b1*BASE^s + b2 と分け、a の上位 2s 桁を b1 で見積もり b2 の積で補正する。
-    static std::pair<std::vector<int>, std::vector<int>>
-    div_3n_2n(const std::vector<int> &a, const std::vector<int> &b, int s) {
-        std::vector<int> b2 = slice(b, 0, s);          // 下位 s 桁
-        std::vector<int> b1 = slice(b, s, s);          // 上位 s 桁
+    static std::pair<std::vector<int>, std::vector<int>> div_3n_2n(const std::vector<int> &a, const std::vector<int> &b,
+                                                                   int s) {
+        std::vector<int> b2 = slice(b, 0, s);  // 下位 s 桁
+        std::vector<int> b1 = slice(b, s, s);  // 上位 s 桁
         // a = a12 * BASE^s + a3 (a3 は下位 s 桁、a12 は上位 2s 桁)。
         std::vector<int> a3 = slice(a, 0, s);
         std::vector<int> a12 = slice(a, s, (int)a.size() - s);

--- a/lib/geometry/cht.hpp
+++ b/lib/geometry/cht.hpp
@@ -38,7 +38,6 @@ struct CHT {
 
     bool check(std::pair<T, T> l1, std::pair<T, T> l2, std::pair<T, T> l3) {
         if (l1 < l3) swap(l1, l3);
-        return (l3.second - l2.second) * (l2.first - l1.first) >=
-               (l2.second - l1.second) * (l3.first - l2.first);
+        return (l3.second - l2.second) * (l2.first - l1.first) >= (l2.second - l1.second) * (l3.first - l2.first);
     }
 };

--- a/lib/geometry/convex_hull.hpp
+++ b/lib/geometry/convex_hull.hpp
@@ -38,9 +38,8 @@ struct Point {
 template <class T>
 std::vector<Point<T>> convex_hull(std::vector<Point<T>> points) {
     int n = points.size(), k = 0;
-    std::sort(std::begin(points), std::end(points), [](const Point<T> &a, const Point<T> &b) {
-        return a.x == b.x ? a.y < b.y : a.x < b.x;
-    });
+    std::sort(std::begin(points), std::end(points),
+              [](const Point<T> &a, const Point<T> &b) { return a.x == b.x ? a.y < b.y : a.x < b.x; });
     std::vector<Point<T>> res(n << 1);
     auto cross = [](Point<T> a, Point<T> b, const Point<T> &c) {
         a -= c, b -= c;

--- a/lib/geometry/geometry.hpp
+++ b/lib/geometry/geometry.hpp
@@ -42,9 +42,7 @@ struct Point {
         rhs = Point<T>(x, y);
         return (is);
     }
-    friend std::ostream &operator<<(std::ostream &os, const Point<T> &rhs) {
-        return os << rhs.x << ' ' << rhs.y;
-    }
+    friend std::ostream &operator<<(std::ostream &os, const Point<T> &rhs) { return os << rhs.x << ' ' << rhs.y; }
 };
 
 template <class T>
@@ -91,9 +89,7 @@ struct Line {
     constexpr bool in_line(Point<T> p) const { return eq(cross(p - a, p - b), 0); }
 
     // 射影
-    constexpr Point<T> proj(const Point<T> &p) const {
-        return a + (b - a) * dot(b - a, p - a) / norm(b - a);
-    }
+    constexpr Point<T> proj(const Point<T> &p) const { return a + (b - a) * dot(b - a, p - a) / norm(b - a); }
     // 反射
     constexpr Point<T> refl(const Point<T> &p) const { return this->proj(p) * 2 - p; }
 
@@ -115,8 +111,7 @@ bool orthogonal(const Line<T> &a, const Line<T> &b) {
 }
 template <class T>
 bool intersection(const Line<T> &a, const Line<T> &b) {
-    return ccw(a.a, a.b, b.a) * ccw(a.a, a.b, b.b) <= 0 &&
-           ccw(b.a, b.b, a.a) * ccw(b.a, b.b, a.b) <= 0;
+    return ccw(a.a, a.b, b.a) * ccw(a.a, a.b, b.b) <= 0 && ccw(b.a, b.b, a.a) * ccw(b.a, b.b, a.b) <= 0;
 }
 template <class T>
 Point<T> cross_point(const Line<T> &a, const Line<T> &b) {

--- a/lib/geometry/kdtree.hpp
+++ b/lib/geometry/kdtree.hpp
@@ -37,9 +37,7 @@ struct kdtree {
     std::int64_t find(int x, int y) { return this->find(0, x, y, 0, -1); }
 
     // [sx, tx) * [sy, ty)
-    std::vector<int> find(int sx, int tx, int sy, int ty) {
-        return this->find(0, sx, tx, sy, ty, 0);
-    }
+    std::vector<int> find(int sx, int tx, int sy, int ty) { return this->find(0, sx, tx, sy, ty, 0); }
 
   private:
     std::vector<_point> points;

--- a/lib/graph/cycle.hpp
+++ b/lib/graph/cycle.hpp
@@ -42,8 +42,7 @@ std::vector<int> cycle_detection_directed(const G &g) {
                     // 今の辺 e を連結する。
                     int pos = (int)vertices.size() - 1;
                     while (vertices[pos] != to) --pos;
-                    for (int i = pos + 1; i < (int)vertices.size(); ++i)
-                        cycle.emplace_back(in_edge[i]);
+                    for (int i = pos + 1; i < (int)vertices.size(); ++i) cycle.emplace_back(in_edge[i]);
                     cycle.emplace_back(eid);
                     break;
                 }
@@ -110,8 +109,7 @@ std::pair<std::vector<int>, std::vector<int>> cycle_detection_undirected(const G
                     int pos = (int)vertices.size() - 1;
                     while (vertices[pos] != to) --pos;
                     for (int i = pos; i < (int)vertices.size(); ++i) cyc_v.emplace_back(vertices[i]);
-                    for (int i = pos + 1; i < (int)vertices.size(); ++i)
-                        cyc_e.emplace_back(in_edge[i]);
+                    for (int i = pos + 1; i < (int)vertices.size(); ++i) cyc_e.emplace_back(in_edge[i]);
                     cyc_e.emplace_back(eid);
                     break;
                 }

--- a/lib/graph/graph.hpp
+++ b/lib/graph/graph.hpp
@@ -319,10 +319,10 @@ struct csr_graph {
   private:
     int _size, _edge_count, _num_edges;
     bool _built;
-    std::vector<int> start;            // CSR の境界（start[v]..start[v+1]）
-    std::vector<edge_type> buf;        // build() 前に蓄積する辺（from でソート前）
-    std::vector<edge_type> elist;      // CSR 本体（from 昇順に詰めた有向辺）
-    std::vector<edge_type> edge_list_; // ID 順の辺リスト（ID→辺の逆引き）
+    std::vector<int> start;             // CSR の境界（start[v]..start[v+1]）
+    std::vector<edge_type> buf;         // build() 前に蓄積する辺（from でソート前）
+    std::vector<edge_type> elist;       // CSR 本体（from 昇順に詰めた有向辺）
+    std::vector<edge_type> edge_list_;  // ID 順の辺リスト（ID→辺の逆引き）
 };
 
 // ---- グラフの concept（list_graph<T> / csr_graph<T> を共通の契約で扱う） ----

--- a/lib/graph/kruskal.hpp
+++ b/lib/graph/kruskal.hpp
@@ -1,8 +1,8 @@
 #pragma once
 #include <algorithm>
 #include <vector>
-#include "graph/graph.hpp"
 #include "data_structure/union_find.hpp"
+#include "graph/graph.hpp"
 
 /// @brief クラスカル法
 /// @tparam G 重み付きグラフ型（`list_graph<T>` / `csr_graph<T>` のいずれでも可）

--- a/lib/internal/internal_type_traits.hpp
+++ b/lib/internal/internal_type_traits.hpp
@@ -1,9 +1,21 @@
 #pragma once
 #include <cassert>
+#include <concepts>
 #include <numeric>
 #include <type_traits>
 
 namespace internal {
+
+/// 体 (field) であることを表明する opt-in マーカー基底。
+/// 四則演算（除算を含む）が閉じ、`0`/`1` を構築でき `==` で比較できる型が継承する。
+/// 整数型・浮動小数点型は構文上は四則演算できても「体である」保証がないため
+/// 区別したく、構文ベースの concept では弾けないのでマーカー方式を採る。
+struct field_base {};
+
+/// 体 (field) として扱える型。`field_base` を継承した型のみが満たす。
+/// modint（素数 mod）や有理数を想定。
+template <class T>
+concept field = std::is_base_of_v<field_base, T>;
 
 template <class T>
 using is_signed_int128 = typename std::conditional<std::is_same<T, __int128_t>::value ||

--- a/lib/internal/internal_type_traits.hpp
+++ b/lib/internal/internal_type_traits.hpp
@@ -18,14 +18,14 @@ template <class T>
 concept field = std::is_base_of_v<field_base, T>;
 
 template <class T>
-using is_signed_int128 = typename std::conditional<std::is_same<T, __int128_t>::value ||
-                                                       std::is_same<T, __int128>::value,
-                                                   std::true_type, std::false_type>::type;
+using is_signed_int128 =
+    typename std::conditional<std::is_same<T, __int128_t>::value || std::is_same<T, __int128>::value, std::true_type,
+                              std::false_type>::type;
 
 template <class T>
-using is_unsigned_int128 = typename std::conditional<std::is_same<T, __uint128_t>::value ||
-                                                         std::is_same<T, unsigned __int128>::value,
-                                                     std::true_type, std::false_type>::type;
+using is_unsigned_int128 =
+    typename std::conditional<std::is_same<T, __uint128_t>::value || std::is_same<T, unsigned __int128>::value,
+                              std::true_type, std::false_type>::type;
 
 template <class T>
 using make_unsigned_int128 =
@@ -33,27 +33,23 @@ using make_unsigned_int128 =
 
 template <class T>
 using is_integral =
-    typename std::conditional<std::is_integral<T>::value || is_signed_int128<T>::value ||
-                                  is_unsigned_int128<T>::value,
+    typename std::conditional<std::is_integral<T>::value || is_signed_int128<T>::value || is_unsigned_int128<T>::value,
                               std::true_type, std::false_type>::type;
 
 template <class T>
 using is_signed_int =
-    typename std::conditional<(is_integral<T>::value && std::is_signed<T>::value) ||
-                                  is_signed_int128<T>::value,
+    typename std::conditional<(is_integral<T>::value && std::is_signed<T>::value) || is_signed_int128<T>::value,
                               std::true_type, std::false_type>::type;
 
 template <class T>
 using is_unsigned_int =
-    typename std::conditional<(is_integral<T>::value && std::is_unsigned<T>::value) ||
-                                  is_unsigned_int128<T>::value,
+    typename std::conditional<(is_integral<T>::value && std::is_unsigned<T>::value) || is_unsigned_int128<T>::value,
                               std::true_type, std::false_type>::type;
 
 template <class T>
 using to_unsigned = typename std::conditional<
     is_signed_int128<T>::value, make_unsigned_int128<T>,
-    typename std::conditional<std::is_signed<T>::value, std::make_unsigned<T>,
-                              std::common_type<T>>::type>::type;
+    typename std::conditional<std::is_signed<T>::value, std::make_unsigned<T>, std::common_type<T>>::type>::type;
 
 template <class T>
 using is_signed_int_t = std::enable_if_t<is_signed_int<T>::value>;

--- a/lib/math/berlekamp_massey.hpp
+++ b/lib/math/berlekamp_massey.hpp
@@ -1,11 +1,12 @@
 #pragma once
 #include <utility>
 #include <vector>
+#include "internal/internal_type_traits.hpp"
 
 /// @brief Berlekamp-Massey 法
 /// 数列 s と矛盾しない最小位数の線形漸化式の係数 c を求める
 /// s_i = \sum_{j=1}^{L} c_{j-1} s_{i-j} (i >= L) を満たす
-template <class T>
+template <internal::field T>
 std::vector<T> berlekamp_massey(const std::vector<T> &s) {
     const int n = s.size();
     // c: 現在の漸化式の係数 (c[0] = 1)、b: 前回更新時の係数

--- a/lib/math/eratosthenes.hpp
+++ b/lib/math/eratosthenes.hpp
@@ -33,10 +33,10 @@ struct eratosthenes {
 
     // セグメントを跨いで篩い込み位置を持ち越すための小さい素数の情報。
     struct sieve_prime {
-        int i;       // 素数 p = 30*i + kMod30[ibit] のバイト位置
-        int ibit;    // p の mod30 wheel での位置
-        int j;       // 次に篩う合成数のバイト位置
-        int k;       // その合成数の wheel 位置
+        int i;     // 素数 p = 30*i + kMod30[ibit] のバイト位置
+        int ibit;  // p の mod30 wheel での位置
+        int j;     // 次に篩う合成数のバイト位置
+        int k;     // その合成数の wheel 位置
     };
 
   public:
@@ -68,9 +68,7 @@ struct eratosthenes {
                 std::uint64_t j = i * pm + (m * m) / 30;
                 int k = ibit;
                 // √N 以下の範囲（＝記録した素数の倍数が現れうる head 部分）はここで篩う。
-                for (; j < head; j += i * C1[k] + C0[ibit][k], k = (k + 1) & 7) {
-                    prime_number[j] &= kMask[ibit][k];
-                }
+                for (; j < head; j += i * C1[k] + C0[ibit][k], k = (k + 1) & 7) { prime_number[j] &= kMask[ibit][k]; }
                 if (j < static_cast<std::uint64_t>(SIZE)) {
                     primes.push_back({static_cast<int>(i), ibit, static_cast<int>(j), k});
                 }
@@ -81,35 +79,39 @@ struct eratosthenes {
         // 書き込みが常にキャッシュ常駐の区間に収まりキャッシュミスを抑える。
         for (int seg_lo = static_cast<int>(head); seg_lo < SIZE; seg_lo += kSegmentSize) {
             const int seg_hi = std::min(seg_lo + kSegmentSize, SIZE);
-            for (sieve_prime& sp : primes) {
+            for (sieve_prime &sp : primes) {
                 const int i = sp.i, ibit = sp.ibit;
-                const auto& mask = kMask[ibit];
-                const auto& c0 = C0[ibit];
+                const auto &mask = kMask[ibit];
+                const auto &c0 = C0[ibit];
                 int j = sp.j, k = sp.k;
                 // 前処理: メインループの起点を k == 0 に揃える。
-                for (; k != 0 && j < seg_hi; j += i * C1[k] + c0[k], k = (k + 1) & 7) {
-                    prime_number[j] &= mask[k];
-                }
+                for (; k != 0 && j < seg_hi; j += i * C1[k] + c0[k], k = (k + 1) & 7) { prime_number[j] &= mask[k]; }
                 // メインループ: wheel 1 周（8 ステップ）を展開して分岐を削減する。
                 // 8 ステップで進むバイト数は i*sum(C1) + sum(C0[ibit]) = 30*i + p。
                 // 8 番目の書き込み位置 j + (30*i + p) - C1[7] - c0[7] が seg_hi 未満なら展開可能。
                 if (k == 0) {
                     const int last8 = 30 * i + (30 * i + 2 * kMod30[ibit]) - (i * C1[7] + c0[7]);
                     while (j + last8 < seg_hi) {
-                        prime_number[j] &= mask[0]; j += i * C1[0] + c0[0];
-                        prime_number[j] &= mask[1]; j += i * C1[1] + c0[1];
-                        prime_number[j] &= mask[2]; j += i * C1[2] + c0[2];
-                        prime_number[j] &= mask[3]; j += i * C1[3] + c0[3];
-                        prime_number[j] &= mask[4]; j += i * C1[4] + c0[4];
-                        prime_number[j] &= mask[5]; j += i * C1[5] + c0[5];
-                        prime_number[j] &= mask[6]; j += i * C1[6] + c0[6];
-                        prime_number[j] &= mask[7]; j += i * C1[7] + c0[7];
+                        prime_number[j] &= mask[0];
+                        j += i * C1[0] + c0[0];
+                        prime_number[j] &= mask[1];
+                        j += i * C1[1] + c0[1];
+                        prime_number[j] &= mask[2];
+                        j += i * C1[2] + c0[2];
+                        prime_number[j] &= mask[3];
+                        j += i * C1[3] + c0[3];
+                        prime_number[j] &= mask[4];
+                        j += i * C1[4] + c0[4];
+                        prime_number[j] &= mask[5];
+                        j += i * C1[5] + c0[5];
+                        prime_number[j] &= mask[6];
+                        j += i * C1[6] + c0[6];
+                        prime_number[j] &= mask[7];
+                        j += i * C1[7] + c0[7];
                     }
                 }
                 // 後処理: セグメント末尾までの残りを 1 ステップずつ。
-                for (; j < seg_hi; j += i * C1[k] + c0[k], k = (k + 1) & 7) {
-                    prime_number[j] &= mask[k];
-                }
+                for (; j < seg_hi; j += i * C1[k] + c0[k], k = (k + 1) & 7) { prime_number[j] &= mask[k]; }
                 sp.j = j;
                 sp.k = k;
             }

--- a/lib/math/fraction.hpp
+++ b/lib/math/fraction.hpp
@@ -3,9 +3,10 @@
 #include <iostream>
 #include <numeric>
 #include <utility>
+#include "internal/internal_type_traits.hpp"
 
 /// @brief 分数ライブラリ
-struct Fraction {
+struct Fraction : internal::field_base {
     Fraction() : x(0), y(1) {}
     Fraction(std::int64_t _x, std::int64_t _y = 1) : x(_x), y(_y) { common(); }
 

--- a/lib/math/min_linear.hpp
+++ b/lib/math/min_linear.hpp
@@ -5,8 +5,8 @@ namespace internal {
 
 namespace min_linear {
 
-std::int64_t min_linear(std::int64_t n, std::int64_t m, std::int64_t a, std::int64_t b, bool is_min,
-                        std::int64_t p, std::int64_t q) {
+std::int64_t min_linear(std::int64_t n, std::int64_t m, std::int64_t a, std::int64_t b, bool is_min, std::int64_t p,
+                        std::int64_t q) {
     if (a == 0) return b;
     if (is_min) {
         if (b >= a) {

--- a/lib/math/modint.hpp
+++ b/lib/math/modint.hpp
@@ -5,10 +5,11 @@
 #include <iostream>
 #include <type_traits>
 #include "internal/internal_math.hpp"
+#include "internal/internal_type_traits.hpp"
 
 namespace internal {
 
-struct modint_base {};
+struct modint_base : field_base {};
 struct static_modint_base {};
 
 template <class T>

--- a/lib/math/slope_trick.hpp
+++ b/lib/math/slope_trick.hpp
@@ -19,9 +19,7 @@ struct slope_trick {
 
     /// @brief Add f(x) = max(0, x - a)
     void add_x_minus_a(T a) {
-        if (!l.empty() && l.top() > a) {
-            min_f += l.top() - a;
-        }
+        if (!l.empty() && l.top() > a) { min_f += l.top() - a; }
         l.push(a);
         r.push(l.top());
         l.pop();
@@ -29,9 +27,7 @@ struct slope_trick {
 
     /// @brief Add f(x) = max(0, a - x)
     void add_a_minus_x(T a) {
-        if (!r.empty() && a > r.top()) {
-            min_f += a - r.top();
-        }
+        if (!r.empty() && a > r.top()) { min_f += a - r.top(); }
         r.push(a);
         l.push(r.top());
         r.pop();

--- a/lib/segtree/monoid.hpp
+++ b/lib/segtree/monoid.hpp
@@ -13,8 +13,7 @@ concept monoid = requires {
     typename M::value_type;
     { M::id() } -> std::same_as<typename M::value_type>;
     {
-        M::op(std::declval<const typename M::value_type &>(),
-              std::declval<const typename M::value_type &>())
+        M::op(std::declval<const typename M::value_type &>(), std::declval<const typename M::value_type &>())
     } -> std::same_as<typename M::value_type>;
 };
 
@@ -156,9 +155,7 @@ template <class T>
 struct Update {
     using value_type = T;
     static constexpr T id() noexcept { return std::numeric_limits<T>::max(); }
-    static constexpr T op(const T &lhs, const T &rhs) noexcept {
-        return lhs == id() ? rhs : lhs;
-    }
+    static constexpr T op(const T &lhs, const T &rhs) noexcept { return lhs == id() ? rhs : lhs; }
 
     template <class U>
     static constexpr U f(const T &lhs, const U &rhs) noexcept {
@@ -185,7 +182,5 @@ template <class M>
 struct Rev {
     using value_type = typename M::value_type;
     static constexpr value_type id() { return M::id(); }
-    static constexpr value_type op(const value_type &lhs, const value_type &rhs) {
-        return M::op(rhs, lhs);
-    }
+    static constexpr value_type op(const value_type &lhs, const value_type &rhs) { return M::op(rhs, lhs); }
 };

--- a/lib/string/suffix_automaton.hpp
+++ b/lib/string/suffix_automaton.hpp
@@ -86,9 +86,7 @@ struct string_suffix_automaton {
         int link;
         std::array<int, ALPHABET_SIZE> next;
 
-        node(int _len, int _link) : len(_len), link(_link) {
-            next.fill(-1);
-        }
+        node(int _len, int _link) : len(_len), link(_link) { next.fill(-1); }
     };
 
     std::vector<node> nodes;

--- a/lib/string/suffix_tree.hpp
+++ b/lib/string/suffix_tree.hpp
@@ -26,17 +26,13 @@ struct suffix_tree {
     suffix_tree(const std::vector<T> &_s)
         : s(_s), root(0), active_node(0), active_edge(0), active_len(0), remainder(0) {
         nodes.emplace_back(-1, -1);
-        for (int i = 0; i < (int)s.size(); ++i) {
-            extend(i);
-        }
+        for (int i = 0; i < (int)s.size(); ++i) { extend(i); }
     }
 
     suffix_tree(const std::string &_s) : root(0), active_node(0), active_edge(0), active_len(0), remainder(0) {
         for (auto c : _s) s.emplace_back(c);
         nodes.emplace_back(-1, -1);
-        for (int i = 0; i < (int)s.size(); ++i) {
-            extend(i);
-        }
+        for (int i = 0; i < (int)s.size(); ++i) { extend(i); }
     }
 
     void extend(int pos) {
@@ -58,7 +54,7 @@ struct suffix_tree {
             } else {
                 int next = nodes[active_node].next[s[active_edge]];
                 int len = nodes[next].len();
-                if (nodes[next].end == -1) len = s.size() - nodes[next].start; // Open edge
+                if (nodes[next].end == -1) len = s.size() - nodes[next].start;  // Open edge
 
                 if (active_len >= len) {
                     active_edge += len;
@@ -87,9 +83,7 @@ struct suffix_tree {
                 nodes[next].start += active_len;
                 nodes[split].next[s[nodes[next].start]] = next;
 
-                if (last_new_node != 0) {
-                    nodes[last_new_node].link = split;
-                }
+                if (last_new_node != 0) { nodes[last_new_node].link = split; }
                 last_new_node = split;
             }
 

--- a/lib/tree/dsu_on_tree.hpp
+++ b/lib/tree/dsu_on_tree.hpp
@@ -10,8 +10,8 @@
 template <graph_type G>
 struct dsu_on_tree {
     dsu_on_tree(const G &_g, const std::vector<int> &query, int r = 0)
-        : g(_g), size(_g.size()), root(r), par(size, -1), sub(), euler(size), left(size),
-          right(size), heavy_path(size, -1), query_order(query.size()), query_size(size) {
+        : g(_g), size(_g.size()), root(r), par(size, -1), sub(), euler(size), left(size), right(size),
+          heavy_path(size, -1), query_order(query.size()), query_size(size) {
         if (size == 0) return;
         for (int x : query) ++query_size[x];
         sub = query_size;
@@ -24,8 +24,8 @@ struct dsu_on_tree {
         for (int i = 0; i < (int)query.size(); ++i) query_order[cnt[query[i]]++] = i;
     }
     dsu_on_tree(const G &_g, int r = 0)
-        : g(_g), size(_g.size()), root(r), par(size, -1), sub(size, 1), euler(size), left(size),
-          right(size), heavy_path(size, -1), query_order(), query_size(size, 1) {
+        : g(_g), size(_g.size()), root(r), par(size, -1), sub(size, 1), euler(size), left(size), right(size),
+          heavy_path(size, -1), query_order(), query_size(size, 1) {
         if (size == 0) return;
         dfs_sz(root);
         if (size > 1) {

--- a/lib/tree/hld.hpp
+++ b/lib/tree/hld.hpp
@@ -52,8 +52,7 @@ struct heavy_light_decomposition {
         }
     }
 
-    heavy_light_decomposition(const internal::graph_csr &g, int r = 0)
-        : heavy_light_decomposition(g.size()) {
+    heavy_light_decomposition(const internal::graph_csr &g, int r = 0) : heavy_light_decomposition(g.size()) {
         std::vector<int> heavy_path(_size, -1);
         std::vector<int> stk;
         stk.reserve(_size);
@@ -178,6 +177,5 @@ struct heavy_light_decomposition {
     int _size;
     std::vector<int> vid, nxt, par, dep, inv, sub;
 
-    heavy_light_decomposition(int n)
-        : _size(n), vid(n, -1), nxt(n), par(n, -1), dep(n), inv(n), sub(n, 1) {}
+    heavy_light_decomposition(int n) : _size(n), vid(n, -1), nxt(n), par(n, -1), dep(n), inv(n), sub(n, 1) {}
 };

--- a/lib/tree/palindromic_tree.hpp
+++ b/lib/tree/palindromic_tree.hpp
@@ -18,8 +18,7 @@ struct palindromic_tree {
         int count;
 
         _node() : link(), suffix_link(), len(), count() {}
-        _node(int _suffix_link, int _len, int _count)
-            : link(), suffix_link(_suffix_link), len(_len), count(_count) {}
+        _node(int _suffix_link, int _len, int _count) : link(), suffix_link(_suffix_link), len(_len), count(_count) {}
     };
 
   public:

--- a/lib/tree/rerooting.hpp
+++ b/lib/tree/rerooting.hpp
@@ -11,10 +11,7 @@ struct ReRooting {
     using Value = typename M::value_type;
 
   public:
-    ReRooting(const G &g, const std::vector<U> &v)
-        : g_(g), data(v), dp(g.size()), values(g.size()) {
-        build();
-    }
+    ReRooting(const G &g, const std::vector<U> &v) : g_(g), data(v), dp(g.size()), values(g.size()) { build(); }
 
     const auto &operator[](int i) const { return values[i]; }
     auto &operator[](int i) { return values[i]; }
@@ -41,7 +38,7 @@ struct ReRooting {
     void dfs_iter() {
         int n = g_.size();
         std::vector<Value> ret(n, M::id());
-        std::vector<Value> res(n, M::id());  // 各頂点の子 dp の op 集約
+        std::vector<Value> res(n, M::id());      // 各頂点の子 dp の op 集約
         std::vector<int> par(n, -1), pe(n, -1);  // 親と「親→自分」の辺添字
         struct frame {
             int v, p, idx;

--- a/lib/tree/stern_brocot_tree.hpp
+++ b/lib/tree/stern_brocot_tree.hpp
@@ -6,13 +6,10 @@
  */
 struct stern_brocot_tree {
     constexpr stern_brocot_tree() : pl(0), ql(1), pr(1), qr(0) {}
-    constexpr stern_brocot_tree(std::uint64_t pl, std::uint64_t ql, std::uint64_t pr,
-                                std::uint64_t qr)
+    constexpr stern_brocot_tree(std::uint64_t pl, std::uint64_t ql, std::uint64_t pr, std::uint64_t qr)
         : pl(pl), ql(ql), pr(pr), qr(qr) {}
 
-    constexpr std::pair<std::uint64_t, std::uint64_t> get() const {
-        return std::make_pair(pl + pr, ql + qr);
-    }
+    constexpr std::pair<std::uint64_t, std::uint64_t> get() const { return std::make_pair(pl + pr, ql + qr); }
 
     constexpr stern_brocot_tree get_left() const {
         auto [p, q] = get();

--- a/mise.toml
+++ b/mise.toml
@@ -19,15 +19,20 @@ uv = "latest"
 "pipx:online-judge-verify-helper" = { version = "latest", uvx_args = "--with setuptools<81", pipx_args = "--preinstall setuptools<81" }
 # Daily Problems の CLI クライアント -> daily（git+ 直インストール、stdlib のみで依存なし）
 "pipx:git+https://github.com/kuhaku-space/daily-problems-cli.git" = "latest"
+# コミット前フック（.githooks/pre-commit）が lib/・test/ の C++ を整形するのに使う。
+# .clang-format（Google ベース）に従う。
+clang-format = "latest"
 
 [tasks.setup]
 description = "Setup project（ツール・oj-tools・shim を一括導入）"
 run = [
-    # [tools] 宣言（jq / uv / pipx:oj 系）をまとめて導入。
+    # [tools] 宣言（jq / uv / clang-format / pipx:oj 系）をまとめて導入。
     "mise install",
     # CLI でしか入らないシステムパッケージ。
     "which xclip > /dev/null || (sudo apt update -qq && sudo apt install -qq xclip)",
     "which g++-14 > /dev/null || (sudo apt update -qq && sudo apt install -qq g++-14)",
+    # コミット前 clang-format フックを有効化（core.hooksPath はリポジトリ毎のローカル設定）。
+    "git config core.hooksPath .githooks",
     "mise run install-shims",
 ]
 

--- a/test/aoj/challenge/2270.test.cpp
+++ b/test/aoj/challenge/2270.test.cpp
@@ -37,8 +37,8 @@ int main(void) {
         std::cin >> u >> v >> k;
         --u, --v;
         auto f = [&](int y) {
-            return wm.rect_sum(0, in[u] + 1, y) + wm.rect_sum(0, in[v] + 1, y) -
-                       wm.rect_sum(0, in[lca(u, v)] + 1, y) - wm.rect_sum(0, in[lca(u, v)], y) <
+            return wm.rect_sum(0, in[u] + 1, y) + wm.rect_sum(0, in[v] + 1, y) - wm.rect_sum(0, in[lca(u, v)] + 1, y) -
+                       wm.rect_sum(0, in[lca(u, v)], y) <
                    k;
         };
         auto ans = meguru_binary_search(0, cps.size() + 1, f);

--- a/test/aoj/challenge/2426.1.test.cpp
+++ b/test/aoj/challenge/2426.1.test.cpp
@@ -19,8 +19,7 @@ int main(void) {
     for (int i = 0; i < m; ++i) {
         int x1, y1, x2, y2;
         std::cin >> x1 >> y1 >> x2 >> y2;
-        std::cout << cs.get(cps_x.get(x1), cps_y.get(y1), cps_x.get(x2 + 1), cps_y.get(y2 + 1))
-                  << '\n';
+        std::cout << cs.get(cps_x.get(x1), cps_y.get(y1), cps_x.get(x2 + 1), cps_y.get(y2 + 1)) << '\n';
     }
 
     return 0;

--- a/test/aoj/challenge/2559.2.test.cpp
+++ b/test/aoj/challenge/2559.2.test.cpp
@@ -7,9 +7,9 @@
 #include <tuple>
 #include <utility>
 #include <vector>
+#include "data_structure/union_find.hpp"
 #include "graph/graph.hpp"
 #include "heap/leftist_heap.hpp"
-#include "data_structure/union_find.hpp"
 
 int main(void) {
     int n, m;
@@ -18,8 +18,7 @@ int main(void) {
     for (auto &[u, v, w] : edges) std::cin >> u >> v >> w, --u, --v;
     std::vector<int> ord(m);
     std::iota(ord.begin(), ord.end(), 0);
-    std::sort(ord.begin(), ord.end(),
-              [&](int x, int y) { return std::get<2>(edges[x]) < std::get<2>(edges[y]); });
+    std::sort(ord.begin(), ord.end(), [&](int x, int y) { return std::get<2>(edges[x]) < std::get<2>(edges[y]); });
     std::int64_t sum = 0;
     union_find uf(n);
     std::vector<leftist_heap<std::pair<int, int>, std::greater<>>> heap(n);
@@ -50,8 +49,7 @@ int main(void) {
         for (auto e : g[x]) {
             if (e.to() == p) continue;
             self(self, e.to(), x);
-            while (!heap[e.to()].empty() && uf.same(e.to(), heap[e.to()].top().second))
-                heap[e.to()].pop();
+            while (!heap[e.to()].empty() && uf.same(e.to(), heap[e.to()].top().second)) heap[e.to()].pop();
             if (!heap[e.to()].empty()) {
                 auto [u, v, w] = edges[e.weight()];
                 ans[e.weight()] = sum - w + heap[e.to()].top().first;

--- a/test/aoj/challenge/2559.test.cpp
+++ b/test/aoj/challenge/2559.test.cpp
@@ -7,9 +7,9 @@
 #include <tuple>
 #include <utility>
 #include <vector>
+#include "data_structure/union_find.hpp"
 #include "graph/graph.hpp"
 #include "heap/skew_heap.hpp"
-#include "data_structure/union_find.hpp"
 
 int main(void) {
     int n, m;
@@ -18,8 +18,7 @@ int main(void) {
     for (auto &[u, v, w] : edges) std::cin >> u >> v >> w, --u, --v;
     std::vector<int> ord(m);
     std::iota(ord.begin(), ord.end(), 0);
-    std::sort(ord.begin(), ord.end(),
-              [&](int x, int y) { return std::get<2>(edges[x]) < std::get<2>(edges[y]); });
+    std::sort(ord.begin(), ord.end(), [&](int x, int y) { return std::get<2>(edges[x]) < std::get<2>(edges[y]); });
     std::int64_t sum = 0;
     union_find uf(n);
     std::vector<skew_heap<std::pair<int, int>, std::greater<>>> heap(n);
@@ -50,8 +49,7 @@ int main(void) {
         for (auto e : g[x]) {
             if (e.to() == p) continue;
             self(self, e.to(), x);
-            while (!heap[e.to()].empty() && uf.same(e.to(), heap[e.to()].top().second))
-                heap[e.to()].pop();
+            while (!heap[e.to()].empty() && uf.same(e.to(), heap[e.to()].top().second)) heap[e.to()].pop();
             if (!heap[e.to()].empty()) {
                 auto [u, v, w] = edges[e.weight()];
                 ans[e.weight()] = sum - w + heap[e.to()].top().first;

--- a/test/aoj/challenge/2834.test.cpp
+++ b/test/aoj/challenge/2834.test.cpp
@@ -2,8 +2,8 @@
 #include <cstdint>
 #include <iostream>
 #include <vector>
-#include "graph/shortest_path.hpp"
 #include "graph/graph.hpp"
+#include "graph/shortest_path.hpp"
 
 int main(void) {
     int n, m, s, t;

--- a/test/aoj/challenge/3163.test.cpp
+++ b/test/aoj/challenge/3163.test.cpp
@@ -9,9 +9,7 @@ struct Monoid {
     using T = std::pair<std::int64_t, std::int64_t>;
     using value_type = T;
     static constexpr T id() { return {0, 0}; };
-    static constexpr T op(const T &lhs, const T &rhs) {
-        return {lhs.first + rhs.first, lhs.second + rhs.second};
-    }
+    static constexpr T op(const T &lhs, const T &rhs) { return {lhs.first + rhs.first, lhs.second + rhs.second}; }
 
     template <class U>
     static constexpr T f(const T &v, U u) {

--- a/test/aoj/dsl/weighted_union_find.test.cpp
+++ b/test/aoj/dsl/weighted_union_find.test.cpp
@@ -1,6 +1,6 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/DSL_1_B
-#include "data_structure/potentialized_union_find.hpp"
 #include <iostream>
+#include "data_structure/potentialized_union_find.hpp"
 
 int main(void) {
     int n, q;

--- a/test/aoj/grl/cycle.test.cpp
+++ b/test/aoj/grl/cycle.test.cpp
@@ -1,7 +1,7 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/GRL_4_A
 #include "graph/cycle.hpp"
-#include "graph/edge_input.hpp"
 #include <iostream>
+#include "graph/edge_input.hpp"
 
 int main(void) {
     int n, m;

--- a/test/aoj/grl/dijkstra.2.test.cpp
+++ b/test/aoj/grl/dijkstra.2.test.cpp
@@ -1,8 +1,8 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/GRL_1_A
-#include "graph/shortest_path.hpp"
 #include <iostream>
 #include <vector>
 #include "graph/edge_input.hpp"
+#include "graph/shortest_path.hpp"
 #include "heap/fibonacci_heap.hpp"
 
 int main(void) {

--- a/test/aoj/grl/dijkstra.3.test.cpp
+++ b/test/aoj/grl/dijkstra.3.test.cpp
@@ -1,8 +1,8 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/GRL_1_A
-#include "graph/shortest_path.hpp"
 #include <iostream>
 #include <vector>
 #include "graph/edge_input.hpp"
+#include "graph/shortest_path.hpp"
 #include "heap/dary_heap.hpp"
 
 int main(void) {

--- a/test/aoj/grl/dijkstra.test.cpp
+++ b/test/aoj/grl/dijkstra.test.cpp
@@ -1,8 +1,8 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/GRL_1_A
-#include "graph/shortest_path.hpp"
 #include <iostream>
 #include <vector>
 #include "graph/edge_input.hpp"
+#include "graph/shortest_path.hpp"
 
 int main(void) {
     int n, m, r;

--- a/test/aoj/grl/hld.test.cpp
+++ b/test/aoj/grl/hld.test.cpp
@@ -1,7 +1,7 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/GRL_5_C
-#include "graph/graph.hpp"
 #include "tree/hld.hpp"
 #include <iostream>
+#include "graph/graph.hpp"
 
 int main(void) {
     int n;

--- a/test/aoj/grl/kruskal.test.cpp
+++ b/test/aoj/grl/kruskal.test.cpp
@@ -1,8 +1,8 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/GRL_2_A
-#include "graph/edge_input.hpp"
 #include "graph/kruskal.hpp"
 #include <iostream>
 #include <vector>
+#include "graph/edge_input.hpp"
 
 int main(void) {
     int n, m;

--- a/test/aoj/grl/prim.test.cpp
+++ b/test/aoj/grl/prim.test.cpp
@@ -1,7 +1,7 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/GRL_2_A
-#include "graph/edge_input.hpp"
 #include "graph/prim.hpp"
 #include <iostream>
+#include "graph/edge_input.hpp"
 
 int main(void) {
     int n, m;

--- a/test/aoj/grl/range_query_on_tree.test.cpp
+++ b/test/aoj/grl/range_query_on_tree.test.cpp
@@ -1,8 +1,8 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/GRL_5_D
 #include <cstdint>
 #include <iostream>
-#include "graph/graph.hpp"
 #include "binary_tree/fenwick_tree.hpp"
+#include "graph/graph.hpp"
 #include "tree/hld.hpp"
 
 int main(void) {

--- a/test/aoj/grl/range_query_on_tree_2.test.cpp
+++ b/test/aoj/grl/range_query_on_tree_2.test.cpp
@@ -1,8 +1,8 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/GRL_5_E
 #include <cstdint>
 #include <iostream>
-#include "graph/graph.hpp"
 #include "binary_tree/fenwick_tree_raq.hpp"
+#include "graph/graph.hpp"
 #include "tree/hld.hpp"
 
 int main(void) {

--- a/test/aoj/grl/scc.test.cpp
+++ b/test/aoj/grl/scc.test.cpp
@@ -1,8 +1,8 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/GRL_3_C
-#include "graph/edge_input.hpp"
 #include "graph/scc.hpp"
 #include <iostream>
 #include <vector>
+#include "graph/edge_input.hpp"
 
 int main(void) {
     int n, m;

--- a/test/aoj/grl/shortest_path_negative.test.cpp
+++ b/test/aoj/grl/shortest_path_negative.test.cpp
@@ -1,7 +1,7 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/GRL_1_B
+#include <iostream>
 #include "graph/edge_input.hpp"
 #include "graph/shortest_path.hpp"
-#include <iostream>
 
 int main(void) {
     int n, m, r;

--- a/test/aoj/grl/shortest_path_spfa.test.cpp
+++ b/test/aoj/grl/shortest_path_spfa.test.cpp
@@ -1,9 +1,9 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/GRL_1_B
-#include "graph/edge_input.hpp"
-#include "graph/shortest_path.hpp"
 #include <iostream>
 #include <limits>
 #include <vector>
+#include "graph/edge_input.hpp"
+#include "graph/shortest_path.hpp"
 
 int main(void) {
     int n, m, r;

--- a/test/aoj/grl/topological_sort.test.cpp
+++ b/test/aoj/grl/topological_sort.test.cpp
@@ -1,8 +1,8 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/GRL_4_B
-#include "graph/edge_input.hpp"
 #include "graph/topological_sort.hpp"
 #include <iostream>
 #include <vector>
+#include "graph/edge_input.hpp"
 
 int main(void) {
     int n, m;

--- a/test/aoj/jag/dsu_on_tree.test.cpp
+++ b/test/aoj/jag/dsu_on_tree.test.cpp
@@ -4,8 +4,8 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
-#include "graph/edge_input.hpp"
 #include "data_structure/union_find.hpp"
+#include "graph/edge_input.hpp"
 
 int main(void) {
     int n, k;

--- a/test/aoj/jag/hash_int.test.cpp
+++ b/test/aoj/jag/hash_int.test.cpp
@@ -1,7 +1,7 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/2971
 #include <iostream>
-#include "math/hashint.hpp"
 #include "data_structure/potentialized_union_find.hpp"
+#include "math/hashint.hpp"
 
 /// HashInt の乗法群（単位元 1・合成 `*`・逆元 `inv()`）としての薄いラッパ
 struct S {

--- a/test/yosupo/data_structure/persistent_range_affine_range_sum.test.cpp
+++ b/test/yosupo/data_structure/persistent_range_affine_range_sum.test.cpp
@@ -18,9 +18,7 @@ struct F {
     using T = std::pair<Mint, Mint>;
     using value_type = T;
     static constexpr T id() { return T(1, 0); }
-    static constexpr T op(T lhs, T rhs) {
-        return {lhs.first * rhs.first, lhs.first * rhs.second + lhs.second};
-    }
+    static constexpr T op(T lhs, T rhs) { return {lhs.first * rhs.first, lhs.first * rhs.second + lhs.second}; }
     template <class U>
     static constexpr U f(T lhs, U rhs) {
         return {lhs.first * rhs.first + lhs.second * rhs.second, rhs.second};

--- a/test/yosupo/data_structure/range_affine_range_sum.test.cpp
+++ b/test/yosupo/data_structure/range_affine_range_sum.test.cpp
@@ -18,9 +18,7 @@ struct M2 {
     using T = std::pair<Mint, Mint>;
     using value_type = T;
     static constexpr T id() { return T(1, 0); }
-    static constexpr T op(T lhs, T rhs) {
-        return {lhs.first * rhs.first, lhs.first * rhs.second + lhs.second};
-    }
+    static constexpr T op(T lhs, T rhs) { return {lhs.first * rhs.first, lhs.first * rhs.second + lhs.second}; }
     template <class U>
     static constexpr U f(T lhs, U rhs) {
         return {lhs.first * rhs.first + lhs.second * rhs.second, rhs.second};

--- a/test/yosupo/data_structure/range_affine_range_sum_large_array.test.cpp
+++ b/test/yosupo/data_structure/range_affine_range_sum_large_array.test.cpp
@@ -19,9 +19,7 @@ struct F {
     using T = std::pair<Mint, Mint>;
     using value_type = T;
     static constexpr T id() { return T(1, 0); }
-    static constexpr T op(T lhs, T rhs) {
-        return {lhs.first * rhs.first, lhs.first * rhs.second + lhs.second};
-    }
+    static constexpr T op(T lhs, T rhs) { return {lhs.first * rhs.first, lhs.first * rhs.second + lhs.second}; }
     template <class U>
     static constexpr U f(T lhs, U rhs) {
         return {lhs.first * rhs.first + lhs.second * rhs.second, rhs.second};

--- a/test/yosupo/data_structure/static_range_frequency.2.test.cpp
+++ b/test/yosupo/data_structure/static_range_frequency.2.test.cpp
@@ -1,7 +1,6 @@
 // competitive-verifier: PROBLEM https://judge.yosupo.jp/problem/static_range_frequency
 #include <iostream>
 #include <vector>
-
 #include "data_structure/merge_sort_tree.hpp"
 
 int main(void) {

--- a/test/yosupo/data_structure/unionfind_with_potential.test.cpp
+++ b/test/yosupo/data_structure/unionfind_with_potential.test.cpp
@@ -1,8 +1,8 @@
 // competitive-verifier: PROBLEM https://judge.yosupo.jp/problem/unionfind_with_potential
 #include <iostream>
 #include <vector>
-#include "math/modint.hpp"
 #include "data_structure/potentialized_union_find.hpp"
+#include "math/modint.hpp"
 
 using Mint = modint998;
 

--- a/test/yosupo/graph/maximum_independent_set.test.cpp
+++ b/test/yosupo/graph/maximum_independent_set.test.cpp
@@ -1,8 +1,8 @@
 // competitive-verifier: PROBLEM https://judge.yosupo.jp/problem/maximum_independent_set
-#include "graph/edge_input.hpp"
 #include "graph/maximum_independent_set.hpp"
 #include <iostream>
 #include <vector>
+#include "graph/edge_input.hpp"
 
 int main(void) {
     int n, m;
@@ -11,8 +11,7 @@ int main(void) {
     auto g = ei.to_undirected(n);
     auto ans = maximum_independent_set(g);
     std::cout << ans.size() << '\n';
-    for (int i = 0; i < (int)ans.size(); ++i)
-        std::cout << ans[i] << (i == (int)ans.size() - 1 ? '\n' : ' ');
+    for (int i = 0; i < (int)ans.size(); ++i) std::cout << ans[i] << (i == (int)ans.size() - 1 ? '\n' : ' ');
 
     return 0;
 }

--- a/test/yosupo/math/find_linear_recurrence.test.cpp
+++ b/test/yosupo/math/find_linear_recurrence.test.cpp
@@ -1,7 +1,7 @@
 // competitive-verifier: PROBLEM https://judge.yosupo.jp/problem/find_linear_recurrence
-#include "math/berlekamp_massey.hpp"
 #include <iostream>
 #include <vector>
+#include "math/berlekamp_massey.hpp"
 #include "math/modint.hpp"
 
 using Mint = modint998;

--- a/test/yosupo/math/montmort_number.test.cpp
+++ b/test/yosupo/math/montmort_number.test.cpp
@@ -15,8 +15,7 @@ int main(void) {
         else ++sum;
         sum %= m;
     }
-    for (int i = 0; i < (int)ans.size(); ++i)
-        std::cout << ans[i] << (i == (int)ans.size() - 1 ? '\n' : ' ');
+    for (int i = 0; i < (int)ans.size(); ++i) std::cout << ans[i] << (i == (int)ans.size() - 1 ? '\n' : ' ');
 
     return 0;
 }

--- a/test/yosupo/matrix/matrix_product.test.cpp
+++ b/test/yosupo/matrix/matrix_product.test.cpp
@@ -19,8 +19,7 @@ int main(void) {
     Matrix<Mint> x(a), y(b);
     auto z = x * y;
     for (auto &&v : z) {
-        for (int i = 0; i < (int)v.size(); ++i)
-            std::cout << v[i] << (i == (int)v.size() - 1 ? '\n' : ' ');
+        for (int i = 0; i < (int)v.size(); ++i) std::cout << v[i] << (i == (int)v.size() - 1 ? '\n' : ' ');
     }
 
     return 0;

--- a/test/yosupo/polynomial/division_of_polynomials.test.cpp
+++ b/test/yosupo/polynomial/division_of_polynomials.test.cpp
@@ -1,7 +1,6 @@
 // competitive-verifier: PROBLEM https://judge.yosupo.jp/problem/division_of_polynomials
 #include <iostream>
 #include <vector>
-
 #include "fft/formal_power_series.hpp"
 
 using Mint = modint998;
@@ -17,16 +16,12 @@ int main(void) {
     if (q.empty()) {
         std::cout << '\n';
     } else {
-        for (int i = 0; i < (int)q.size(); ++i) {
-            std::cout << q[i] << (i == (int)q.size() - 1 ? '\n' : ' ');
-        }
+        for (int i = 0; i < (int)q.size(); ++i) { std::cout << q[i] << (i == (int)q.size() - 1 ? '\n' : ' '); }
     }
     if (r.empty()) {
         std::cout << '\n';
     } else {
-        for (int i = 0; i < (int)r.size(); ++i) {
-            std::cout << r[i] << (i == (int)r.size() - 1 ? '\n' : ' ');
-        }
+        for (int i = 0; i < (int)r.size(); ++i) { std::cout << r[i] << (i == (int)r.size() - 1 ? '\n' : ' '); }
     }
 
     return 0;

--- a/test/yosupo/polynomial/exp_of_formal_power_series.test.cpp
+++ b/test/yosupo/polynomial/exp_of_formal_power_series.test.cpp
@@ -11,8 +11,7 @@ int main(void) {
     std::vector<Mint> a(n);
     for (auto &e : a) std::cin >> e;
     auto ans = fps::exp(a);
-    for (int i = 0; i < (int)ans.size(); ++i)
-        std::cout << ans[i] << (i == (int)ans.size() - 1 ? '\n' : ' ');
+    for (int i = 0; i < (int)ans.size(); ++i) std::cout << ans[i] << (i == (int)ans.size() - 1 ? '\n' : ' ');
 
     return 0;
 }

--- a/test/yosupo/polynomial/inv_of_formal_power_series.test.cpp
+++ b/test/yosupo/polynomial/inv_of_formal_power_series.test.cpp
@@ -11,8 +11,7 @@ int main(void) {
     std::vector<Mint> a(n);
     for (auto &e : a) std::cin >> e;
     auto ans = fps::inv(a);
-    for (int i = 0; i < (int)ans.size(); ++i)
-        std::cout << ans[i] << (i == (int)ans.size() - 1 ? '\n' : ' ');
+    for (int i = 0; i < (int)ans.size(); ++i) std::cout << ans[i] << (i == (int)ans.size() - 1 ? '\n' : ' ');
 
     return 0;
 }

--- a/test/yosupo/polynomial/log_of_formal_power_series.test.cpp
+++ b/test/yosupo/polynomial/log_of_formal_power_series.test.cpp
@@ -11,8 +11,7 @@ int main(void) {
     std::vector<Mint> a(n);
     for (auto &e : a) std::cin >> e;
     auto ans = fps::log(a);
-    for (int i = 0; i < (int)ans.size(); ++i)
-        std::cout << ans[i] << (i == (int)ans.size() - 1 ? '\n' : ' ');
+    for (int i = 0; i < (int)ans.size(); ++i) std::cout << ans[i] << (i == (int)ans.size() - 1 ? '\n' : ' ');
 
     return 0;
 }

--- a/test/yosupo/polynomial/multipoint_evaluation.test.cpp
+++ b/test/yosupo/polynomial/multipoint_evaluation.test.cpp
@@ -12,9 +12,7 @@ int main(void) {
     for (Mint &e : c) std::cin >> e;
     for (Mint &e : p) std::cin >> e;
     auto ans = fps::multipoint_evaluation(c, p);
-    for (int i = 0; i < (int)ans.size(); ++i) {
-        std::cout << ans[i] << (i == (int)ans.size() - 1 ? '\n' : ' ');
-    }
+    for (int i = 0; i < (int)ans.size(); ++i) { std::cout << ans[i] << (i == (int)ans.size() - 1 ? '\n' : ' '); }
 
     return 0;
 }

--- a/test/yosupo/polynomial/polynomial_interpolation.test.cpp
+++ b/test/yosupo/polynomial/polynomial_interpolation.test.cpp
@@ -12,9 +12,7 @@ int main(void) {
     for (Mint &e : x) std::cin >> e;
     for (Mint &e : y) std::cin >> e;
     auto ans = fps::polynomial_interpolation(x, y);
-    for (int i = 0; i < (int)ans.size(); ++i) {
-        std::cout << ans[i] << (i == (int)ans.size() - 1 ? '\n' : ' ');
-    }
+    for (int i = 0; i < (int)ans.size(); ++i) { std::cout << ans[i] << (i == (int)ans.size() - 1 ? '\n' : ' '); }
 
     return 0;
 }

--- a/test/yosupo/polynomial/pow_of_formal_power_series.test.cpp
+++ b/test/yosupo/polynomial/pow_of_formal_power_series.test.cpp
@@ -13,8 +13,7 @@ int main(void) {
     std::vector<Mint> a(n);
     for (auto &e : a) std::cin >> e;
     auto ans = fps::pow(a, m);
-    for (int i = 0; i < (int)ans.size(); ++i)
-        std::cout << ans[i] << (i == (int)ans.size() - 1 ? '\n' : ' ');
+    for (int i = 0; i < (int)ans.size(); ++i) std::cout << ans[i] << (i == (int)ans.size() - 1 ? '\n' : ' ');
 
     return 0;
 }

--- a/test/yosupo/polynomial/product_of_polynomial_sequence.test.cpp
+++ b/test/yosupo/polynomial/product_of_polynomial_sequence.test.cpp
@@ -4,14 +4,12 @@
 #include <queue>
 #include <utility>
 #include <vector>
-
 #include "fft/ntt.hpp"
 
 using Mint = modint998;
 
 std::vector<Mint> prod(const std::vector<std::vector<Mint>> &a, int l, int r) {
-    if (l + 1 == r)
-        return a[l];
+    if (l + 1 == r) return a[l];
     int m = (l + r) / 2;
     return convolution(prod(a, l, m), prod(a, m, r));
 }
@@ -20,8 +18,7 @@ int main(void) {
     int n;
     std::cin >> n;
     std::vector<std::vector<Mint>> a(n);
-    std::priority_queue<std::pair<int, int>, std::vector<std::pair<int, int>>, std::greater<>>
-        p_que;
+    std::priority_queue<std::pair<int, int>, std::vector<std::pair<int, int>>, std::greater<>> p_que;
     for (int i = 0; i < n; ++i) {
         int d;
         std::cin >> d;
@@ -34,8 +31,7 @@ int main(void) {
         std::cout << 1 << '\n';
     } else {
         auto ans = prod(a, 0, n);
-        for (int i = 0; i < (int)ans.size(); ++i)
-            std::cout << ans[i] << (i == (int)ans.size() - 1 ? '\n' : ' ');
+        for (int i = 0; i < (int)ans.size(); ++i) std::cout << ans[i] << (i == (int)ans.size() - 1 ? '\n' : ' ');
     }
 
     return 0;

--- a/test/yosupo/set_power_series/subset_convolution.test.cpp
+++ b/test/yosupo/set_power_series/subset_convolution.test.cpp
@@ -13,8 +13,7 @@ int main(void) {
     for (auto &e : a) std::cin >> e;
     for (auto &e : b) std::cin >> e;
     auto ans = subset_convolution(a, b);
-    for (int i = 0; i < (int)ans.size(); ++i)
-        std::cout << ans[i] << (i == (int)ans.size() - 1 ? '\n' : ' ');
+    for (int i = 0; i < (int)ans.size(); ++i) std::cout << ans[i] << (i == (int)ans.size() - 1 ? '\n' : ' ');
 
     return 0;
 }

--- a/test/yosupo/string/enumerate_palindromes.test.cpp
+++ b/test/yosupo/string/enumerate_palindromes.test.cpp
@@ -19,8 +19,7 @@ int main(void) {
     ans.erase(ans.begin());
     ans.pop_back();
     Dec >> ans;
-    for (int i = 0; i < (int)ans.size(); ++i)
-        std::cout << ans[i] << (i == (int)ans.size() - 1 ? '\n' : ' ');
+    for (int i = 0; i < (int)ans.size(); ++i) std::cout << ans[i] << (i == (int)ans.size() - 1 ? '\n' : ' ');
 
     return 0;
 }

--- a/test/yosupo/string/number_of_substring.2.test.cpp
+++ b/test/yosupo/string/number_of_substring.2.test.cpp
@@ -11,9 +11,7 @@ int main() {
     suffix_tree<char> st(s);
 
     long long ans = 0;
-    for (size_t i = 1; i < st.nodes.size(); ++i) {
-        ans += st.nodes[i].len();
-    }
+    for (size_t i = 1; i < st.nodes.size(); ++i) { ans += st.nodes[i].len(); }
 
     std::cout << ans << std::endl;
 

--- a/test/yosupo/string/number_of_substring.3.test.cpp
+++ b/test/yosupo/string/number_of_substring.3.test.cpp
@@ -10,9 +10,7 @@ int main(void) {
 
     suffix_automaton<char> sa(s);
     std::int64_t ans = 0;
-    for (int i = 1; i < sa.size(); ++i) {
-        ans += sa.nodes[i].len - sa.nodes[sa.nodes[i].link].len;
-    }
+    for (int i = 1; i < sa.size(); ++i) { ans += sa.nodes[i].len - sa.nodes[sa.nodes[i].link].len; }
     std::cout << ans << '\n';
 
     return 0;

--- a/test/yosupo/string/number_of_substring.4.test.cpp
+++ b/test/yosupo/string/number_of_substring.4.test.cpp
@@ -10,9 +10,7 @@ int main(void) {
 
     string_suffix_automaton<> sa(s);
     std::int64_t ans = 0;
-    for (int i = 1; i < sa.size(); ++i) {
-        ans += sa.nodes[i].len - sa.nodes[sa.nodes[i].link].len;
-    }
+    for (int i = 1; i < sa.size(); ++i) { ans += sa.nodes[i].len - sa.nodes[sa.nodes[i].link].len; }
     std::cout << ans << '\n';
 
     return 0;

--- a/test/yosupo/string/suffix_array.2.test.cpp
+++ b/test/yosupo/string/suffix_array.2.test.cpp
@@ -28,8 +28,7 @@ int main(void) {
         return s[x + l] < s[y + l];
     });
 
-    for (int i = 0; i < (int)ord.size(); ++i)
-        std::cout << ord[i] << (i == (int)ord.size() - 1 ? '\n' : ' ');
+    for (int i = 0; i < (int)ord.size(); ++i) std::cout << ord[i] << (i == (int)ord.size() - 1 ? '\n' : ' ');
 
     return 0;
 }

--- a/test/yosupo/string/suffix_array.test.cpp
+++ b/test/yosupo/string/suffix_array.test.cpp
@@ -8,8 +8,7 @@ int main(void) {
     std::string s;
     std::cin >> s;
     auto ans = suffix_array(s);
-    for (int i = 0; i < (int)ans.size(); ++i)
-        std::cout << ans[i] << (i == (int)ans.size() - 1 ? '\n' : ' ');
+    for (int i = 0; i < (int)ans.size(); ++i) std::cout << ans[i] << (i == (int)ans.size() - 1 ? '\n' : ' ');
 
     return 0;
 }

--- a/test/yosupo/string/zalgorithm.2.test.cpp
+++ b/test/yosupo/string/zalgorithm.2.test.cpp
@@ -23,8 +23,7 @@ int main(void) {
         }
         ans.emplace_back(l);
     }
-    for (int i = 0; i < (int)ans.size(); ++i)
-        std::cout << ans[i] << (i == (int)ans.size() - 1 ? '\n' : ' ');
+    for (int i = 0; i < (int)ans.size(); ++i) std::cout << ans[i] << (i == (int)ans.size() - 1 ? '\n' : ' ');
 
     return 0;
 }

--- a/test/yosupo/string/zalgorithm.test.cpp
+++ b/test/yosupo/string/zalgorithm.test.cpp
@@ -8,8 +8,7 @@ int main(void) {
     std::string s;
     std::cin >> s;
     auto ans = z_algorithm(s);
-    for (int i = 0; i < (int)ans.size(); ++i)
-        std::cout << ans[i] << (i == (int)ans.size() - 1 ? '\n' : ' ');
+    for (int i = 0; i < (int)ans.size(); ++i) std::cout << ans[i] << (i == (int)ans.size() - 1 ? '\n' : ' ');
 
     return 0;
 }

--- a/test/yosupo/tree/cartesian_tree.test.cpp
+++ b/test/yosupo/tree/cartesian_tree.test.cpp
@@ -12,8 +12,7 @@ int main(void) {
     for (int i = 0; i < n; ++i) {
         if (ans[i] == -1) ans[i] = i;
     }
-    for (int i = 0; i < (int)ans.size(); ++i)
-        std::cout << ans[i] << (i == (int)ans.size() - 1 ? '\n' : ' ');
+    for (int i = 0; i < (int)ans.size(); ++i) std::cout << ans[i] << (i == (int)ans.size() - 1 ? '\n' : ' ');
 
     return 0;
 }

--- a/test/yosupo/tree/tree_diameter.test.cpp
+++ b/test/yosupo/tree/tree_diameter.test.cpp
@@ -22,8 +22,7 @@ int main(void) {
         gl = p[gl];
     }
     std::cout << *std::max_element(d.begin(), d.end()) << ' ' << ans.size() << '\n';
-    for (int i = 0; i < (int)ans.size(); ++i)
-        std::cout << ans[i] << (i == (int)ans.size() - 1 ? '\n' : ' ');
+    for (int i = 0; i < (int)ans.size(); ++i) std::cout << ans[i] << (i == (int)ans.size() - 1 ? '\n' : ' ');
 
     return 0;
 }

--- a/test/yosupo/tree/tree_path_composite_sum.test.cpp
+++ b/test/yosupo/tree/tree_path_composite_sum.test.cpp
@@ -17,9 +17,7 @@ struct Monoid {
     using T = std::pair<Mint, Mint>;
     using value_type = T;
     static constexpr T id() { return T(); }
-    static constexpr T op(const T &lhs, const T &rhs) {
-        return {lhs.first + rhs.first, lhs.second + rhs.second};
-    }
+    static constexpr T op(const T &lhs, const T &rhs) { return {lhs.first + rhs.first, lhs.second + rhs.second}; }
 
     template <class U>
     static constexpr T f(const T &v, U u) {
@@ -42,8 +40,7 @@ int main(void) {
     ReRooting<Monoid, list_graph<std::pair<Mint, Mint>>, Mint> rr(g, a);
     std::vector<Mint> ans;
     for (int i = 0; i < n; ++i) ans.emplace_back(rr[i].first);
-    for (int i = 0; i < (int)ans.size(); ++i)
-        std::cout << ans[i] << (i == (int)ans.size() - 1 ? '\n' : ' ');
+    for (int i = 0; i < (int)ans.size(); ++i) std::cout << ans[i] << (i == (int)ans.size() - 1 ? '\n' : ' ');
 
     return 0;
 }

--- a/test/yosupo/tree/vertex_add_path_sum.test.cpp
+++ b/test/yosupo/tree/vertex_add_path_sum.test.cpp
@@ -2,8 +2,8 @@
 #include <cstdint>
 #include <iostream>
 #include <vector>
-#include "graph/edge_input.hpp"
 #include "binary_tree/fenwick_tree.hpp"
+#include "graph/edge_input.hpp"
 #include "tree/hld.hpp"
 
 int main(void) {

--- a/test/yosupo/tree/vertex_add_subtree_sum.2.test.cpp
+++ b/test/yosupo/tree/vertex_add_subtree_sum.2.test.cpp
@@ -3,9 +3,9 @@
 #include <utility>
 #include <vector>
 #include "binary_tree/fenwick_tree.hpp"
+#include "data_structure/union_find.hpp"
 #include "graph/edge_input.hpp"
 #include "tree/dsu_on_tree.hpp"
-#include "data_structure/union_find.hpp"
 
 int main(void) {
     int n, q;

--- a/test/yukicoder/0618.test.cpp
+++ b/test/yukicoder/0618.test.cpp
@@ -14,12 +14,8 @@ struct S {
 struct M {
     using T = S;
     using value_type = T;
-    static constexpr T id() {
-        return T(std::numeric_limits<std::int64_t>::max() / 2, 0);
-    }
-    static constexpr T op(const T& lhs, const T& rhs) {
-        return S{std::min(lhs.x, rhs.x), lhs.s + rhs.s};
-    }
+    static constexpr T id() { return T(std::numeric_limits<std::int64_t>::max() / 2, 0); }
+    static constexpr T op(const T &lhs, const T &rhs) { return S{std::min(lhs.x, rhs.x), lhs.s + rhs.s}; }
 };
 
 int main(void) {
@@ -31,10 +27,8 @@ int main(void) {
     std::int64_t s = 0;
     std::vector<std::int64_t> a;
     for (int i = 0; i < q; ++i) {
-        if (t[i] == 1)
-            a.emplace_back(x[i] - s);
-        else if (t[i] == 3)
-            s += x[i];
+        if (t[i] == 1) a.emplace_back(x[i] - s);
+        else if (t[i] == 3) s += x[i];
     }
 
     s = 0;
@@ -52,9 +46,7 @@ int main(void) {
         } else {
             s += x[i];
         }
-        auto f = [&](S y) {
-            return y.x + s >= y.s;
-        };
+        auto f = [&](S y) { return y.x + s >= y.s; };
         int k = st.min_left(f);
         auto t = st.prod(k, cps.size());
         std::int64_t ans = std::min(t.x + s, t.s);


### PR DESCRIPTION
## 概要

PR #288 は auto-merge が最初のコミットだけを拾って squash マージされ、後続の
2 コミット（field concept 制約・clang-format フック）が main に入らなかった。
本 PR でそれらを復元しつつ、リポジトリ全体を clang-format で一括整形する。

## 含む変更

1. **`internal::field` concept の復元** — 四則演算（除算含む）が閉じる「体」を
   opt-in マーカー `field_base` で表明。`modint_base` / `Fraction` が継承し、
   `berlekamp_massey` の `T` を `field` で制約（int/double を弾く）。
2. **clang-format の mise 管理 + pre-commit フック** — `.githooks/pre-commit` が
   ステージ済み `.cpp/.hpp` を整形して再 stage。`mise run setup` で `core.hooksPath`
   を設定。
3. **`lib/` `test/` の一括整形（74 ファイル）** — `.clang-format`（Google ベース）に
   準拠。以後の差分をクリーンに保つ。
4. **`.clang-format-ignore`** — `template/` は include 順が load-bearing
   （`template.hpp` の `<bits/stdc++.h>` が `macro.hpp` より前に来る必要がある）で、
   clang-format の include ソートが壊すため除外。

## 検証

- 整形した全 lib ヘッダ・全 test を `g++ -std=c++23 -fsyntax-only` でチェック → 全通過。
- `berlekamp_massey` が `int`/`double` を制約で弾き、`modint998` の verify テストが通ることを確認。
- pre-commit フックがコミット時に冪等に動く（再整形で差分を残さない）ことを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)