### PR TITLE
improve: 全方位木dp を森対応・concept化・2型対応し verify 追加、命名規約を確定

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,19 @@ g++ -std=c++23 -I lib -Wall -Wextra -fsyntax-only <test_file>
 - **標準ヘッダは明示 include**（`<bits/stdc++.h>` や `template/template.hpp` に依存しない）。
   - `template.hpp` への暗黙依存を外すと、それ経由で標準ヘッダを得ていたテストが
     壊れることがある → テスト側に明示 include を補う。
-- **`namespace` は snake_case**。
+- **命名規約: 「型は PascalCase、それ以外は snake_case」**。型/値（インスタンス・関数）の
+  区別をケースだけで符号化する方針。
+  - **型（`struct`/`class`）は PascalCase**: データ構造・モノイド・値型すべて。
+    例: `SegmentTree`、`UnionFind`、`ReRooting`、`Add`/`Min`/`Max`、`BitAnd`/`BitOr`/`BitXor`、
+    `Matrix`、`Point`。
+  - **それ以外は snake_case**: `namespace`、`concept`（std concept に倣う。型ではなく述語）、
+    関数（自由関数・メンバ関数。`begin`/`end`/`size` 等の STL interop も自然に満たす）、
+    メンバ型エイリアス（`value_type` 等）、変数。
+  - **テンプレート引数**は短い大文字 1〜数文字または PascalCase（`M`/`S`/`F`/`G`/`Comp` 等）。
+  - **移行は段階的に行う**。既存には snake_case の型名が多数残っている（`segment_tree`、
+    `union_find` など旧 ACL 流の名残）。これらを一括改名はしない。**そのライブラリを
+    変更するついでに、対象ファイルの型名を PascalCase へ改名し、`lib/`・`test/` 全体の
+    参照も同時に追随させる**（破壊的変更を中途半端に残さない方針に従う）。
 - C++20/23 機能を使う: SFINAE より **concept**、サイズは **`std::bit_ceil`**、円周率は **`std::numbers::pi`**。
 - コメントは行コメントで統一し、**ブロックコメント（`/** */` や `/* */`）は使わない**。
   - **Doxygen ドキュメントコメントは `///`**（`@brief` などを付ける説明）。

--- a/lib/tree/rerooting.hpp
+++ b/lib/tree/rerooting.hpp
@@ -1,11 +1,30 @@
 #pragma once
+#include <concepts>
 #include <vector>
 #include "graph/graph.hpp"
+#include "segtree/monoid.hpp"
+
+/// @brief 全方位木dp用モノイドの要件
+/// @details モノイド（子の集約 `op`・単位元 `id`）に加えて、辺を通す変換 `f(値, 辺重み)` と
+///          頂点で確定する変換 `g(値, 頂点データ)` を持つこと。`f` / `g` は関数テンプレートでも
+///          非テンプレートでもよい。
+/// @tparam M 判定対象のモノイド
+/// @tparam W 辺重みの型
+/// @tparam U 頂点データの型
+template <class M, class W, class U>
+concept rerooting_monoid = monoid<M> && requires(const typename M::value_type &v, const W &w, const U &u) {
+    { M::f(v, w) } -> std::convertible_to<typename M::value_type>;
+    { M::g(v, u) } -> std::convertible_to<typename M::value_type>;
+};
 
 /// @brief 全方位木dp
 /// @see https://algo-logic.info/tree-dp/
+/// @details 非連結（森）にも対応する。各連結成分をそれぞれ独立に処理する。
+/// @tparam M 全方位木dp用モノイド（`rerooting_monoid`）
 /// @tparam G 重み付きグラフ型（`list_graph<T>` / `csr_graph<T>` のいずれでも可）
+/// @tparam U 頂点データの型
 template <class M, weighted_graph_type G, class U>
