### PR TITLE
improve: cht を規約準拠に書き直し overflow 安全化、yukicoder 703/952 で verify

### DIFF
--- a/lib/dp/cht.hpp
+++ b/lib/dp/cht.hpp
@@ -1,43 +1,64 @@
-#include "template/template.hpp"
+#pragma once
+#include <cassert>
+#include <functional>
+#include <type_traits>
+#include <utility>
+#include <vector>
 
-/**
- * @brief Convex Hull Trick
- *
- * Usage:
- * CHT cht(ll(1e13), [](ll l, ll r) { return l >= r; });
- *
- * @tparam T 要素の型
- * @tparam Comp 比較関数
- */
-template <class T, class Comp>
-struct CHT {
-    CHT(T _e, Comp _comp) : comp(_comp) { lines.emplace_back(0, _e); };
-
+/// @brief Convex Hull Trick (monotone)
+///
+/// 直線 $ax+b$ を傾き単調順に add し、任意の $x$ における最小値（または最大値）を
+/// 二分探索で求める。最小値は `Comp = std::less<>`（既定）で傾きを単調減少順、
+/// 最大値は `Comp = std::greater<>` で傾きを単調増加順に add すること。
+/// クエリ `get(x)` の $x$ は任意の順で与えてよい。
+template <class T, class Comp = std::less<T>>
+struct cht {
+    /// @brief 直線 $ax+b$ を追加する（傾きは単調順）
     void add(T a, T b) {
-        std::pair<T, T> line(a, b);
-        while (lines.size() >= 2 && check(*(lines.end() - 2), lines.back(), line)) lines.pop_back();
-        lines.emplace_back(line);
+        line_t line{a, b};
+        if (!lines.empty() && lines.back().a == a) {
+            // 同じ傾きはより良い切片だけ残す
+            if (!comp(b, lines.back().b)) return;
+            lines.pop_back();
+        }
+        while (lines.size() >= 2 && bad(lines[lines.size() - 2], lines.back(), line)) lines.pop_back();
+        lines.push_back(line);
     }
 
-    T f(int i, T x) { return lines[i].first * x + lines[i].second; }
-    T f(std::pair<T, T> line, T x) { return line.first * x + line.second; }
-
-    T get(T x) {
-        int low = -1, high = lines.size() - 1;
-        while (high - low > 1) {
-            int mid = (high + low) / 2;
-            if (comp(f(mid, x), f(mid + 1, x))) low = mid;
+    /// @brief $x$ における最小値（または最大値）
+    T get(T x) const {
+        assert(!lines.empty());
+        int low = 0, high = static_cast<int>(lines.size()) - 1;
+        while (low < high) {
+            int mid = (low + high) / 2;
+            if (comp(f(lines[mid + 1], x), f(lines[mid], x))) low = mid + 1;
             else high = mid;
         }
-        return f(high, x);
+        return f(lines[low], x);
     }
 
+    bool empty() const { return lines.empty(); }
+
   private:
-    std::vector<std::pair<T, T>> lines;
+    struct line_t {
+        T a, b;
+    };
+
+    std::vector<line_t> lines;
     Comp comp;
 
-    bool check(std::pair<T, T> l1, std::pair<T, T> l2, std::pair<T, T> l3) {
-        if (l1 < l3) swap(l1, l3);
-        return (l3.second - l2.second) * (l2.first - l1.first) >= (l2.second - l1.second) * (l3.first - l2.first);
+    static T f(const line_t &line, T x) { return line.a * x + line.b; }
+
+    // 中央の直線 l2 が l1, l3 に隠れて不要かどうかを判定する。
+    // 直線 (l1,l2) と (l2,l3) の交点 x 座標が逆順なら l2 は包絡線に現れない。
+    // 交点比較を割り算なしの掛け算で行う（整数型では __int128 で桁あふれを防ぐ）。
+    // min（傾き単調減少）・max（傾き単調増加）のどちらの追加順でも同じ式で判定できる。
+    static bool bad(const line_t &l1, const line_t &l2, const line_t &l3) {
+        if constexpr (std::is_integral_v<T>) {
+            return static_cast<__int128>(l2.b - l1.b) * (l2.a - l3.a) >=
+                   static_cast<__int128>(l3.b - l2.b) * (l1.a - l2.a);
+        } else {
+            return (l2.b - l1.b) * (l2.a - l3.a) >= (l3.b - l2.b) * (l1.a - l2.a);
+        }
     }
 };

--- a/test/yukicoder/0703.test.cpp
+++ b/test/yukicoder/0703.test.cpp
@@ -1,0 +1,28 @@
+// competitive-verifier: PROBLEM https://yukicoder.me/problems/no/703
+#include <cstdint>
+#include <iostream>
+#include <vector>
+#include "dp/cht.hpp"
+
+int main(void) {
+    int n;
+    std::cin >> n;
+    std::vector<std::int64_t> a(n), x(n), y(n);
+    for (auto &v : a) std::cin >> v;
+    for (auto &v : x) std::cin >> v;
+    for (auto &v : y) std::cin >> v;
+
+    // dp[i] = (a_i - x_j)^2 + y_j^2 + dp[j-1] の最小化
+    //       = a_i^2 + min_j ( (-2 x_j) a_i + (x_j^2 + y_j^2 + dp[j-1]) )
+    // 傾き -2 x_j は x の昇順より単調減少 → 最小値用 CHT
+    cht<std::int64_t> ch;
+    auto sq = [](std::int64_t v) { return v * v; };
+    std::vector<std::int64_t> dp(n);
+    for (int i = 0; i < n; ++i) {
+        std::int64_t prev = (i == 0 ? 0 : dp[i - 1]);
+        ch.add(-2 * x[i], sq(x[i]) + sq(y[i]) + prev);
+        dp[i] = ch.get(a[i]) + sq(a[i]);
+    }
+    std::cout << dp[n - 1] << '\n';
+    return 0;
+}

--- a/test/yukicoder/0952.test.cpp
+++ b/test/yukicoder/0952.test.cpp
@@ -1,0 +1,45 @@
+// competitive-verifier: PROBLEM https://yukicoder.me/problems/no/952
+#include <cstdint>
+#include <iostream>
+#include <utility>
+#include <vector>
+#include "dp/cht.hpp"
+
+// k 個の扉を開けたときの危険度（連続して開いた扉の和の二乗の総和）の最小値を
+// k = 1..N について求める。仮想的な仕切りを位置 0 と N+1 に置くと、
+// 仕切りを t 個使った dp は
+//   dp[t][i] = min_{l < i} dp[t-1][l] + (S[i-1] - S[l])^2
+//            = S[i-1]^2 + min_l ( (-2 S[l]) S[i-1] + (dp[t-1][l] + S[l]^2) )
+// となる。S は単調増加なので傾き -2 S[l] は単調減少 → 最小値用の単調 CHT。
+int main(void) {
+    int n;
+    std::cin >> n;
+    std::vector<std::int64_t> s(n + 1, 0);
+    for (int i = 1; i <= n; ++i) {
+        std::int64_t a;
+        std::cin >> a;
+        s[i] = s[i - 1] + a;
+    }
+
+    const std::int64_t inf = static_cast<std::int64_t>(4e18);
+    std::vector<std::int64_t> prev(n + 2, inf), ans(n + 1, inf);
+    prev[0] = 0;
+    for (int t = 1; t <= n; ++t) {
+        std::vector<std::int64_t> cur(n + 2, inf);
+        cht<std::int64_t> ch;
+        int l = 0;
+        for (int i = t; i <= n + 1; ++i) {
+            while (l <= i - 1) {
+                if (prev[l] < inf) ch.add(-2 * s[l], prev[l] + s[l] * s[l]);
+                ++l;
+            }
+            if (!ch.empty()) cur[i] = ch.get(s[i - 1]) + s[i - 1] * s[i - 1];
+        }
+        // 仕切り t 個 → 閉じた扉 t-1 個 → 開けた扉 k = N-(t-1)
+        ans[n - (t - 1)] = cur[n + 1];
+        prev = std::move(cur);
+    }
+
+    for (int k = 1; k <= n; ++k) std::cout << ans[k] << '\n';
+    return 0;
+}


### PR DESCRIPTION
## 概要

verify が無く旧スタイルだった `lib/dp/cht.hpp`（単調 CHT）を規約準拠に書き直し、オーバーフロー安全化し、yukicoder の二乗距離系 DP 2 問で verify を追加する。

## 変更内容

### `lib/dp/cht.hpp`
- `template/template.hpp` 依存とブロックコメント `/** */` を排し、`#pragma once` + 明示 include + `///`/`//` に統一（`swap`→`std::swap`）
- 凸性判定の交点比較を整数型では `__int128` で計算しオーバーフローを防止（値域 1e13 では旧 `ll` 乗算が破綻）。浮動小数点型は `if constexpr` で従来式にフォールバック
- 旧 `get` の二分探索方向が凸性判定と噛み合わず誤答していたのを単峰探索に整理。凸性判定式を min（傾き単調減少）・max（傾き単調増加）の双方で同一式で正しく動くよう導出
- 同傾きの劣加直線を `add` 時に除去し、二分探索の前提（単峰性）を保証
- sentinel 引数 `_e` を廃して既定構築の API に変更。`Comp = std::less<>` 既定（最小）、`std::greater<>` で最大

### verify 追加
- `test/yukicoder/0703.test.cpp`（ゴミ拾い Easy / 二乗距離）— 傾き −2xⱼ 単調の最小値 CHT
- `test/yukicoder/0952.test.cpp`（危険な火薬庫 / 区間和の二乗）— 仮想仕切りで層化し各層を最小値 CHT、N=3000 で 0.07s

## 検証
- ランダムテストで naive と全一致（distinct/equal 傾き × min/max、#952 は bit 全探索と 3000 ケース一致）
- 両 verify ともサンプル一致、`-Wall -Wextra -fsyntax-only` 通過、clang-format 適用済み

## 備考
- #704（Manhattan）は積項が無く累積 min で解け CHT 不要、#705（3 乗）は直線化不能のため verify 対象外
- line_add_get_min 系（オンライン任意順）は既存 `li_chao_tree.hpp` が担当

🤖 Generated with [Claude Code](https://claude.com/claude-code)