### PR TITLE
style: include 順を標準ヘッダ先頭に統一 (MainIncludeChar: AngleBracket)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -18,6 +18,9 @@ DerivePointerAlignment: false
 # atcoder.hpp のループマクロ。範囲 for と同様に整形させる（`rep (...) { ... }` の括弧前空白など）。
 ForEachMacros: ['rep', 'repn', 'repr', 'repnr']
 IncludeBlocks: Merge
+# 主ヘッダ判定を <...> 限定にして、引用符のライブラリヘッダが先頭固定されないようにする
+# （basename がファイル名と一致しても主ヘッダ扱いしない）。include 順は「標準 <...> 先頭」に統一。
+MainIncludeChar: AngleBracket
 # template/{atcoder,library_checker}.hpp は template/template.hpp（<bits/stdc++.h> を引く）を
 # 必ず先頭に置く必要がある。include ソートは効かせたまま最優先（負 Priority）で先頭固定する。
 IncludeCategories:

--- a/lib/graph/floyd_warshall.hpp
+++ b/lib/graph/floyd_warshall.hpp
@@ -1,6 +1,6 @@
 #pragma once
-#include "graph/matrix_graph.hpp"
 #include "template/template.hpp"
+#include "graph/matrix_graph.hpp"
 
 /// @brief ワーシャルフロイド法
 template <class T>

--- a/lib/tree/dsu_on_tree.hpp
+++ b/lib/tree/dsu_on_tree.hpp
@@ -1,9 +1,9 @@
 #pragma once
+#include "template/template.hpp"
 #include <cassert>
 #include <utility>
 #include <vector>
 #include "graph/graph.hpp"
-#include "template/template.hpp"
 
 /// @brief DSU on Tree
 /// @tparam G グラフ型（`list_graph<T>` / `csr_graph<T>` のいずれでも可）

--- a/lib/tree/link_cut_tree.hpp
+++ b/lib/tree/link_cut_tree.hpp
@@ -1,6 +1,6 @@
 #pragma once
-#include "segtree/monoid.hpp"
 #include "template/template.hpp"
+#include "segtree/monoid.hpp"
 
 /// @brief Link-Cut Tree
 template <monoid M>

--- a/test/aoj/alds1/dary_heap.test.cpp
+++ b/test/aoj/alds1/dary_heap.test.cpp
@@ -1,7 +1,7 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/ALDS1_9_C
-#include "heap/dary_heap.hpp"
 #include <iostream>
 #include <string>
