### PR TITLE
chore: download タスクにシステムテスト取得用の -a/--system フラグを追加

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -102,15 +102,18 @@ done
 # CWD をまたぐネストした `mise run` を避ける（random-check は checker/ 配下でも使う）。
 
 [tasks.download]
-description = "workspace でテストケースをダウンロード（oj d）"
+description = "workspace でテストケースをダウンロード（oj d、-a でシステムテスト）"
 alias = "ojd"
 dir = "{{config_root}}/workspace"
 usage = '''
+flag "-a --system" help="システムテスト（全テストケース）をダウンロードする"
 arg "<url>" help="問題ページの URL" required=#true
 '''
 run = """
 #!/bin/bash
-rm -rf test/ && oj d "$usage_url"
+oj_args=()
+[[ "$usage_system" == "true" ]] && oj_args+=(-a)
+rm -rf test/ && oj d "${oj_args[@]}" "$usage_url"
 """
 
 [tasks.new]


### PR DESCRIPTION
oj d にシステムテスト全件取得 (-a) を渡せるよう、download (ojd) タスクに
-a/--system フラグを追加。指定時のみ oj d に -a を付与する。

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
