### PR TITLE
docs: CLAUDE.md を圧縮しルールを保ったままトークンを削減

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,8 +3,8 @@
 競技プログラミング用の C++ ヘッダオンリーライブラリ。`lib/` に実装、`test/` に
 [competitive-verifier](https://github.com/competitive-verifier/competitive-verifier) 用の検証ファイル。
 
-- 言語: **C++23**（応答・コメントは日本語）
-- include ルートは **`lib/`**。ヘッダ間は `lib/` からの相対パス（例: `#include "math/modint.hpp"`）
+- 言語: **C++23**（応答・コメントは日本語）。
+- include ルートは **`lib/`**。ヘッダ間は `lib/` からの相対パス（例: `#include "math/modint.hpp"`）。
 
 ## ビルド・テスト
 
@@ -12,113 +12,68 @@
 g++ -std=c++23 -I lib -Wall -Wextra -fsyntax-only <test_file>
 ```
 
-正しさはランダムテストで naive 実装と突き合わせて確認する。
-
-### verify 用問題を探す優先順位
-
-ライブラリの verify 用問題は次の優先順位で探す:
-
-1. **Library Checker**（<https://judge.yosupo.jp/>）
-2. **yukicoder**（<https://yukicoder.me/>）
-3. **AOJ**（Aizu Online Judge）
-
-どのジャッジにも素直に対応する問題がなければ verify は保留する
-（competitive-verifier の UNIT_TEST は使わない）。
+- 正しさはランダムテストで naive 実装と突き合わせる。
+- verify 用問題は **Library Checker → yukicoder → AOJ** の順で探す。素直に対応する問題が
+  なければ verify は保留（competitive-verifier の UNIT_TEST は使わない）。
 
 ## コーディング規約
 
 - 全ヘッダ先頭に **`#pragma once`**。
 - **標準ヘッダは明示 include**（`<bits/stdc++.h>` や `template/template.hpp` に依存しない）。
-  - `template.hpp` への暗黙依存を外すと、それ経由で標準ヘッダを得ていたテストが
-    壊れることがある → テスト側に明示 include を補う。
-- **命名規約: 「型は PascalCase、それ以外は snake_case」**。型/値（インスタンス・関数）の
-  区別をケースだけで符号化する方針。
-  - **型（`struct`/`class`）は PascalCase**: データ構造・モノイド・値型すべて。
-    例: `SegmentTree`、`UnionFind`、`ReRooting`、`Add`/`Min`/`Max`、`BitAnd`/`BitOr`/`BitXor`、
-    `Matrix`、`Point`。
-  - **それ以外は snake_case**: `namespace`、`concept`（std concept に倣う。型ではなく述語）、
-    関数（自由関数・メンバ関数。`begin`/`end`/`size` 等の STL interop も自然に満たす）、
-    メンバ型エイリアス（`value_type` 等）、変数。
-  - **テンプレート引数**は短い大文字 1〜数文字または PascalCase（`M`/`S`/`F`/`G`/`Comp` 等）。
-  - **移行は段階的に行う**。既存には snake_case の型名が多数残っている（`segment_tree`、
-    `union_find` など旧 ACL 流の名残）。これらを一括改名はしない。**そのライブラリを
-    変更するついでに、対象ファイルの型名を PascalCase へ改名し、`lib/`・`test/` 全体の
-    参照も同時に追随させる**（破壊的変更を中途半端に残さない方針に従う）。
-- C++20/23 機能を使う: SFINAE より **concept**、サイズは **`std::bit_ceil`**、円周率は **`std::numbers::pi`**。
-- コメントは行コメントで統一し、**ブロックコメント（`/** */` や `/* */`）は使わない**。
-  - **Doxygen ドキュメントコメントは `///`**（`@brief` などを付ける説明）。
-  - **通常の実装コメントは `//`**。
+  暗黙依存を外してテストが壊れたら、テスト側に明示 include を補う。
+- **命名: 型は PascalCase、それ以外は snake_case**（ケースで型/値を区別）。
+  - 型（`struct`/`class`、データ構造・モノイド・値型）→ PascalCase（`SegmentTree`、`UnionFind`、
+    `Add`/`Min`/`BitXor`、`Matrix` 等）。
+  - `namespace`・`concept`（std 流の述語）・関数・メンバ型エイリアス（`value_type`）・変数 → snake_case。
+  - テンプレート引数 → 短い大文字または PascalCase（`M`/`S`/`F`/`Comp` 等）。
+  - 移行は段階的。一括改名はせず、**そのライブラリを変更するついでに型名を PascalCase 化し、
+    `lib/`・`test/` の参照も同時に追随**させる（旧 `segment_tree` 等の名残あり）。
+- C++20/23 を使う: SFINAE より **concept**、サイズは **`std::bit_ceil`**、円周率は **`std::numbers::pi`**。
+- コメントは行コメントのみ（ブロックコメント禁止）。Doxygen は **`///`**、実装コメントは **`//`**。
 - 浮動小数点→整数の丸めは **`std::llround`**（`T(x + 0.5)` は負値で誤る）。
-- グラフアルゴリズムは具体型に依存せず **`graph_type` / `weighted_graph_type` concept** で書き、
-  `list_graph<T>`・`csr_graph<T>` の両方に対応させる。
-- ヒープ（`lib/heap/`）の `Key`/`Value` 規約: **`Key` が順序基準**（`Comp` で比較する側・
-  radix の整数キー）、**`Value` が付随データ**。`push(key, value)` / `top() -> pair<key, value>` /
-  `update(handle, key)`。`shortest_path` では `Heap<距離, 頂点, Comp>` として使う。
-- **「付随データなし」を型引数 `void` で受ける場合、本体は `void` 部分特殊化で分けず
-  `std::conditional_t<is_void_v<V>, std::monostate, V>` に正規化して 1 本に保つ**
-  （`if constexpr` で API を出し分け、空メンバは `[[no_unique_address]]`）。例: `radix_heap`、
-  `doubling`。ただし `void` で**別のデータ構造**を選ぶ場合（`matrix_graph<void>` の
-  `vector<vector<bool>>` 最適化など）は、正規化せず部分特殊化のままにする。
+- グラフは **`graph_type` / `weighted_graph_type` concept** で書き、`list_graph<T>`・`csr_graph<T>` 両対応。
+- ヒープ（`lib/heap/`）規約: **`Key` が順序基準**（`Comp` 比較側・radix の整数キー）、**`Value` が付随データ**。
+  `push(key, value)` / `top() -> pair<key, value>` / `update(handle, key)`。`shortest_path` では `Heap<距離, 頂点, Comp>`。
+- 「付随データなし」の型引数 `void`: 本体は部分特殊化で分けず
+  `std::conditional_t<is_void_v<V>, std::monostate, V>` に正規化して 1 本化（API は `if constexpr`、
+  空メンバは `[[no_unique_address]]`）。例: `radix_heap`、`doubling`。ただし `void` で**別のデータ構造**を
+  選ぶ場合（`matrix_graph<void>` の `vector<vector<bool>>` 等）は部分特殊化のまま。
 
 ## フォーマット
 
-- 整形は **clang-format**（`.clang-format`、Google ベース）。clang-format は **mise 管理**
-  （`mise install` で導入）。
-- コミット時に **`.githooks/pre-commit`** がステージ済みの `.cpp`/`.hpp` を自動整形して
-  再 stage する。有効化は `git config core.hooksPath .githooks`（`mise run setup` に組込み済み）。
-- `lib/template/{atcoder,library_checker}.hpp` は `template/template.hpp`
-  （`<bits/stdc++.h>` を引く）を先頭に置く必要がある。`.clang-format` の `IncludeCategories`
-  で `template/template.hpp` に最優先（負 `Priority`）を与え、ソートを効かせたまま先頭固定して
-  いるので、`template/` も通常どおり整形してよい。
+- **clang-format**（`.clang-format`、Google ベース、mise 管理）。`.githooks/pre-commit` が
+  ステージ済み `.cpp`/`.hpp` を自動整形して再 stage（`mise run setup` で有効化済み）。
+- `lib/template/{atcoder,library_checker}.hpp` は `template/template.hpp`（`<bits/stdc++.h>`）を
+  先頭に置く。`.clang-format` の `IncludeCategories` が負 `Priority` で先頭固定するので `template/` も通常整形でよい。
 
 ## ライブラリ変更の方針
 
-- 個人用ライブラリなので、**後方互換性のために妥協しない**。設計・命名・API をより良く
-  できるなら、破壊的変更（リネーム・シグネチャ変更・削除・再構成）を積極的に行う。
-- 破壊的変更の際は、リポジトリ全体（`lib/`・`test/`）から参照箇所を洗い出して
-  **呼び出し側もすべて追随させる**。古い API を中途半端に残さない。
-- **計算量を悪化させる変更はしない**。リファクタやバグ修正であっても、各操作の
-  時間計算量を既存より悪くしてはならない（例: O(log N) を O(N) にする、
-  定数倍を大きく増やす）。可読性・簡潔さと計算量がトレードオフになる場合は計算量を
-  優先する。計算量を変える必要があるなら、その妥当性を明示して合意を取ること。
-  - 空間計算量は実用に影響がない範囲では考慮しなくてよい。ただしこれは必要以上に
-    領域を使ってよいという意味ではなく、不要なコピーや確保は引き続き避ける。
+- 個人用ライブラリ。**後方互換性のために妥協しない**——設計・命名・API を良くできるなら
+  破壊的変更（リネーム・シグネチャ変更・削除・再構成）を積極的に行う。
+- 破壊的変更時は `lib/`・`test/` から参照を洗い出し**呼び出し側もすべて追随**。古い API を中途半端に残さない。
+- **計算量を悪化させない**。リファクタ・バグ修正でも各操作の時間計算量を既存より悪くしない
+  （可読性とトレードオフなら計算量優先。変える必要があれば妥当性を示して合意を取る）。
+  空間計算量は実用範囲では問わないが、不要なコピー・確保は避ける。
 
 ## Git・PR 運用
 
 ### ブランチ
-
-- **`main` には直接コミットしない**。ブランチ保護で `main` への push は弾かれるため、
-  作業は必ず新しいブランチを切ってそこにコミットする（`git switch -c <branch>`）。
-- **新しいブランチは必ず最新の `main` から切る**。別の作業ブランチ（特に PR が
-  squash マージ済みのブランチ）の上から切らない。squash マージ後はそのブランチの
-  コミットが `main` の履歴と別物になり、同じ変更が二重に乗ってマージ時にコンフリクト
-  する。先に `git switch main && git pull`（または `git fetch origin main`）してから
-  `git switch -c <branch> origin/main` で切ること。
-- **PR を作成していない作業ブランチを勝手に切り替えない**。コミット済みでも未 PR の
-  ブランチは作業中扱いとし、そのブランチ上で作業を続ける。`git switch` で別ブランチへ
-  移ったり `git stash` で退避したりするのは、ユーザが明示的に指示したとき
-  （ブランチ統合など）だけにする。
+- **`main` に直接コミットしない**（保護で push が弾かれる）。`git switch -c <branch>` で作業。
+- **新ブランチは必ず最新 `main` から切る**: `git switch main && git pull`（or `git fetch origin main`）→
+  `git switch -c <branch> origin/main`。squash マージ済みブランチ上から切るとコンフリクトする。
+- **未 PR の作業ブランチを勝手に切り替えない**。`git switch`/`git stash` はユーザの明示指示時のみ。
 
 ### コミット
+- **ひと区切りしたら指示を待たず自動コミット**（意味のある単位で、`main` 以外のブランチ上で）。
+- **PR を作成したブランチには追加コミットしない**（auto-merge で削除される）。新作業は別ブランチで。
 
-- **作業がひと区切りしたらコミットまでは自動で行う**。指示を待たずに、意味のある
-  単位でコミットメッセージを付けてコミットする（`main` 以外のブランチ上で）。
-- **PR を作成したブランチには新しくコミットしない**。PR 作成後は auto-merge で
-  「CI 通過 → bot 承認 → 自動マージ → ブランチ削除」まで自動進行するため、追加変更を
-  そのブランチに積むとマージ対象がずれたり削除済みブランチを掘り起こしたりする。
-  新しい作業は別のブランチを切って行う。
-
-### PR・マージ（ユーザが明示的に指示したときのみ）
-
-- **PR の作成はユーザが明示的に指示したときのみ**。指示があるまで作業はコミットまでで
-  止め、`gh pr create` / push / auto-merge は実行しない。
-- PR を作成したら必ず auto-merge を有効化する。
+### PR・マージ（ユーザの明示指示時のみ）
+- **PR 作成はユーザの明示指示時のみ**。それまでは push / auto-merge を実行しない。
+- PR を作成したら必ず auto-merge を有効化:
 
   ```sh
   gh pr create --fill && gh pr merge --auto --squash
   ```
 
-- リポジトリ側は auto-merge の前提が整っている（`allow_auto_merge` ON、必須チェック
-  `docs-and-check`、`pr-auto-approve.yml` が bot で自動承認）。これで「CI 通過 → bot 承認
-  → 自動マージ → ブランチ削除」まで全自動で完結する。
+  リポジトリは前提が整っており（`allow_auto_merge` ON、必須チェック `docs-and-check`、
+  `pr-auto-approve.yml` が bot 承認）、CI 通過 → 承認 → マージ → ブランチ削除まで全自動。


### PR DESCRIPTION
説明的な散文・重複・冗長な例示を削り、各規約の指示は全項目維持。
毎ターン全文がコンテキストに載るためセッションの固定コストを削減する。

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