+#include "heap/dary_heap.hpp"
 #include "template/sonic.hpp"
 
 int main(void) {

--- a/test/aoj/alds1/interval_heap.test.cpp
+++ b/test/aoj/alds1/interval_heap.test.cpp
@@ -1,7 +1,7 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/ALDS1_9_C
-#include "heap/interval_heap.hpp"
 #include <iostream>
 #include <string>
+#include "heap/interval_heap.hpp"
 #include "template/sonic.hpp"
 
 int main(void) {

--- a/test/aoj/alds1/inversion_number.test.cpp
+++ b/test/aoj/alds1/inversion_number.test.cpp
@@ -1,7 +1,7 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/ALDS1_5_D
-#include "algorithm/inversion_number.hpp"
 #include <iostream>
 #include <vector>
+#include "algorithm/inversion_number.hpp"
 
 int main(void) {
     int n;

--- a/test/aoj/alds1/kmp.test.cpp
+++ b/test/aoj/alds1/kmp.test.cpp
@@ -1,7 +1,7 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/ALDS1_14_B
-#include "string/kmp.hpp"
 #include <iostream>
 #include <string>
+#include "string/kmp.hpp"
 
 int main(void) {
     std::string s, t;

--- a/test/aoj/alds1/leftist_heap.test.cpp
+++ b/test/aoj/alds1/leftist_heap.test.cpp
@@ -1,7 +1,7 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/ALDS1_9_C
-#include "heap/leftist_heap.hpp"
 #include <iostream>
 #include <string>
+#include "heap/leftist_heap.hpp"
 #include "template/sonic.hpp"
 
 int main(void) {

--- a/test/aoj/alds1/rolling_hash.test.cpp
+++ b/test/aoj/alds1/rolling_hash.test.cpp
@@ -1,7 +1,7 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/ALDS1_14_B
-#include "string/rolling_hash.hpp"
 #include <iostream>
 #include <string>
+#include "string/rolling_hash.hpp"
 
 int main(void) {
     std::string s;

--- a/test/aoj/alds1/skew_heap.test.cpp
+++ b/test/aoj/alds1/skew_heap.test.cpp
@@ -1,7 +1,7 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/ALDS1_9_C
-#include "heap/skew_heap.hpp"
 #include <iostream>
 #include <string>
+#include "heap/skew_heap.hpp"
 #include "template/sonic.hpp"
 
 int main(void) {

--- a/test/aoj/alds1/suffix_array.test.cpp
+++ b/test/aoj/alds1/suffix_array.test.cpp
@@ -1,7 +1,7 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/ALDS1_14_D
-#include "string/suffix_array.hpp"
 #include <iostream>
 #include <string>
+#include "string/suffix_array.hpp"
 
 int main(void) {
     std::string s;

--- a/test/aoj/cgl/convex_hull.test.cpp
+++ b/test/aoj/cgl/convex_hull.test.cpp
@@ -1,8 +1,8 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/CGL_4_A
-#include "geometry/convex_hull.hpp"
 #include <algorithm>
 #include <iostream>
 #include <vector>
+#include "geometry/convex_hull.hpp"
 
 int main(void) {
     int n;

--- a/test/aoj/dsl/union_find.test.cpp
+++ b/test/aoj/dsl/union_find.test.cpp
@@ -1,6 +1,6 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/DSL_1_A
-#include "union_find/union_find.hpp"
 #include <iostream>
+#include "union_find/union_find.hpp"
 
 int main(void) {
     int n, q;

--- a/test/aoj/grl/cycle.test.cpp
+++ b/test/aoj/grl/cycle.test.cpp
@@ -1,6 +1,6 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/GRL_4_A
-#include "graph/cycle.hpp"
 #include <iostream>
+#include "graph/cycle.hpp"
 #include "graph/edge_input.hpp"
 
 int main(void) {

--- a/test/aoj/grl/floyd_warshall.test.cpp
+++ b/test/aoj/grl/floyd_warshall.test.cpp
@@ -1,8 +1,8 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/GRL_1_C
-#include "graph/floyd_warshall.hpp"
 #include <cstdint>
 #include <iostream>
 #include <string>
+#include "graph/floyd_warshall.hpp"
 #include "graph/matrix_graph.hpp"
 
 int main(void) {

--- a/test/aoj/grl/hld.test.cpp
+++ b/test/aoj/grl/hld.test.cpp
@@ -1,7 +1,7 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/GRL_5_C
-#include "tree/hld.hpp"
 #include <iostream>
 #include "graph/graph.hpp"
+#include "tree/hld.hpp"
 
 int main(void) {
     int n;

--- a/test/aoj/grl/kruskal.test.cpp
+++ b/test/aoj/grl/kruskal.test.cpp
@@ -1,8 +1,8 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/GRL_2_A
-#include "graph/kruskal.hpp"
 #include <iostream>
 #include <vector>
 #include "graph/edge_input.hpp"
+#include "graph/kruskal.hpp"
 
 int main(void) {
     int n, m;

--- a/test/aoj/grl/max_flow.test.cpp
+++ b/test/aoj/grl/max_flow.test.cpp
@@ -1,6 +1,6 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/GRL_6_A
-#include "flow/max_flow.hpp"
 #include <iostream>
+#include "flow/max_flow.hpp"
 
 int main(void) {
     int n, m;

--- a/test/aoj/grl/min_cost_flow.test.cpp
+++ b/test/aoj/grl/min_cost_flow.test.cpp
@@ -1,6 +1,6 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/GRL_6_B
-#include "flow/min_cost_flow.hpp"
 #include <iostream>
+#include "flow/min_cost_flow.hpp"
 
 int main(void) {
     int n, m, f;

--- a/test/aoj/grl/prim.test.cpp
+++ b/test/aoj/grl/prim.test.cpp
@@ -1,7 +1,7 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/GRL_2_A
-#include "graph/prim.hpp"
 #include <iostream>
 #include "graph/edge_input.hpp"
+#include "graph/prim.hpp"
 
 int main(void) {
     int n, m;

--- a/test/aoj/grl/scc.test.cpp
+++ b/test/aoj/grl/scc.test.cpp
@@ -1,8 +1,8 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/GRL_3_C
-#include "graph/scc.hpp"
 #include <iostream>
 #include <vector>
 #include "graph/edge_input.hpp"
+#include "graph/scc.hpp"
 
 int main(void) {
     int n, m;

--- a/test/aoj/grl/topological_sort.test.cpp
+++ b/test/aoj/grl/topological_sort.test.cpp
@@ -1,8 +1,8 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/GRL_4_B
-#include "graph/topological_sort.hpp"
 #include <iostream>
 #include <vector>
 #include "graph/edge_input.hpp"
+#include "graph/topological_sort.hpp"
 
 int main(void) {
     int n, m;

--- a/test/aoj/jag/aho_corasick.test.cpp
+++ b/test/aoj/jag/aho_corasick.test.cpp
@@ -1,10 +1,10 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/2863
-#include "string/aho_corasick.hpp"
 #include <algorithm>
 #include <iostream>
 #include <string>
 #include <vector>
 #include "math/modint.hpp"
+#include "string/aho_corasick.hpp"
 #include "tree/tree_function.hpp"
 
 using Mint = modint107;

--- a/test/aoj/jag/doubling.test.cpp
+++ b/test/aoj/jag/doubling.test.cpp
@@ -1,5 +1,4 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/2320
-#include "algorithm/doubling.hpp"
 #include <algorithm>
 #include <cstdint>
 #include <iostream>
@@ -7,6 +6,7 @@
 #include <numeric>
 #include <string>
 #include <vector>
+#include "algorithm/doubling.hpp"
 #include "graph/grid.hpp"
 
 int main(void) {

--- a/test/aoj/jag/dsu_on_tree.test.cpp
+++ b/test/aoj/jag/dsu_on_tree.test.cpp
@@ -1,10 +1,10 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/2995
-#include "tree/dsu_on_tree.hpp"
 #include <iostream>
 #include <unordered_map>
 #include <utility>
 #include <vector>
 #include "graph/edge_input.hpp"
+#include "tree/dsu_on_tree.hpp"
 #include "union_find/union_find.hpp"
 
 int main(void) {

--- a/test/aoj/jag/dynamic_union_find.test.cpp
+++ b/test/aoj/jag/dynamic_union_find.test.cpp
@@ -1,11 +1,11 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/2995
-#include "union_find/dynamic_union_find.hpp"
 #include <iostream>
 #include <unordered_map>
 #include <utility>
 #include <vector>
 #include "graph/edge_input.hpp"
 #include "tree/dsu_on_tree.hpp"
+#include "union_find/dynamic_union_find.hpp"
 
 int main(void) {
     int n, k;

--- a/test/aoj/jag/functional_graph.test.cpp
+++ b/test/aoj/jag/functional_graph.test.cpp
@@ -1,7 +1,7 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/2970
-#include "graph/functional_graph.hpp"
 #include <iostream>
 #include <vector>
+#include "graph/functional_graph.hpp"
 #include "number_theory/chinese_rem.hpp"
 
 int main(void) {

--- a/test/aoj/jag/hopcroft_karp.2.test.cpp
+++ b/test/aoj/jag/hopcroft_karp.2.test.cpp
@@ -1,9 +1,9 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/2976
-#include "flow/hopcroft_karp.hpp"
 #include <iostream>
 #include <set>
 #include <utility>
 #include <vector>
+#include "flow/hopcroft_karp.hpp"
 #include "union_find/union_find.hpp"
 
 int main(void) {

--- a/test/aoj/jag/hopcroft_karp.test.cpp
+++ b/test/aoj/jag/hopcroft_karp.test.cpp
@@ -1,7 +1,7 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/2251
-#include "flow/hopcroft_karp.hpp"
 #include <algorithm>
 #include <iostream>
+#include "flow/hopcroft_karp.hpp"
 #include "graph/floyd_warshall.hpp"
 #include "graph/matrix_graph.hpp"
 

--- a/test/aoj/jag/rolling_hash.2.test.cpp
+++ b/test/aoj/jag/rolling_hash.2.test.cpp
@@ -1,11 +1,11 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/2863
-#include "string/rolling_hash.hpp"
 #include <algorithm>
 #include <iostream>
 #include <string>
 #include <unordered_set>
 #include <vector>
 #include "math/modint.hpp"
+#include "string/rolling_hash.hpp"
 
 using Mint = modint107;
 

--- a/test/aoj/jag/rolling_hash.test.cpp
+++ b/test/aoj/jag/rolling_hash.test.cpp
@@ -1,9 +1,9 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/2444
-#include "string/rolling_hash.hpp"
 #include <cstdint>
 #include <iostream>
 #include <string>
 #include <unordered_set>
+#include "string/rolling_hash.hpp"
 
 int main(void) {
     int n, q;

--- a/test/aoj/joi/prefix_sum.test.cpp
+++ b/test/aoj/joi/prefix_sum.test.cpp
@@ -1,8 +1,8 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/0516
-#include "algorithm/prefix_sum.hpp"
 #include <iostream>
 #include <limits>
 #include <vector>
+#include "algorithm/prefix_sum.hpp"
 
 int main(void) {
     while (true) {

--- a/test/aoj/joi/priority_k_sum.test.cpp
+++ b/test/aoj/joi/priority_k_sum.test.cpp
@@ -1,9 +1,9 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/0516
-#include "heap/priority_k_sum.hpp"
 #include <algorithm>
 #include <iostream>
 #include <limits>
 #include <vector>
+#include "heap/priority_k_sum.hpp"
 
 int main(void) {
     while (true) {

--- a/test/aoj/joi/undo_union_find.test.cpp
+++ b/test/aoj/joi/undo_union_find.test.cpp
@@ -1,9 +1,9 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/0723
-#include "union_find/undo_union_find.hpp"
 #include <algorithm>
 #include <iostream>
 #include <map>
 #include <vector>
+#include "union_find/undo_union_find.hpp"
 
 int main(void) {
     int n, m, k;

--- a/test/yosupo/data_structure/binary_trie.test.cpp
+++ b/test/yosupo/data_structure/binary_trie.test.cpp
@@ -1,6 +1,6 @@
 // competitive-verifier: PROBLEM https://judge.yosupo.jp/problem/set_xor_min
-#include "ordered_set/binary_trie.hpp"
 #include <iostream>
+#include "ordered_set/binary_trie.hpp"
 
 int main(void) {
     int q;

--- a/test/yosupo/data_structure/patricia_binary_trie.test.cpp
+++ b/test/yosupo/data_structure/patricia_binary_trie.test.cpp
@@ -1,6 +1,6 @@
 // competitive-verifier: PROBLEM https://judge.yosupo.jp/problem/set_xor_min
-#include "ordered_set/patricia_binary_trie.hpp"
 #include <iostream>
+#include "ordered_set/patricia_binary_trie.hpp"
 
 int main(void) {
     int q;

--- a/test/yosupo/data_structure/persistent_queue.test.cpp
+++ b/test/yosupo/data_structure/persistent_queue.test.cpp
@@ -1,7 +1,7 @@
 // competitive-verifier: PROBLEM https://judge.yosupo.jp/problem/persistent_queue
-#include "persistent_ds/persistent_queue.hpp"
 #include <iostream>
 #include <vector>
+#include "persistent_ds/persistent_queue.hpp"
 
 int main(void) {
     int q;

--- a/test/yosupo/data_structure/persistent_union_find.test.cpp
+++ b/test/yosupo/data_structure/persistent_union_find.test.cpp
@@ -1,7 +1,7 @@
 // competitive-verifier: PROBLEM https://judge.yosupo.jp/problem/persistent_unionfind
-#include "union_find/persistent_union_find.hpp"
 #include <iostream>
 #include <vector>
+#include "union_find/persistent_union_find.hpp"
 
 int main(void) {
     int n, q;

--- a/test/yosupo/data_structure/undo_union_find.test.cpp
+++ b/test/yosupo/data_structure/undo_union_find.test.cpp
@@ -1,9 +1,9 @@
 // competitive-verifier: PROBLEM https://judge.yosupo.jp/problem/persistent_unionfind
-#include "union_find/undo_union_find.hpp"
 #include <iostream>
 #include <utility>
 #include <vector>
 #include "graph/graph.hpp"
+#include "union_find/undo_union_find.hpp"
 
 struct S {
     int k, u, v;

--- a/test/yosupo/enumerative_conbinatorics/partition_function.test.cpp
+++ b/test/yosupo/enumerative_conbinatorics/partition_function.test.cpp
@@ -1,6 +1,6 @@
 // competitive-verifier: PROBLEM https://judge.yosupo.jp/problem/partition_function
-#include "combinatorics/partition_function.hpp"
 #include <iostream>
+#include "combinatorics/partition_function.hpp"
 
 using Mint = modint998;
 

--- a/test/yosupo/graph/chromatic_number.test.cpp
+++ b/test/yosupo/graph/chromatic_number.test.cpp
@@ -1,6 +1,6 @@
 // competitive-verifier: PROBLEM https://judge.yosupo.jp/problem/chromatic_number
-#include "graph/chromatic_number.hpp"
 #include <iostream>
+#include "graph/chromatic_number.hpp"
 
 int main(void) {
     int n, m;

--- a/test/yosupo/graph/dominator_tree.test.cpp
+++ b/test/yosupo/graph/dominator_tree.test.cpp
@@ -1,6 +1,6 @@
 // competitive-verifier: PROBLEM https://judge.yosupo.jp/problem/dominatortree
-#include "graph/dominator_tree.hpp"
 #include <iostream>
+#include "graph/dominator_tree.hpp"
 #include "graph/edge_input.hpp"
 
 int main() {

--- a/test/yosupo/graph/maximum_independent_set.test.cpp
+++ b/test/yosupo/graph/maximum_independent_set.test.cpp
@@ -1,8 +1,8 @@
 // competitive-verifier: PROBLEM https://judge.yosupo.jp/problem/maximum_independent_set
-#include "graph/maximum_independent_set.hpp"
 #include <iostream>
 #include <vector>
 #include "graph/edge_input.hpp"
+#include "graph/maximum_independent_set.hpp"
 
 int main(void) {
     int n, m;

--- a/test/yosupo/graph/shortest_path.test.cpp
+++ b/test/yosupo/graph/shortest_path.test.cpp
@@ -1,4 +1,5 @@
 // competitive-verifier: PROBLEM https://judge.yosupo.jp/problem/shortest_path
+#include "template/template.hpp"
 #include <functional>
 #include <iostream>
 #include <limits>
@@ -6,7 +7,6 @@
 #include <utility>
 #include <vector>
 #include "graph/edge_input.hpp"
-#include "template/template.hpp"
 
 template <class T>
 std::pair<std::vector<T>, std::vector<int>> dijkstra(const csr_graph<T> &g, int s = 0,

--- a/test/yosupo/math/floor_sum.test.cpp
+++ b/test/yosupo/math/floor_sum.test.cpp
@@ -1,6 +1,6 @@
 // competitive-verifier: PROBLEM https://judge.yosupo.jp/problem/sum_of_floor_of_linear
-#include "number_theory/floor_sum.hpp"
 #include <iostream>
+#include "number_theory/floor_sum.hpp"
 
 int main(void) {
     int t;

--- a/test/yosupo/math/min_linear.test.cpp
+++ b/test/yosupo/math/min_linear.test.cpp
@@ -1,6 +1,6 @@
 // competitive-verifier: PROBLEM https://judge.yosupo.jp/problem/min_of_mod_of_linear
-#include "number_theory/min_linear.hpp"
 #include <iostream>
+#include "number_theory/min_linear.hpp"
 
 int main() {
     int t;

--- a/test/yosupo/number_theory/factorize.test.cpp
+++ b/test/yosupo/number_theory/factorize.test.cpp
@@ -1,7 +1,7 @@
 // competitive-verifier: PROBLEM https://judge.yosupo.jp/problem/factorize
-#include "number_theory/factorize.hpp"
 #include <cstdint>
 #include <iostream>
+#include "number_theory/factorize.hpp"
 
 int main(void) {
     int q;

--- a/test/yosupo/other/two_sat.test.cpp
+++ b/test/yosupo/other/two_sat.test.cpp
@@ -1,7 +1,7 @@
 // competitive-verifier: PROBLEM https://judge.yosupo.jp/problem/two_sat
-#include "graph/two_sat.hpp"
 #include <iostream>
 #include <string>
+#include "graph/two_sat.hpp"
 
 int main(void) {
     std::string tmp;

--- a/test/yosupo/set_power_series/subset_convolution.test.cpp
+++ b/test/yosupo/set_power_series/subset_convolution.test.cpp
@@ -1,7 +1,7 @@
 // competitive-verifier: PROBLEM https://judge.yosupo.jp/problem/subset_convolution
-#include "convolution/subset_convolution.hpp"
 #include <iostream>
 #include <vector>
+#include "convolution/subset_convolution.hpp"
 #include "math/modint.hpp"
 
 using Mint = modint998;

--- a/test/yosupo/string/aho_corasick.test.cpp
+++ b/test/yosupo/string/aho_corasick.test.cpp
@@ -1,8 +1,8 @@
 // competitive-verifier: PROBLEM https://judge.yosupo.jp/problem/aho_corasick
-#include "string/aho_corasick.hpp"
 #include <iostream>
 #include <string>
 #include <vector>
+#include "string/aho_corasick.hpp"
 
 int main() {
     int n;

--- a/test/yosupo/string/suffix_array.test.cpp
+++ b/test/yosupo/string/suffix_array.test.cpp
@@ -1,8 +1,8 @@
 // competitive-verifier: PROBLEM https://judge.yosupo.jp/problem/suffixarray
-#include "string/suffix_array.hpp"
 #include <iostream>
 #include <string>
 #include <vector>
+#include "string/suffix_array.hpp"
 
 int main(void) {
     std::string s;

--- a/test/yosupo/tree/cartesian_tree.test.cpp
+++ b/test/yosupo/tree/cartesian_tree.test.cpp
@@ -1,7 +1,7 @@
 // competitive-verifier: PROBLEM https://judge.yosupo.jp/problem/cartesian_tree
-#include "tree/cartesian_tree.hpp"
 #include <iostream>
 #include <vector>
+#include "tree/cartesian_tree.hpp"
 
 int main(void) {
     int n;

--- a/test/yosupo/tree/stern_brocot_tree.test.cpp
+++ b/test/yosupo/tree/stern_brocot_tree.test.cpp
@@ -1,8 +1,8 @@
 // competitive-verifier: PROBLEM https://judge.yosupo.jp/problem/stern_brocot_tree
-#include "number_theory/stern_brocot_tree.hpp"
 #include <cstdint>
 #include <iostream>
 #include <string>
+#include "number_theory/stern_brocot_tree.hpp"
 #include "template/sonic.hpp"
 
 using sbt = stern_brocot_tree;


### PR DESCRIPTION
clang-format の主ヘッダ判定がファイル名と basename 一致するライブラリヘッダを
先頭固定していたため、テストごとに include 順が混在していた。主ヘッダ判定を
<...> 限定にして全体を「標準 <...> 先頭 → 引用符ヘッダ」に統一する。
template/template.hpp の Priority -1 先頭固定も本来どおり効くようになる。

差分は include 並べ替えのみ。53 ファイルの test を syntax-only でコンパイル確認。

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
