### PR TITLE
feat: segment_tree に assign を追加

### DIFF
--- a/lib/segtree/segment_tree.hpp
+++ b/lib/segtree/segment_tree.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <algorithm>
 #include <bit>
 #include <cassert>
 #include <vector>
@@ -39,6 +40,17 @@ struct segment_tree {
         data = std::vector<T>(_size << 1, M::id());
         for (int i = 0; i < _n; ++i) data[_size + i] = T(v[i]);
         for (int i = _size - 1; i >= 1; --i) update(i);
+    }
+
+    // 確保済みの領域を保ったまま全要素を e で埋め直す（再確保せず木を再利用）
+    void assign(int n, T e = M::id()) {
+        assert(n <= _size);
+        _n = n;
+        std::fill(data.begin(), data.end(), M::id());
+        if (e != M::id()) {
+            std::fill(data.begin() + _size, data.begin() + _size + _n, e);
+            for (int i = _size - 1; i >= 1; --i) update(i);
+        }
     }
 
     const T &operator[](int k) const { return data[k + _size]; }


### PR DESCRIPTION
## 概要

`segment_tree` に `assign(n, e)` を追加した。確保済みの内部配列を再利用したまま全要素を `e`（既定は単位元）で埋め直す。セグ木をループ内で毎回作り直す代わりに使うと、再確保コストを省ける。

## 実装

- 全体を単位元 `id()` で埋めた後、葉 `[0, n)` を `e` で埋めて内部ノードを `update` で再構築する。
- `e == id()` のときは葉の fill と再構築を省略（全体 fill だけで完了）。

## 検証

- cap 1〜33・各 n・冪等 monoid（`Max`/`Min`）と非冪等 monoid（`Add`）、`e = id()` を含む正負の `e` について、`assign(n, e)` 後の全区間 `prod` が「サイズ `n` を `e` で構築したセグ木」と完全一致することを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)