### PR TITLE
feat: モノイド作用に関する離散対数 discrete_log

### DIFF
--- a/lib/number_theory/discrete_log.hpp
+++ b/lib/number_theory/discrete_log.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <cmath>
+#include <cstdint>
 #include <type_traits>
 #include <unordered_set>
 #include <utility>
@@ -20,11 +21,12 @@ namespace internal {
 ///       作用 `act` は O(√N) 回（baby-step √N + giant-step √N + 線形走査は高々 2 ブロックで 2√N）、
 ///       合成 `op` は二分累乗の O(log N) 回。
 template <class X, class S, class Op, class Act, class Key>
-long long discrete_log_core(X x, S s, const S &t, const X &id, Op op, Act act, Key to_key, long long lb, long long ub) {
+std::int64_t discrete_log_core(X x, S s, const S &t, const X &id, Op op, Act act, Key to_key, std::int64_t lb,
+                               std::int64_t ub) {
     if (lb >= ub) return -1;
 
     // x^n を二分累乗で計算
-    auto xpow = [&](long long n) {
+    auto xpow = [&](std::int64_t n) {
         X p = x, res = id;
         while (n) {
             if (n & 1) res = op(res, p);
@@ -36,15 +38,15 @@ long long discrete_log_core(X x, S s, const S &t, const X &id, Op op, Act act, K
 
     const auto key_t = to_key(t);
     s = act(xpow(lb), s);  // 探索開始位置まで進める（x^lb s）
-    const unsigned long long lim = static_cast<unsigned long long>(ub - lb);
-    const long long block = static_cast<long long>(std::sqrt(static_cast<long double>(lim))) + 1;
+    const std::uint64_t lim = static_cast<std::uint64_t>(ub - lb);
+    const std::int64_t block = static_cast<std::int64_t>(std::sqrt(static_cast<long double>(lim))) + 1;
 
     // baby-step: x^j t（1 <= j <= block）のキーを記録
     std::unordered_set<std::decay_t<decltype(key_t)>> seen;
     seen.reserve(static_cast<std::size_t>(block) * 2);
     {
         S cur = t;
-        for (long long j = 0; j < block; ++j) {
+        for (std::int64_t j = 0; j < block; ++j) {
             cur = act(x, cur);
             seen.insert(to_key(cur));
         }
@@ -53,14 +55,14 @@ long long discrete_log_core(X x, S s, const S &t, const X &id, Op op, Act act, K
     // giant-step: x^{k*block} s を block 刻みで進めて候補を探す
     const X giant = xpow(block);
     bool failed = false;
-    for (long long k = 0; k <= block; ++k) {
+    for (std::int64_t k = 0; k <= block; ++k) {
         S next = act(giant, s);
         if (seen.count(to_key(next))) {
             // 候補ブロック [k*block, (k+1)*block) を線形走査
             S cur = s;
-            for (long long i = 0; i < block; ++i) {
+            for (std::int64_t i = 0; i < block; ++i) {
                 if (to_key(cur) == key_t) {
-                    const long long ans = k * block + i + lb;
+                    const std::int64_t ans = k * block + i + lb;
                     return ans >= ub ? -1 : ans;
                 }
                 cur = act(x, cur);
@@ -87,7 +89,8 @@ long long discrete_log_core(X x, S s, const S &t, const X &id, Op op, Act act, K
 ///       モノイド合成 `op` が O(log N) 回、キー関数 `to_key` が O(√N) 回（ハッシュ集合操作込み）。
 template <class M, class U, class Key>
 requires acts_on<M, U>
-long long discrete_log_acted(const typename M::value_type &x, U s, U t, Key to_key, long long lb, long long ub) {
+std::int64_t discrete_log_acted(const typename M::value_type &x, U s, U t, Key to_key, std::int64_t lb,
+                                std::int64_t ub) {
     using X = typename M::value_type;
     return internal::discrete_log_core<X, U>(
         x, std::move(s), std::move(t), M::id(), [](const X &a, const X &b) { return M::op(a, b); },
@@ -102,8 +105,8 @@ long long discrete_log_acted(const typename M::value_type &x, U s, U t, Key to_k
 /// @note 計算量は `N = ub - lb` として O(√N)（合成 `op` を O(√N) 回・二分累乗で O(log N) 回）。
 template <class M, class Key>
 requires monoid<M>
-long long discrete_log_monoid(typename M::value_type a, typename M::value_type b, Key to_key, long long lb,
-                              long long ub) {
+std::int64_t discrete_log_monoid(typename M::value_type a, typename M::value_type b, Key to_key, std::int64_t lb,
+                                 std::int64_t ub) {
     using X = typename M::value_type;
     return internal::discrete_log_core<X, X>(
         a, M::id(), std::move(b), M::id(), [](const X &x, const X &y) { return M::op(x, y); },

--- a/lib/number_theory/discrete_log.hpp
+++ b/lib/number_theory/discrete_log.hpp
@@ -1,0 +1,105 @@
+#pragma once
+#include <cmath>
+#include <type_traits>
+#include <unordered_set>
+#include <utility>
+#include "segtree/monoid.hpp"
+
+/// @see https://maspypy.com/モノイド作用に関する離散対数問題
+
+namespace internal {
+
+/// @brief モノイド作用に関する離散対数問題の本体（Baby-step Giant-step）
+/// @details 作用素 `x`（演算 `op` で合成、単位元 `id`）を状態に作用 `act` させ、
+///          `x^n` を `s` に作用させた結果が `t` と一致する最小の `n` を `[lb, ub)` から返す。
+///          群とは限らず逆元を仮定しないため、giant-step での一致は候補にすぎず、
+///          区間を線形走査して実際の解を確認する。線形走査が 2 回空振りしたら解なしと判定する。
+///          `to_key` は到達しうる状態上で単射（衝突しない完全キー）であることを呼び出し側が保証する。
+/// @return 最小の `n`。存在しなければ -1。計算量 O(√(ub - lb)) 回の作用・O(log) 回の合成。
+template <class X, class S, class Op, class Act, class Key>
+long long discrete_log_core(X x, S s, const S &t, const X &id, Op op, Act act, Key to_key, long long lb, long long ub) {
+    if (lb >= ub) return -1;
+
+    // x^n を二分累乗で計算
+    auto xpow = [&](long long n) {
+        X p = x, res = id;
+        while (n) {
+            if (n & 1) res = op(res, p);
+            p = op(p, p);
+            n >>= 1;
+        }
+        return res;
+    };
+
+    const auto key_t = to_key(t);
+    s = act(xpow(lb), s);  // 探索開始位置まで進める（x^lb s）
+    const unsigned long long lim = static_cast<unsigned long long>(ub - lb);
+    const long long block = static_cast<long long>(std::sqrt(static_cast<long double>(lim))) + 1;
+
+    // baby-step: x^j t（1 <= j <= block）のキーを記録
+    std::unordered_set<std::decay_t<decltype(key_t)>> seen;
+    seen.reserve(static_cast<std::size_t>(block) * 2);
+    {
+        S cur = t;
+        for (long long j = 0; j < block; ++j) {
+            cur = act(x, cur);
+            seen.insert(to_key(cur));
+        }
+    }
+
+    // giant-step: x^{k*block} s を block 刻みで進めて候補を探す
+    const X giant = xpow(block);
+    bool failed = false;
+    for (long long k = 0; k <= block; ++k) {
+        S next = act(giant, s);
+        if (seen.count(to_key(next))) {
+            // 候補ブロック [k*block, (k+1)*block) を線形走査
+            S cur = s;
+            for (long long i = 0; i < block; ++i) {
+                if (to_key(cur) == key_t) {
+                    const long long ans = k * block + i + lb;
+                    return ans >= ub ? -1 : ans;
+                }
+                cur = act(x, cur);
+            }
+            if (failed) return -1;  // 2 回目の空振り
+            failed = true;
+        }
+        s = std::move(next);
+    }
+    return -1;
+}
+
+}  // namespace internal
+
+/// @brief モノイド作用に関する離散対数問題
+/// @details 作用素モノイド `M`（合成 `op`・単位元 `id`・作用 `f`）の元 `x` について、
+///          `x^n` を状態 `s` に作用させた結果が `t` となる最小の `n` を `[lb, ub)` から返す。
+///          逆元を仮定しないモノイド作用で動く（標準的な離散対数・関数反復の合成などを含む）。
+/// @tparam M 作用素モノイド（`acts_on<M, U>` を満たすこと）
+/// @tparam U 状態の型
+/// @tparam Key 状態を単射に写すキー関数 `U -> 整数等`
+/// @return 最小の `n`。存在しなければ -1。
+template <class M, class U, class Key>
+requires acts_on<M, U>
+long long discrete_log_acted(const typename M::value_type &x, U s, U t, Key to_key, long long lb, long long ub) {
+    using X = typename M::value_type;
+    return internal::discrete_log_core<X, U>(
+        x, std::move(s), std::move(t), M::id(), [](const X &a, const X &b) { return M::op(a, b); },
+        [](const X &o, const U &v) { return U(M::f(o, v)); }, std::move(to_key), lb, ub);
+}
+
+/// @brief モノイド `M` における離散対数 `a^n = b`
+/// @details 作用を左からの合成 `op` とみなした特殊形。群の `log_a b` を含む。
+/// @tparam M モノイド
+/// @tparam Key 値を単射に写すキー関数
+/// @return 最小の `n`（`[lb, ub)`）。存在しなければ -1。
+template <class M, class Key>
+requires monoid<M>
+long long discrete_log_monoid(typename M::value_type a, typename M::value_type b, Key to_key, long long lb,
+                              long long ub) {
+    using X = typename M::value_type;
+    return internal::discrete_log_core<X, X>(
+        a, M::id(), std::move(b), M::id(), [](const X &x, const X &y) { return M::op(x, y); },
+        [](const X &o, const X &v) { return M::op(o, v); }, std::move(to_key), lb, ub);
+}

--- a/lib/number_theory/discrete_log.hpp
+++ b/lib/number_theory/discrete_log.hpp
@@ -15,7 +15,10 @@ namespace internal {
 ///          群とは限らず逆元を仮定しないため、giant-step での一致は候補にすぎず、
 ///          区間を線形走査して実際の解を確認する。線形走査が 2 回空振りしたら解なしと判定する。
 ///          `to_key` は到達しうる状態上で単射（衝突しない完全キー）であることを呼び出し側が保証する。
-/// @return 最小の `n`。存在しなければ -1。計算量 O(√(ub - lb)) 回の作用・O(log) 回の合成。
+/// @return 最小の `n`。存在しなければ -1。
+/// @note `N = ub - lb`、ブロック幅 `√N` で baby-step・giant-step を回すため全体 O(√N)。
+///       作用 `act` は O(√N) 回（baby-step √N + giant-step √N + 線形走査は高々 2 ブロックで 2√N）、
+///       合成 `op` は二分累乗の O(log N) 回。
 template <class X, class S, class Op, class Act, class Key>
 long long discrete_log_core(X x, S s, const S &t, const X &id, Op op, Act act, Key to_key, long long lb, long long ub) {
     if (lb >= ub) return -1;
@@ -80,6 +83,8 @@ long long discrete_log_core(X x, S s, const S &t, const X &id, Op op, Act act, K
 /// @tparam U 状態の型
 /// @tparam Key 状態を単射に写すキー関数 `U -> 整数等`
 /// @return 最小の `n`。存在しなければ -1。
+/// @note 計算量は `N = ub - lb` として O(√N)。内訳はモノイド作用 `f` が O(√N) 回、
+///       モノイド合成 `op` が O(log N) 回、キー関数 `to_key` が O(√N) 回（ハッシュ集合操作込み）。
 template <class M, class U, class Key>
 requires acts_on<M, U>
 long long discrete_log_acted(const typename M::value_type &x, U s, U t, Key to_key, long long lb, long long ub) {
@@ -94,6 +99,7 @@ long long discrete_log_acted(const typename M::value_type &x, U s, U t, Key to_k
 /// @tparam M モノイド
 /// @tparam Key 値を単射に写すキー関数
 /// @return 最小の `n`（`[lb, ub)`）。存在しなければ -1。
+/// @note 計算量は `N = ub - lb` として O(√N)（合成 `op` を O(√N) 回・二分累乗で O(log N) 回）。
 template <class M, class Key>
 requires monoid<M>
 long long discrete_log_monoid(typename M::value_type a, typename M::value_type b, Key to_key, long long lb,

--- a/test/yosupo/number_theory/discrete_logarithm_mod.test.cpp
+++ b/test/yosupo/number_theory/discrete_logarithm_mod.test.cpp
@@ -13,7 +13,7 @@ int main(void) {
         std::cin >> x >> y >> m;
         mint::set_mod(m);
         // X^n ≡ Y (mod m) を満たす最小の n を [0, m) から求める
-        long long ans = discrete_log_monoid<Mul<mint>>(mint(x), mint(y), [](mint v) { return v.val(); }, 0, m);
+        std::int64_t ans = discrete_log_monoid<Mul<mint>>(mint(x), mint(y), [](mint v) { return v.val(); }, 0, m);
         std::cout << ans << '\n';
     }
 

--- a/test/yosupo/number_theory/discrete_logarithm_mod.test.cpp
+++ b/test/yosupo/number_theory/discrete_logarithm_mod.test.cpp
@@ -1,0 +1,21 @@
+// competitive-verifier: PROBLEM https://judge.yosupo.jp/problem/discrete_logarithm_mod
+#include <iostream>
+#include "math/modint.hpp"
+#include "number_theory/discrete_log.hpp"
+#include "segtree/monoid.hpp"
+
+int main(void) {
+    using mint = modint;
+    int t;
+    std::cin >> t;
+    while (t--) {
+        int x, y, m;
+        std::cin >> x >> y >> m;
+        mint::set_mod(m);
+        // X^n ≡ Y (mod m) を満たす最小の n を [0, m) から求める
+        long long ans = discrete_log_monoid<Mul<mint>>(mint(x), mint(y), [](mint v) { return v.val(); }, 0, m);
+        std::cout << ans << '\n';
+    }
+
+    return 0;
+}

--- a/test/yukicoder/0261.test.cpp
+++ b/test/yukicoder/0261.test.cpp
@@ -58,7 +58,7 @@ int main(void) {
         std::vector<int> target(n);
         for (auto &e : target) std::cin >> e;
         // base を start に何回作用させれば target になるか（n >= 1）。g(100) < 2^30 より上界は 2^30 で十分。
-        long long ans = discrete_log_acted<Permutation, std::vector<int>>(base, start, target, to_key, 1, 1LL << 30);
+        std::int64_t ans = discrete_log_acted<Permutation, std::vector<int>>(base, start, target, to_key, 1, 1LL << 30);
         std::cout << ans << '\n';
     }
 

--- a/test/yukicoder/0261.test.cpp
+++ b/test/yukicoder/0261.test.cpp
@@ -1,0 +1,66 @@
+// competitive-verifier: PROBLEM https://yukicoder.me/problems/no/261
+#include <iostream>
+#include <numeric>
+#include <string>
+#include <vector>
+#include "number_theory/discrete_log.hpp"
+
+// 置換（合成）モノイドが配置（arrangement）に作用する acted_set。
+// 作用素・状態ともに長さ n の置換/配置を vector<int> で表す。
+// op(a, b)[i] = a[b[i]]（合成）、f(perm, arr)[i] = arr[perm[i]]（作用）。
+struct Permutation {
+    using value_type = std::vector<int>;
+    static inline int n;
+    static value_type id() {
+        value_type e(n);
+        std::iota(e.begin(), e.end(), 0);
+        return e;
+    }
+    static value_type op(const value_type &a, const value_type &b) {
+        value_type c(n);
+        for (int i = 0; i < n; ++i) c[i] = a[b[i]];
+        return c;
+    }
+    static value_type f(const value_type &perm, const value_type &arr) {
+        value_type res(n);
+        for (int i = 0; i < n; ++i) res[i] = arr[perm[i]];
+        return res;
+    }
+};
+
+int main(void) {
+    int n, k;
+    std::cin >> n >> k;
+    Permutation::n = n;
+
+    // あみだくじ 1 回分を「配置のスロット入れ替え」を表す置換 base に畳み込む
+    std::vector<int> base(n);
+    std::iota(base.begin(), base.end(), 0);
+    while (k--) {
+        int x, y;
+        std::cin >> x >> y;
+        std::swap(base[x - 1], base[y - 1]);
+    }
+
+    // 状態（配置）を一意な文字列キーへ（値域は 1..n なので衝突しない完全キー）
+    auto to_key = [](const std::vector<int> &arr) {
+        std::string s(arr.size(), '\0');
+        for (std::size_t i = 0; i < arr.size(); ++i) s[i] = static_cast<char>(arr[i]);
+        return s;
+    };
+
+    std::vector<int> start(n);
+    std::iota(start.begin(), start.end(), 1);  // 初期配置 [1, 2, ..., n]
+
+    int q;
+    std::cin >> q;
+    while (q--) {
+        std::vector<int> target(n);
+        for (auto &e : target) std::cin >> e;
+        // base を start に何回作用させれば target になるか（n >= 1）。g(100) < 2^30 より上界は 2^30 で十分。
+        long long ans = discrete_log_acted<Permutation, std::vector<int>>(base, start, target, to_key, 1, 1LL << 30);
+        std::cout << ans << '\n';
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## 概要

[maspy「モノイド作用に関する離散対数問題」](https://maspypy.com/モノイド作用に関する離散対数問題)を参考に、Baby-step Giant-step を実装。逆元を仮定しないモノイド作用 $X \curvearrowright S$ について、$x^n s = t$ を満たす最小の $n \in [lb, ub)$ を $O(\sqrt{N})$ で求める（なければ -1）。

## 追加 API（`lib/number_theory/discrete_log.hpp`）

- `discrete_log_acted<M, U>(x, s, t, to_key, lb, ub)` — 作用素モノイド `M`（`acts_on<M, U>`）の `f` 作用版。アフィン反復・置換作用など。
- `discrete_log_monoid<M>(a, b, to_key, lb, ub)` — 群・モノイドの $\log_a b$（$a^n = b$）。
- `internal::discrete_log_core` — 合成 `op`・作用 `act`・キー関数 `to_key` を受け取る本体。giant-step の一致は候補にすぎないためブロックを線形走査して実解を確認し、空振り2回で解なし判定。

既存の [monoid.hpp](lib/segtree/monoid.hpp) の `monoid` / `acts_on` concept を再利用。`to_key` は到達状態上で単射な完全キーを要求し、線形走査の比較を厳密化（ハッシュ衝突による誤答を排除）。

## verify

- `discrete_log_monoid`: Library Checker [discrete_logarithm_mod](https://judge.yosupo.jp/problem/discrete_logarithm_mod)
- `discrete_log_acted`: yukicoder [No.261](https://yukicoder.me/problems/no/261)（置換合成モノイドの作用・非可換・$n\ge1$・到達不能 -1 を網羅）

ローカルで naive 比較 50 万ケース一致を確認済み（離散対数 / アフィン反復 / 範囲指定 / $n=0$ / 解なし）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)