+requires rerooting_monoid<M, graph_weight_t<G>, U>
 struct ReRooting {
   private:
     using Value = typename M::value_type;
@@ -34,73 +53,86 @@ struct ReRooting {
 
     // 反復版の dfs（再帰だと深い木でスタックオーバーフローしうる）。
     // 帰りがけに各頂点の集約値 ret[v] = M::g(op(子のdp), data[v]) を確定し、
-    // 親側の dp[親][自分への辺] を更新する。
+    // 親側の dp[親][自分への辺] を更新する。森に対応するため、未訪問の各頂点を根として回す。
     void dfs_iter() {
         int n = g_.size();
         std::vector<Value> ret(n, M::id());
         std::vector<Value> res(n, M::id());      // 各頂点の子 dp の op 集約
         std::vector<int> par(n, -1), pe(n, -1);  // 親と「親→自分」の辺添字
+        std::vector<bool> visited(n, false);     // 連結成分ごとに 1 度だけ根にするための訪問印
         struct frame {
             int v, p, idx;
         };
         std::vector<frame> stk;
         stk.reserve(n);
         for (int i = 0; i < n; ++i) dp[i] = std::vector<Value>(g_[i].size(), M::id());
-        stk.push_back({0, -1, 0});
-        while (!stk.empty()) {
-            frame &f = stk.back();
-            int v = f.v;
-            if (f.idx < (int)g_[v].size()) {
-                int i = f.idx++;
-                auto e = g_[v][i];
-                if (e.to() == f.p) continue;
-                par[e.to()] = v;
-                pe[e.to()] = i;
-                stk.push_back({e.to(), v, 0});
-            } else {
-                ret[v] = M::g(res[v], data[v]);
-                int p = par[v];
-                stk.pop_back();
-                if (p != -1) {
-                    dp[p][pe[v]] = M::f(ret[v], g_[p][pe[v]].weight());
-                    res[p] = M::op(res[p], dp[p][pe[v]]);
+        for (int s = 0; s < n; ++s) {
+            if (visited[s]) continue;
+            visited[s] = true;
+            stk.push_back({s, -1, 0});
+            while (!stk.empty()) {
+                frame &f = stk.back();
+                int v = f.v;
+                if (f.idx < (int)g_[v].size()) {
+                    int i = f.idx++;
+                    auto e = g_[v][i];
+                    if (e.to() == f.p) continue;
+                    par[e.to()] = v;
+                    pe[e.to()] = i;
+                    visited[e.to()] = true;
+                    stk.push_back({e.to(), v, 0});
+                } else {
+                    ret[v] = M::g(res[v], data[v]);
+                    int p = par[v];
+                    stk.pop_back();
+                    if (p != -1) {
+                        dp[p][pe[v]] = M::f(ret[v], g_[p][pe[v]].weight());
+                        res[p] = M::op(res[p], dp[p][pe[v]]);
+                    }
                 }
             }
         }
     }
 
     // 反復版の bfs（行きがけに親から伝播する dp_p を渡しながら values を確定）。
+    // 森に対応するため、未訪問の各頂点を根として回す。
     void bfs_iter() {
         int n = g_.size();
         std::vector<int> par(n, -1);
         std::vector<Value> dp_p_of(n, M::id());  // 各頂点が親から受け取る dp_p
+        std::vector<bool> visited(n, false);     // 連結成分ごとに 1 度だけ根にするための訪問印
         std::vector<int> stk;
         stk.reserve(n);
-        stk.push_back(0);
-        // 行きがけ順に処理（スタックでも順序非依存: values は各頂点 1 回書く）
-        while (!stk.empty()) {
-            int v = stk.back();
-            stk.pop_back();
-            int p = par[v];
-            Value dp_p = dp_p_of[v];
-            int deg = g_[v].size();
-            std::vector<Value> dp_r(deg + 1, M::id());
-            for (int i = deg - 1; i >= 0; --i) {
-                auto e = g_[v][i];
-                if (e.to() == p) dp[v][i] = M::f(dp_p, e.weight());
-                dp_r[i] = M::op(dp[v][i], dp_r[i + 1]);
-            }
-            Value dp_l = M::id();
-            for (int i = 0; i < deg; ++i) {
-                int u = g_[v][i].to();
-                if (u != p) {
-                    par[u] = v;
-                    dp_p_of[u] = M::g(M::op(dp_l, dp_r[i + 1]), data[v]);
-                    stk.push_back(u);
+        for (int s = 0; s < n; ++s) {
+            if (visited[s]) continue;
+            visited[s] = true;
+            stk.push_back(s);
+            // 行きがけ順に処理（スタックでも順序非依存: values は各頂点 1 回書く）
+            while (!stk.empty()) {
+                int v = stk.back();
+                stk.pop_back();
+                int p = par[v];
+                Value dp_p = dp_p_of[v];
+                int deg = g_[v].size();
+                std::vector<Value> dp_r(deg + 1, M::id());
+                for (int i = deg - 1; i >= 0; --i) {
+                    auto e = g_[v][i];
+                    if (e.to() == p) dp[v][i] = M::f(dp_p, e.weight());
+                    dp_r[i] = M::op(dp[v][i], dp_r[i + 1]);
                 }
-                dp_l = M::op(dp_l, dp[v][i]);
+                Value dp_l = M::id();
+                for (int i = 0; i < deg; ++i) {
+                    int u = g_[v][i].to();
+                    if (u != p) {
+                        par[u] = v;
+                        visited[u] = true;
+                        dp_p_of[u] = M::g(M::op(dp_l, dp_r[i + 1]), data[v]);
+                        stk.push_back(u);
+                    }
+                    dp_l = M::op(dp_l, dp[v][i]);
+                }
+                values[v] = M::g(dp_l, data[v]);
             }
-            values[v] = M::g(dp_l, data[v]);
         }
     }
 };

--- a/lib/tree/rerooting.hpp
+++ b/lib/tree/rerooting.hpp
@@ -4,22 +4,44 @@
 #include "graph/graph.hpp"
 #include "segtree/monoid.hpp"
 
+/// @brief 全方位木dp用モノイドの確定値型（`key_type`、省略時は `value_type`）
+/// @details 全方位木dp は 2 つの型を扱う:
+///          - `value_type`（集約型 Sum）: 単位元 `id` と `op` で畳み込まれる、部分木を集約した値の型。
+///          - `key_type`（確定値型 Key）: 頂点で `g` により確定した値（= 出力）の型。`f` の入力でもある。
+///          多くの問題は Sum = Key で済むため、`key_type` を省略すると `value_type` にフォールバックする。
+/// @tparam M モノイド
+template <class M>
+struct rerooting_key {
+    using type = typename M::value_type;
+};
+template <class M>
+requires requires { typename M::key_type; }
+struct rerooting_key<M> {
+    using type = typename M::key_type;
+};
+template <class M>
+using rerooting_key_t = typename rerooting_key<M>::type;
+
 /// @brief 全方位木dp用モノイドの要件
-/// @details モノイド（子の集約 `op`・単位元 `id`）に加えて、辺を通す変換 `f(値, 辺重み)` と
-///          頂点で確定する変換 `g(値, 頂点データ)` を持つこと。`f` / `g` は関数テンプレートでも
-///          非テンプレートでもよい。
+/// @details 集約型 `value_type` 上のモノイド（単位元 `id`・子の集約 `op`）に加えて、
+///          辺を通す変換 `f(確定値, 辺重み) -> 集約値` と、頂点で確定する変換
+///          `g(集約値, 頂点データ) -> 確定値` を持つこと。確定値型は `key_type`
+///          （省略時 `value_type`）。`f` / `g` は関数テンプレートでも非テンプレートでもよい。
 /// @tparam M 判定対象のモノイド
 /// @tparam W 辺重みの型
 /// @tparam U 頂点データの型
 template <class M, class W, class U>
-concept rerooting_monoid = monoid<M> && requires(const typename M::value_type &v, const W &w, const U &u) {
-    { M::f(v, w) } -> std::convertible_to<typename M::value_type>;
-    { M::g(v, u) } -> std::convertible_to<typename M::value_type>;
-};
+concept rerooting_monoid =
+    monoid<M> && requires(const rerooting_key_t<M> &k, const typename M::value_type &s, const W &w, const U &u) {
+        { M::f(k, w) } -> std::convertible_to<typename M::value_type>;
+        { M::g(s, u) } -> std::convertible_to<rerooting_key_t<M>>;
+    };
 
 /// @brief 全方位木dp
 /// @see https://algo-logic.info/tree-dp/
 /// @details 非連結（森）にも対応する。各連結成分をそれぞれ独立に処理する。
+///          集約型 `value_type` と確定値型 `key_type`（省略時 `value_type`）を区別でき、
+///          `operator[]` は確定値型を返す。
 /// @tparam M 全方位木dp用モノイド（`rerooting_monoid`）
 /// @tparam G 重み付きグラフ型（`list_graph<T>` / `csr_graph<T>` のいずれでも可）
 /// @tparam U 頂点データの型
@@ -27,7 +49,8 @@ template <class M, weighted_graph_type G, class U>
 requires rerooting_monoid<M, graph_weight_t<G>, U>
 struct ReRooting {
   private:
-    using Value = typename M::value_type;
+    using Sum = typename M::value_type;  // 集約型（id / op の対象、dp が保持する型）
+    using Key = rerooting_key_t<M>;      // 確定値型（g の結果・f の入力・出力）
 
   public:
     ReRooting(const G &g, const std::vector<U> &v) : g_(g), data(v), dp(g.size()), values(g.size()) { build(); }
@@ -42,8 +65,8 @@ struct ReRooting {
   private:
     G g_;
     const std::vector<U> &data;
-    std::vector<std::vector<Value>> dp;
-    std::vector<Value> values;
+    std::vector<std::vector<Sum>> dp;
+    std::vector<Key> values;
 
     void build() {
         if ((int)g_.size() == 0) return;
@@ -52,12 +75,13 @@ struct ReRooting {
     }
 
     // 反復版の dfs（再帰だと深い木でスタックオーバーフローしうる）。
-    // 帰りがけに各頂点の集約値 ret[v] = M::g(op(子のdp), data[v]) を確定し、
-    // 親側の dp[親][自分への辺] を更新する。森に対応するため、未訪問の各頂点を根として回す。
+    // 帰りがけに各頂点の確定値 ret[v] = M::g(op(子のdp), data[v]) を求め、
+    // 親側の dp[親][自分への辺] = M::f(ret[v], 辺重み) を更新する。
+    // 森に対応するため、未訪問の各頂点を根として回す。
     void dfs_iter() {
         int n = g_.size();
-        std::vector<Value> ret(n, M::id());
-        std::vector<Value> res(n, M::id());      // 各頂点の子 dp の op 集約
+        std::vector<Key> ret(n);                 // 各頂点の確定値（設定直後に親側で消費）
+        std::vector<Sum> res(n, M::id());        // 各頂点の子 dp の op 集約
         std::vector<int> par(n, -1), pe(n, -1);  // 親と「親→自分」の辺添字
         std::vector<bool> visited(n, false);     // 連結成分ごとに 1 度だけ根にするための訪問印
         struct frame {
@@ -65,7 +89,7 @@ struct ReRooting {
         };
         std::vector<frame> stk;
         stk.reserve(n);
-        for (int i = 0; i < n; ++i) dp[i] = std::vector<Value>(g_[i].size(), M::id());
+        for (int i = 0; i < n; ++i) dp[i] = std::vector<Sum>(g_[i].size(), M::id());
         for (int s = 0; s < n; ++s) {
             if (visited[s]) continue;
             visited[s] = true;
@@ -94,13 +118,13 @@ struct ReRooting {
         }
     }
 
-    // 反復版の bfs（行きがけに親から伝播する dp_p を渡しながら values を確定）。
+    // 反復版の bfs（行きがけに親から伝播する確定値 dp_p を渡しながら values を確定）。
     // 森に対応するため、未訪問の各頂点を根として回す。
     void bfs_iter() {
         int n = g_.size();
         std::vector<int> par(n, -1);
-        std::vector<Value> dp_p_of(n, M::id());  // 各頂点が親から受け取る dp_p
-        std::vector<bool> visited(n, false);     // 連結成分ごとに 1 度だけ根にするための訪問印
+        std::vector<Key> dp_p_of(n);          // 各頂点が親から受け取る確定値 dp_p（根では未使用）
+        std::vector<bool> visited(n, false);  // 連結成分ごとに 1 度だけ根にするための訪問印
         std::vector<int> stk;
         stk.reserve(n);
         for (int s = 0; s < n; ++s) {
@@ -112,15 +136,15 @@ struct ReRooting {
                 int v = stk.back();
                 stk.pop_back();
                 int p = par[v];
-                Value dp_p = dp_p_of[v];
+                Key dp_p = dp_p_of[v];
                 int deg = g_[v].size();
-                std::vector<Value> dp_r(deg + 1, M::id());
+                std::vector<Sum> dp_r(deg + 1, M::id());
                 for (int i = deg - 1; i >= 0; --i) {
                     auto e = g_[v][i];
                     if (e.to() == p) dp[v][i] = M::f(dp_p, e.weight());
                     dp_r[i] = M::op(dp[v][i], dp_r[i + 1]);
                 }
-                Value dp_l = M::id();
+                Sum dp_l = M::id();
                 for (int i = 0; i < deg; ++i) {
                     int u = g_[v][i].to();
                     if (u != p) {

--- a/lib/tree/rerooting.hpp
+++ b/lib/tree/rerooting.hpp
@@ -47,13 +47,13 @@ concept rerooting_monoid =
 /// @tparam U 頂点データの型
 template <class M, weighted_graph_type G, class U>
 requires rerooting_monoid<M, graph_weight_t<G>, U>
-struct ReRooting {
+struct Rerooting {
   private:
     using Sum = typename M::value_type;  // 集約型（id / op の対象、dp が保持する型）
     using Key = rerooting_key_t<M>;      // 確定値型（g の結果・f の入力・出力）
 
   public:
-    ReRooting(const G &g, const std::vector<U> &v) : g_(g), data(v), dp(g.size()), values(g.size()) { build(); }
+    Rerooting(const G &g, const std::vector<U> &v) : g_(g), data(v), dp(g.size()), values(g.size()) { build(); }
 
     const auto &operator[](int i) const { return values[i]; }
     auto &operator[](int i) { return values[i]; }

--- a/test/aoj/challenge/3163.test.cpp
+++ b/test/aoj/challenge/3163.test.cpp
@@ -30,7 +30,7 @@ int main(void) {
     edge_input<void> ei(n - 1);
     auto g = ei.to_undirected(n);
 
-    ReRooting<Monoid, csr_graph<void>, std::int64_t> rr(g, a);
+    Rerooting<Monoid, csr_graph<void>, std::int64_t> rr(g, a);
     for (int i = 0; i < n; ++i) std::cout << rr[i].first << '\n';
 
     return 0;

--- a/test/aoj/grl/tree_height.test.cpp
+++ b/test/aoj/grl/tree_height.test.cpp
@@ -27,7 +27,7 @@ int main() {
     list_graph<long long> g(n);
     g.input_edges(n - 1, 0);
     std::vector<int> data(n, 0);  // 頂点データは未使用（ダミー）
-    ReRooting<Monoid, list_graph<long long>, int> rr(g, data);
+    Rerooting<Monoid, list_graph<long long>, int> rr(g, data);
     for (int i = 0; i < n; ++i) std::cout << rr[i] << '\n';
     return 0;
 }

--- a/test/aoj/grl/tree_height.test.cpp
+++ b/test/aoj/grl/tree_height.test.cpp
@@ -1,0 +1,33 @@
+// competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/GRL_5_B
+#include <algorithm>
+#include <iostream>
+#include <vector>
+#include "graph/graph.hpp"
+#include "tree/rerooting.hpp"
+
+// 各頂点を根としたときの木の高さ（その頂点から最も遠い葉までの距離）。
+// op = max、f = 辺重みを足す、g = 集約値をそのまま返す（頂点データは使わない）。
+struct Monoid {
+    using value_type = long long;
+    static constexpr long long id() { return 0; }
+    static constexpr long long op(long long a, long long b) { return std::max(a, b); }
+    template <class W>
+    static constexpr long long f(long long v, W w) {
+        return v + w;
+    }
+    template <class U>
+    static constexpr long long g(long long v, U) {
+        return v;
+    }
+};
+
+int main() {
+    int n;
+    std::cin >> n;
+    list_graph<long long> g(n);
+    g.input_edges(n - 1, 0);
+    std::vector<int> data(n, 0);  // 頂点データは未使用（ダミー）
+    ReRooting<Monoid, list_graph<long long>, int> rr(g, data);
+    for (int i = 0; i < n; ++i) std::cout << rr[i] << '\n';
+    return 0;
+}

--- a/test/yosupo/tree/tree_path_composite_sum.test.cpp
+++ b/test/yosupo/tree/tree_path_composite_sum.test.cpp
@@ -37,7 +37,7 @@ int main(void) {
     for (auto &e : a) std::cin >> e;
     list_graph<std::pair<Mint, Mint>> g(n);
     g.input_edges(n - 1, 0);
-    ReRooting<Monoid, list_graph<std::pair<Mint, Mint>>, Mint> rr(g, a);
+    Rerooting<Monoid, list_graph<std::pair<Mint, Mint>>, Mint> rr(g, a);
     std::vector<Mint> ans;
     for (int i = 0; i < n; ++i) ans.emplace_back(rr[i].first);
     for (int i = 0; i < (int)ans.size(); ++i) std::cout << ans[i] << (i == (int)ans.size() - 1 ? '\n' : ' ');

--- a/test/yukicoder/1718.test.cpp
+++ b/test/yukicoder/1718.test.cpp
@@ -1,0 +1,65 @@
+// competitive-verifier: PROBLEM https://yukicoder.me/problems/no/1718
+#include <algorithm>
+#include <iostream>
+#include <vector>
+#include "graph/graph.hpp"
+#include "tree/rerooting.hpp"
+
+// 各始点 X について、全どんぐり頂点を訪れる最小移動数を求める。
+// 戻る必要はないので、答 = 2 * |Steiner木(どんぐり ∪ {X}) の辺数| - max(X からどんぐりまでの距離)。
+//   - 2 * 辺数 は全辺を往復する分、最後に一番遠いどんぐりへ向かう枝だけ片道で済むので max を引く。
+
+// E(X) = Steiner木(どんぐり ∪ {X}) の辺数。集約型 ESum と確定値型 EKey を分ける 2 型モノイド。
+struct ESum {
+    bool has;         // この方向（複数方向の集約）にどんぐりがあるか
+    long long edges;  // この方向が X の Steiner 木に寄与する辺数
+};
+struct EKey {
+    bool has;     // この部分木にどんぐりがあるか
+    long long s;  // この部分木の内部にある Steiner 辺数
+};
+struct EMonoid {
+    using value_type = ESum;
+    using key_type = EKey;
+    static ESum id() { return {false, 0}; }
+    static ESum op(const ESum &a, const ESum &b) { return {a.has || b.has, a.edges + b.edges}; }
+    // 辺を渡る: 子部分木にどんぐりがあれば「辺 1 本 + 内部の Steiner 辺」が寄与する。
+    template <class W>
+    static ESum f(const EKey &k, W) {
+        return {k.has, k.has ? k.s + 1 : 0};
+    }
+    // 頂点で確定: 自身がどんぐりなら has を立てる。内部 Steiner 辺数は子方向の寄与の総和。
+    static EKey g(const ESum &s, int is_acorn) { return {is_acorn != 0 || s.has, s.edges}; }
+};
+
+// maxdist(X) = X から最も遠いどんぐりまでの距離（辺数）。max モノイド。
+struct DMonoid {
+    using value_type = long long;
+    static constexpr long long NEG = -(1LL << 60);  // どんぐり無しの番兵
+    static long long id() { return NEG; }
+    static long long op(long long a, long long b) { return std::max(a, b); }
+    template <class W>
+    static long long f(long long v, W) {
+        return v + 1;
+    }
+    static long long g(long long v, int is_acorn) { return std::max(v, is_acorn != 0 ? 0LL : NEG); }
+};
+
+int main() {
+    int n, k;
+    std::cin >> n >> k;
+    csr_graph<void> g(n);
+    g.input_edges(n - 1);  // 1-indexed・重みなし無向辺
+    std::vector<int> acorn(n, 0);
+    for (int i = 0; i < k; ++i) {
+        int d;
+        std::cin >> d;
+        acorn[d - 1] = 1;
+    }
+
+    ReRooting<EMonoid, csr_graph<void>, int> rr_e(g, acorn);
+    ReRooting<DMonoid, csr_graph<void>, int> rr_d(g, acorn);
+    for (int x = 0; x < n; ++x) std::cout << 2 * rr_e[x].s - rr_d[x] << '\n';
+
+    return 0;
+}

--- a/test/yukicoder/1718.test.cpp
+++ b/test/yukicoder/1718.test.cpp
@@ -57,8 +57,8 @@ int main() {
         acorn[d - 1] = 1;
     }
 
-    ReRooting<EMonoid, csr_graph<void>, int> rr_e(g, acorn);
-    ReRooting<DMonoid, csr_graph<void>, int> rr_d(g, acorn);
+    Rerooting<EMonoid, csr_graph<void>, int> rr_e(g, acorn);
+    Rerooting<DMonoid, csr_graph<void>, int> rr_d(g, acorn);
     for (int x = 0; x < n; ++x) std::cout << 2 * rr_e[x].s - rr_d[x] << '\n';
 
     return 0;


### PR DESCRIPTION
全方位木dp（`Rerooting`）の機能拡張・検証追加と、それに付随する命名規約の確定。

## ライブラリ変更（`lib/tree/rerooting.hpp`）
- **森（非連結）対応**: 連結成分ごとに DFS/BFS を回し、非連結でも全頂点の値を確定（O(N) 維持）。
- **concept 化**: 型引数 `M` を無制約から `rerooting_monoid<M, 辺重み型, U>` 制約へ（`monoid` に加え `f`/`g` を要求）。
- **2 型対応**: 集約型 `value_type`(Sum) と確定値型 `key_type`(Key) を分離。`key_type` 省略時は `value_type` にフォールバックするため、単一型の既存利用は無改変。
- **リネーム**: `ReRooting` → `Rerooting`（"rerooting" は接頭辞 re- の 1 語なので内部大文字なしが正しい綴り。`rerooting.hpp`/`rerooting_monoid`/`rerooting_key_t` と語幹が一致）。

## verify 追加
- **AOJ GRL_5_B（木の高さ）**: max モノイドを検証（既存の sum 系とは別演算）。
- **yukicoder No.1718（Random Squirrel）**: 2 型モノイド + max モノイド。`key_type` による 2 型対応を判定機で初めて検証。

いずれも公式サンプル一致＋ランダムテストで naive/brute と突き合わせ済み。森対応・2型はジャッジに該当問題がないためランダムテストで担保。

## 命名規約の確定（`CLAUDE.md`）
- 「**型は PascalCase、それ以外（concept・関数・namespace・メンバ型エイリアス・変数）は snake_case**」を明文化。テンプレート引数は短い大文字。
- 既存の snake_case 型は一括改名せず、**該当ライブラリを変更する際に PascalCase 化し参照も追随**する段階移行とする。

🤖 Generated with [Claude Code](https://claude.com/claude-code)