### PR TITLE
perf: target を avx2,popcnt,lzcnt,bmi に整理し AtCoder(Zen) で遅い bmi2 を除外

### DIFF
--- a/lib/template/template.hpp
+++ b/lib/template/template.hpp
@@ -2,7 +2,7 @@
 #pragma GCC optimize("Ofast,fast-math,unroll-all-loops")
 #include <bits/stdc++.h>
 #if !defined(ATCODER) && !defined(EVAL)
-#pragma GCC target("sse4.2,avx2,bmi2")
+#pragma GCC target("avx2,popcnt,lzcnt,bmi")
 #endif
 template <class T, class U>
 constexpr bool chmax(T &a, const U &b) {


### PR DESCRIPTION
AtCoder ジャッジ(AMD Zen 系)では BMI2 の PDEP/PEXT がマイクロコード実装で
遅いため target から bmi2 を外す(lib/test 内に PDEP/PEXT 等の依存はなし)。
代わりに popcnt/lzcnt を明示し、std::popcount/__builtin_clz 系が BSR でなく
依存の浅い POPCNT/LZCNT(0 で安全)に展開されるようにする。bmi(BMI1: TZCNT/
ANDN/BLSI 等)は全 Zen で高速なため維持。sse4.2 は avx2 に包含されるため削除。

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
