### PR TITLE
refactor: cht を convex_hull_trick にリネーム

### DIFF
--- a/lib/dp/convex_hull_trick.hpp
+++ b/lib/dp/convex_hull_trick.hpp
@@ -12,7 +12,7 @@
 /// 最大値は `Comp = std::greater<>` で傾きを単調増加順に add すること。
 /// クエリ `get(x)` の $x$ は任意の順で与えてよい。
 template <class T, class Comp = std::less<T>>
-struct cht {
+struct convex_hull_trick {
     /// @brief 直線 $ax+b$ を追加する（傾きは単調順）
     void add(T a, T b) {
         line_t line{a, b};

--- a/test/yukicoder/0703.test.cpp
+++ b/test/yukicoder/0703.test.cpp
@@ -2,7 +2,7 @@
 #include <cstdint>
 #include <iostream>
 #include <vector>
-#include "dp/cht.hpp"
+#include "dp/convex_hull_trick.hpp"
 
 int main(void) {
     int n;
@@ -15,7 +15,7 @@ int main(void) {
     // dp[i] = (a_i - x_j)^2 + y_j^2 + dp[j-1] の最小化
     //       = a_i^2 + min_j ( (-2 x_j) a_i + (x_j^2 + y_j^2 + dp[j-1]) )
     // 傾き -2 x_j は x の昇順より単調減少 → 最小値用 CHT
-    cht<std::int64_t> ch;
+    convex_hull_trick<std::int64_t> ch;
     auto sq = [](std::int64_t v) { return v * v; };
     std::vector<std::int64_t> dp(n);
     for (int i = 0; i < n; ++i) {

--- a/test/yukicoder/0952.test.cpp
+++ b/test/yukicoder/0952.test.cpp
@@ -3,7 +3,7 @@
 #include <iostream>
 #include <utility>
 #include <vector>
-#include "dp/cht.hpp"
+#include "dp/convex_hull_trick.hpp"
 
 // k 個の扉を開けたときの危険度（連続して開いた扉の和の二乗の総和）の最小値を
 // k = 1..N について求める。仮想的な仕切りを位置 0 と N+1 に置くと、
@@ -26,7 +26,7 @@ int main(void) {
     prev[0] = 0;
     for (int t = 1; t <= n; ++t) {
         std::vector<std::int64_t> cur(n + 2, inf);
-        cht<std::int64_t> ch;
+        convex_hull_trick<std::int64_t> ch;
         int l = 0;
         for (int i = t; i <= n + 1; ++i) {
             while (l <= i - 1) {


### PR DESCRIPTION
省略形 cht がフルネーム規約（li_chao_tree, slope_trick, monotone_minima）から
浮いていたためファイル名と struct 名を convex_hull_trick に統一。参照する
yukicoder 0703/0952 テストも追随。

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
