### PR TITLE
feat: stern_brocot_tree に nearest と述語二分探索 search を追加

### DIFF
--- a/lib/tree/stern_brocot_tree.hpp
+++ b/lib/tree/stern_brocot_tree.hpp
@@ -14,9 +14,7 @@ struct sbt_fraction {
     constexpr sbt_fraction() : p(0), q(1) {}
     constexpr sbt_fraction(std::int64_t p, std::int64_t q) : p(p), q(q) {}
 
-    friend constexpr bool operator==(const sbt_fraction &a, const sbt_fraction &b) {
-        return a.p == b.p && a.q == b.q;
-    }
+    friend constexpr bool operator==(const sbt_fraction &a, const sbt_fraction &b) { return a.p == b.p && a.q == b.q; }
     friend constexpr auto operator<=>(const sbt_fraction &a, const sbt_fraction &b) {
         return (__int128)a.p * b.q <=> (__int128)b.p * a.q;
     }
@@ -126,8 +124,136 @@ struct stern_brocot_tree {
         return {0, 0};
     }
 
+    // 目標有理数 target (= p/q, 既約でなくてよい。0/1 や 1/0 も可) に最も近い、
+    // 分母が max_denominator 以下の既約分数を返す。距離が等しいときは値が小さい方。
+    // SBT を target に向かって降りる過程で、各方向への連続ステップ数を
+    // 「target を越えない最大回数」と「分母制約を超えない最大回数」の小さい方として
+    // 閉じた式で一括計算するため O(log) で求まる。比較は __int128。
+    static fraction nearest(fraction target, std::int64_t max_denominator) {
+        using i128 = __int128;
+        const i128 R = target.p, D = target.q, N = max_denominator;
+        // target との符号付きクロス差 p*D - R*q (0 で一致)。
+        auto diff = [&](i128 p, i128 q) { return p * D - R * q; };
+
+        stern_brocot_tree t;
+        while (true) {
+            // 境界がちょうど target なら距離 0 で確定 (分母 <= N なら採用)。
+            if (t.lo.q != 0 && diff(t.lo.p, t.lo.q) == 0 && t.lo.q <= N) return t.lo;
+            if (t.hi.q != 0 && diff(t.hi.p, t.hi.q) == 0 && t.hi.q <= N) return t.hi;
+
+            fraction m = t.value();
+            i128 dm = diff(m.p, m.q);
+            if (dm == 0) {
+                if (m.q <= N) return m;
+                break;  // メディアントは target だが分母超過 -> 境界で判定
+            }
+            if (dm < 0) {
+                // メディアント < target: 右へ lo += k*hi。
+                // k <= (R*lo.q - lo.p*D) / (hi.p*D - R*hi.q) で target を越えない。
+                i128 num = -diff(t.lo.p, t.lo.q);  // > 0
+                i128 den = diff(t.hi.p, t.hi.q);   // > 0 (hi > target)
+                i128 kr = num / den;
+                // hi.q == 0 (hi が +∞) のときは分母制約がかからない。
+                bool denom_free = (t.hi.q == 0);
+                i128 kn = denom_free ? kr : (N - t.lo.q) / t.hi.q;  // 分母 <= N
+                i128 k = denom_free ? kr : std::min(kr, kn);
+                if (k <= 0) break;
+                t.lo = {t.lo.p + (std::int64_t)k * t.hi.p, t.lo.q + (std::int64_t)k * t.hi.q};
+                if (!denom_free && k < kr) break;  // 分母制約で目標まで進めず終了
+            } else {
+                // メディアント > target: 左へ hi += k*lo。
+                i128 num = diff(t.hi.p, t.hi.q);   // > 0
+                i128 den = -diff(t.lo.p, t.lo.q);  // > 0 (lo < target)
+                i128 kr = num / den;
+                // lo.q == 0 はありえない (lo は常に有限) が、対称性のため同様に扱う。
+                bool denom_free = (t.lo.q == 0);
+                i128 kn = denom_free ? kr : (N - t.hi.q) / t.lo.q;
+                i128 k = denom_free ? kr : std::min(kr, kn);
+                if (k <= 0) break;
+                t.hi = {t.hi.p + (std::int64_t)k * t.lo.p, t.hi.q + (std::int64_t)k * t.lo.q};
+                if (!denom_free && k < kr) break;
+            }
+        }
+
+        // 残った両境界のうち分母 <= N のものから、target に近い方 (同距離なら小さい方) を選ぶ。
+        auto abs_diff = [&](fraction f) {
+            i128 v = diff(f.p, f.q);
+            return v < 0 ? -v : v;
+        };
+        fraction best{0, 0};
+        bool has = false;
+        auto consider = [&](fraction f) {
+            if (f.q == 0 || f.q > N) return;
+            if (!has) {
+                best = f, has = true;
+                return;
+            }
+            // |target - f| vs |target - best| : abs_diff(f)/f.q vs abs_diff(best)/best.q
+            i128 l = abs_diff(f) * best.q, r = abs_diff(best) * f.q;
+            if (l < r || (l == r && f < best)) best = f;
+        };
+        consider(t.lo);
+        consider(t.hi);
+        return best;
+    }
+
+    // 単調述語 pred に対する Stern-Brocot 二分探索。
+    // pred(p, q) は分数 p/q が小さいほど真になる単調述語 (pred(0/1) は真を仮定)。
+    // 「pred が真である最大の分数」のうち分母が max_denominator 以下のものを返す。
+    // 各方向の連続ステップ数を二分探索で一括処理するため、述語呼び出しは
+    // O(log^2 max_denominator) 回。pred の符号を反転すれば「偽になる最小の分数」も探せる。
+    template <class F>
+    static fraction search(F pred, std::int64_t max_denominator) {
+        const std::int64_t N = max_denominator;
+        fraction lo{0, 1}, hi{1, 0};  // pred(lo) は真。lo を最大化していく。
+        while (true) {
+            fraction m{lo.p + hi.p, lo.q + hi.q};  // mediant
+            if (m.q > N) break;                    // 分母上限を超える -> これ以上分割不可
+            if (pred(m.p, m.q)) {
+                // mediant が真 -> 答えは m 以上。右へ lo += k*hi を進める。
+                // lo + k*hi が真を保ち、かつ分母 lo.q + k*hi.q <= N となる最大 k (>=1)。
+                // hi.q==0 (hi=+∞) のときは分母が変わらないので分母制約なし -> 述語のみで止める。
+                std::int64_t hk = (hi.q == 0) ? step_cap(lo, hi) : (N - lo.q) / hi.q;
+                std::int64_t k = max_step(hk, [&](std::int64_t j) { return pred(lo.p + j * hi.p, lo.q + j * hi.q); });
+                lo = {lo.p + k * hi.p, lo.q + k * hi.q};
+                if (hi.q != 0 && k == hk) break;  // 分母上限に達した -> 確定
+            } else {
+                // mediant が偽 -> 答えは m 未満。左へ hi += k*lo を進める。
+                std::int64_t hk = (lo.q == 0) ? step_cap(hi, lo) : (N - hi.q) / lo.q;
+                std::int64_t k = max_step(hk, [&](std::int64_t j) { return !pred(hi.p + j * lo.p, hi.q + j * lo.q); });
+                hi = {hi.p + k * lo.p, hi.q + k * lo.q};
+                if (lo.q != 0 && k == hk) break;
+            }
+        }
+        return lo;
+    }
+
   private:
     fraction lo, hi;  // 子孫区間の左端・右端
+
+    // base + k*step の分子・分母が int64 を溢れさせない最大 k。
+    // step.q==0 (step=+∞) のときの右進み量の上限に使う。
+    static std::int64_t step_cap(fraction base, fraction step) {
+        constexpr std::int64_t LIM = (std::int64_t)4e18;
+        std::int64_t k = LIM;
+        if (step.p > 0) k = std::min(k, (LIM - base.p) / step.p);
+        if (step.q > 0) k = std::min(k, (LIM - base.q) / step.q);
+        return k;
+    }
+
+    // ok(j) が j について単調 (真->偽) なとき、ok(j) が真を保つ最大の j を
+    // [0, hk] の範囲で返す。ok(0) は真を仮定。倍々+二分で O(log hk) 回呼ぶ。
+    template <class G>
+    static std::int64_t max_step(std::int64_t hk, G ok) {
+        if (hk <= 0) return 0;
+        if (ok(hk)) return hk;         // 範囲端まで真
+        std::int64_t lo = 0, hi = hk;  // ok(lo)=true, ok(hi)=false
+        while (hi - lo > 1) {
+            std::int64_t mid = lo + (hi - lo) / 2;
+            (ok(mid) ? lo : hi) = mid;
+        }
+        return lo;
+    }
 
     // 子へ k 回降りる。'L' なら右端を左端側へ、'R' なら左端を右端側へ k 回寄せる。
     constexpr void descend(char c, std::int64_t k) {


### PR DESCRIPTION
## 概要

`stern_brocot_tree` に SBT 上の探索プリミティブを 2 つ追加した。

## 追加 API

### `nearest(target, max_denominator)`
目標有理数 `target`（既約でなくてよい。`0/1`・`1/0` も可）に最も近い、分母が `max_denominator` 以下の既約分数を返す。距離が等しいときは値が小さい方。SBT を `target` に向かって降りつつ、各方向の連続ステップ数を「target を越えない最大回数」と「分母制約を超えない最大回数」の min として閉じた式で一括計算するため **O(log)**。比較は `__int128`。

### `search(pred, max_denominator)`
単調述語 `pred(p, q)`（小さい分数ほど真）が真である最大の分数で、分母 ≤ `max_denominator` のものを返す。各方向の連続ステップ数を二分探索で一括処理するため述語呼び出しは **O(log² max_denominator)**。`pred` の符号反転で「偽になる最小の分数」も探せる。

## 検証

- naive 実装とのランダム照合で全一致（`nearest` 4000 件・`search` 5000 件、target > 1・約分前・0 などを含む）。
- 応用問題のサンプルにも一致: [ABC294-F](https://atcoder.jp/contests/abc294/tasks/abc294_f)（`search`）, [ABC333-G](https://atcoder.jp/contests/abc333/tasks/abc333_g)（`nearest`）。
- `-Wall -Wextra` 警告なし。既存テスト（LC stern_brocot_tree / AOJ 1208）は無改修で通過。
- Library Checker に素直に対応する問題がないため verify は保留（ランダムテストで担保）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)