### PR TITLE
fix: leftist_heap/skew_heap の meld を O(log N) に戻し AOJ 2559 の TLE/MLE を解消

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -79,6 +79,10 @@ jobs:
       # SPLIT_SIZE must equal the number of matrix indices below.
       SPLIT_SIZE: "10"
     strategy:
+      # 1 つの shard が失敗しても他をキャンセルしない。fail-fast で巻き添え
+      # キャンセルすると result.json が欠けたまま docs-and-check に渡り、
+      # 不完全な結果で Check が緑になりうる。
+      fail-fast: false
       matrix:
         # prettier-ignore
         index:
@@ -161,9 +165,22 @@ jobs:
   docs-and-check:
     runs-on: ubuntu-latest
     needs: [verify]
+    # verify が失敗しても必ず走らせ、Check ステップで失敗を集約して
+    # このジョブ自体の結論に伝播させる。これを必須チェックに据えることで
+    # CI 失敗時のマージを確実にブロックする。
+    if: always()
     outputs:
       upload-pages: ${{steps.upload-pages.outcome == 'success'}}
     steps:
+      # verify matrix が 1 つでも成功以外なら、ここで即失敗させる。
+      # competitive-verifier の Check は欠損 shard を検知しないため、
+      # ジョブ結論への失敗伝播はこのガードに依存する。
+      - name: Guard against failed verify shards
+        if: needs.verify.result != 'success'
+        run: |
+          echo "verify ジョブが success ではありません: ${{ needs.verify.result }}"
+          exit 1
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 2147483647

--- a/lib/heap/leftist_heap.hpp
+++ b/lib/heap/leftist_heap.hpp
@@ -1,13 +1,17 @@
 #pragma once
+#include <deque>
 #include <functional>
+#include <memory>
 #include <utility>
 #include <vector>
 
 /// @brief leftist heap（融合可能ヒープ）
 /// @see http://hos.ac/blog/#blog0001
-/// @details ノードを `std::vector` のプールに置き `int` インデックスで連結する index-pool
-///          実装で、`new`/`delete` を一切行わない（コピー・ムーブも自動で正しい）。
-///          各ノードの rank（右脊柱の長さ）でバランスを保ち、`meld` は O(log N)。
+/// @details ノードをポインタで連結し、`meld` は右脊柱を辿って O(log N) で融合する。
+///          ノード実体は `std::deque` のプールが所有する（要素アドレスが安定し、
+///          `new`/`delete` を一切行わずリークもしない）。`meld` で別ヒープの要素を
+///          取り込む際は相手のプールを `shared_ptr` で延命するだけなので、プールを
+///          コピーせず連結は O(log N) のまま。
 ///          `Comp = std::less<>` で最大ヒープ、`std::greater<>` で最小ヒープ。
 /// @note `meld` は引数のヒープを空にして要素を取り込む破壊的操作。
 template <class T, class Comp = std::less<>>
@@ -15,19 +19,18 @@ struct leftist_heap {
   private:
     struct _node {
         T val;
-        int left, right;  // 子のプールインデックス（-1 で null）
+        _node *left, *right;
         int rank;
     };
-    static constexpr int nil = -1;
 
   public:
     using value_type = T;
 
-    leftist_heap() : pool(), root(nil), _size(), comp() {}
+    leftist_heap() : pool(std::make_shared<std::deque<_node>>()), root(nullptr), _size(), comp() {}
 
-    constexpr bool empty() const { return root == nil; }
+    constexpr bool empty() const { return root == nullptr; }
     constexpr int size() const { return _size; }
-    T top() const { return pool[root].val; }
+    T top() const { return root->val; }
 
     void push(const T &val) { root = meld(root, make_node(val)), ++_size; }
     void push(T &&val) { root = meld(root, make_node(std::move(val))), ++_size; }
@@ -36,45 +39,41 @@ struct leftist_heap {
         root = meld(root, make_node(T(std::forward<Args>(args)...))), ++_size;
     }
 
-    void pop() { root = meld(pool[root].left, pool[root].right), --_size; }
+    void pop() { root = meld(root->left, root->right), --_size; }
 
-    // rhs を空にして、その全要素を自分へ取り込む。
+    // rhs を空にして、その全要素を自分へ取り込む。rhs のノードは rhs のプールが
+    // 所有しているので、そのプールを shared_ptr で延命して以後も参照できるようにする。
     void meld(leftist_heap &rhs) {
-        if (this == &rhs || rhs.root == nil) return;
-        int offset = (int)pool.size();
-        pool.insert(pool.end(), rhs.pool.begin(), rhs.pool.end());
-        // 取り込んだ側のインデックスを offset 分ずらす。
-        for (int i = offset; i < (int)pool.size(); ++i) {
-            if (pool[i].left != nil) pool[i].left += offset;
-            if (pool[i].right != nil) pool[i].right += offset;
-        }
-        root = meld(root, rhs.root + offset);
+        if (this == &rhs || rhs.root == nullptr) return;
+        if (rhs.pool != pool) extra_pools.push_back(rhs.pool);
+        root = meld(root, rhs.root);
         _size += rhs._size;
-        rhs.pool.clear();
-        rhs.root = nil;
+        rhs.root = nullptr;
         rhs._size = 0;
     }
 
   private:
-    std::vector<_node> pool;
-    int root;
+    std::shared_ptr<std::deque<_node>> pool;
+    // meld で取り込んだ相手のプールを延命するための保持先。
+    std::vector<std::shared_ptr<std::deque<_node>>> extra_pools;
+    _node *root;
     int _size;
     Comp comp;
 
-    int make_node(T val) {
-        pool.push_back({std::move(val), nil, nil, 0});
-        return (int)pool.size() - 1;
+    _node *make_node(T val) {
+        pool->push_back({std::move(val), nullptr, nullptr, 0});
+        return &pool->back();
     }
 
-    int rank(int x) const { return x == nil ? 0 : pool[x].rank; }
+    static int rank(const _node *x) { return x == nullptr ? 0 : x->rank; }
 
-    int meld(int a, int b) {
-        if (a == nil) return b;
-        if (b == nil) return a;
-        if (comp(pool[a].val, pool[b].val)) std::swap(a, b);
-        pool[a].right = meld(pool[a].right, b);
-        if (rank(pool[a].left) < rank(pool[a].right)) std::swap(pool[a].left, pool[a].right);
-        pool[a].rank = rank(pool[a].right) + 1;
+    _node *meld(_node *a, _node *b) {
+        if (a == nullptr) return b;
+        if (b == nullptr) return a;
+        if (comp(a->val, b->val)) std::swap(a, b);
+        a->right = meld(a->right, b);
+        if (rank(a->left) < rank(a->right)) std::swap(a->left, a->right);
+        a->rank = rank(a->right) + 1;
         return a;
     }
 };

--- a/lib/heap/skew_heap.hpp
+++ b/lib/heap/skew_heap.hpp
@@ -1,12 +1,17 @@
 #pragma once
+#include <deque>
 #include <functional>
+#include <memory>
 #include <utility>
 #include <vector>
 
 /// @brief skew heap（融合可能ヒープ）
 /// @see http://hos.ac/blog/#blog0001
-/// @details ノードを `std::vector` のプールに置き `int` インデックスで連結する index-pool
-///          実装で、`new`/`delete` を一切行わない（コピー・ムーブも自動で正しい）。
+/// @details ノードをポインタで連結し、`meld` は右脊柱を辿って融合する（ならし O(log N)）。
+///          ノード実体は `std::deque` のプールが所有する（要素アドレスが安定し、
+///          `new`/`delete` を一切行わずリークもしない）。`meld` で別ヒープの要素を
+///          取り込む際は相手のプールを `shared_ptr` で延命するだけなので、プールを
+///          コピーせず連結はならし O(log N) のまま。
 ///          `Comp = std::less<>` で最大ヒープ、`std::greater<>` で最小ヒープ。
 /// @note `meld` は引数のヒープを空にして要素を取り込む破壊的操作。
 template <class T, class Comp = std::less<>>
@@ -14,18 +19,17 @@ struct skew_heap {
   private:
     struct _node {
         T val;
-        int left, right;  // 子のプールインデックス（-1 で null）
+        _node *left, *right;
     };
-    static constexpr int nil = -1;
 
   public:
     using value_type = T;
 
-    skew_heap() : pool(), root(nil), _size(), comp() {}
+    skew_heap() : pool(std::make_shared<std::deque<_node>>()), root(nullptr), _size(), comp() {}
 
-    constexpr bool empty() const { return root == nil; }
+    constexpr bool empty() const { return root == nullptr; }
     constexpr int size() const { return _size; }
-    T top() const { return pool[root].val; }
+    T top() const { return root->val; }
 
     void push(const T &val) { root = meld(root, make_node(val)), ++_size; }
     void push(T &&val) { root = meld(root, make_node(std::move(val))), ++_size; }
@@ -34,42 +38,38 @@ struct skew_heap {
         root = meld(root, make_node(T(std::forward<Args>(args)...))), ++_size;
     }
 
-    void pop() { root = meld(pool[root].left, pool[root].right), --_size; }
+    void pop() { root = meld(root->left, root->right), --_size; }
 
-    // rhs を空にして、その全要素を自分へ取り込む。
+    // rhs を空にして、その全要素を自分へ取り込む。rhs のノードは rhs のプールが
+    // 所有しているので、そのプールを shared_ptr で延命して以後も参照できるようにする。
     void meld(skew_heap &rhs) {
-        if (this == &rhs || rhs.root == nil) return;
-        int offset = (int)pool.size();
-        pool.insert(pool.end(), rhs.pool.begin(), rhs.pool.end());
-        // 取り込んだ側のインデックスを offset 分ずらす。
-        for (int i = offset; i < (int)pool.size(); ++i) {
-            if (pool[i].left != nil) pool[i].left += offset;
-            if (pool[i].right != nil) pool[i].right += offset;
-        }
-        root = meld(root, rhs.root + offset);
+        if (this == &rhs || rhs.root == nullptr) return;
+        if (rhs.pool != pool) extra_pools.push_back(rhs.pool);
+        root = meld(root, rhs.root);
         _size += rhs._size;
-        rhs.pool.clear();
-        rhs.root = nil;
+        rhs.root = nullptr;
         rhs._size = 0;
     }
 
   private:
-    std::vector<_node> pool;
-    int root;
+    std::shared_ptr<std::deque<_node>> pool;
+    // meld で取り込んだ相手のプールを延命するための保持先。
+    std::vector<std::shared_ptr<std::deque<_node>>> extra_pools;
+    _node *root;
     int _size;
     Comp comp;
 
-    int make_node(T val) {
-        pool.push_back({std::move(val), nil, nil});
-        return (int)pool.size() - 1;
+    _node *make_node(T val) {
+        pool->push_back({std::move(val), nullptr, nullptr});
+        return &pool->back();
     }
 
-    int meld(int a, int b) {
-        if (a == nil) return b;
-        if (b == nil) return a;
-        if (comp(pool[a].val, pool[b].val)) std::swap(a, b);
-        pool[a].right = meld(pool[a].right, b);
-        std::swap(pool[a].left, pool[a].right);
+    _node *meld(_node *a, _node *b) {
+        if (a == nullptr) return b;
+        if (b == nullptr) return a;
+        if (comp(a->val, b->val)) std::swap(a, b);
+        a->right = meld(a->right, b);
+        std::swap(a->left, a->right);
         return a;
     }
 };


### PR DESCRIPTION
## 概要

PR #302 の heap 再設計（index-pool 化）で `leftist_heap` / `skew_heap` の
`meld(Heap&)` が **相手の pool 全体をコピー結合する実装**になり、累積 meld で
**O(N²) 時間・メモリ**に退行していた。`pop` 済みの死にノードも pool に残り続け、
meld 毎に丸ごとコピーされるのが原因。

これにより `test/aoj/challenge/2559.test.cpp`（skew）/ `2559.2.test.cpp`（leftist）の
`90_antidfs` ケースで TLE/MLE → GitHub Actions runner がキャンセルし、verify が
失敗していた（`main` の commit `91588be` 以降で再現、直前の `3dc624ba` は success）。

## 修正

- ノード連結を **ポインタベース**に戻し `meld` を右脊柱 O(log N)（skew はならし）に。
- ノード実体は `std::deque` プールが所有（要素アドレス安定・`new`/`delete` 不要・リークなし）。
- meld 時は相手の pool を `shared_ptr` で延命するだけにして **プールコピーを排除**。

## 検証（ローカル）

`std::priority_queue` と突き合わせて push/pop/meld の正しさを確認。連鎖 meld の性能:

| 実装 | N | 時間 | 最大メモリ |
|---|---|---|---|
| 旧 (#302) | 20,000 | 2029 ms | 3.1 GB |
| 新 | 200,000 | ~130 ms | 数MB |

## ワークフロー修正も同梱

`docs-and-check` に `if: always()` + verify 失敗ガードを追加し、`fail-fast: false` で
shard の巻き添えキャンセルを防止。これにより CI 失敗が必須チェックを通じて確実に
マージをブロックする（このバグを実際に検出した）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)