### PR TITLE
feat: 乗法的関数ライブラリ（線形篩・杜教筛・Min_25 篩）

### DIFF
--- a/lib/number_theory/min25_sieve.hpp
+++ b/lib/number_theory/min25_sieve.hpp
@@ -1,0 +1,112 @@
+#pragma once
+#include <cmath>
+#include <functional>
+#include <utility>
+#include <vector>
+
+/// @brief f(p) の素数項 coef * p^pw を表す
+///
+/// prefix(x) = Σ_{i=1}^{x} i^pw（pw 乗和の閉じた式）を渡す。
+template <class T>
+struct Min25Term {
+    T coef;
+    int pw;
+    std::function<T(long long)> prefix;
+};
+
+/// @brief Min_25 篩：乗法的関数の累積和を O(N^{3/4} / log N) で計算する
+///
+/// 素数 p での値 f(p) が p の多項式 Σ coef·p^pw で表せる乗法的関数 f について、
+/// S(N) = Σ_{i=1}^{N} f(i) を求める。素数冪での値 f(p^e) は fpe で与える。
+/// @tparam T 値の型（modint 等）
+/// @tparam Fpe (long long p, int e, long long pe) -> T。pe == p^e で f(p^e) を返す。
+template <class T, class Fpe>
+struct Min25Sieve {
+    Min25Sieve(long long n, std::vector<Min25Term<T>> terms, Fpe fpe) : N(n), fpe(std::move(fpe)) { build(terms); }
+
+    /// @brief S(N) = Σ_{i=1}^{N} f(i)
+    T sum() { return N <= 0 ? T(0) : T(1) + rec(N, 0); }
+
+  private:
+    long long N, sq = 0;
+    std::vector<long long> primes;
+    // small[v] = Σ_{p<=v} f(p)（v <= sq）、large[i] = Σ_{p<=N/i} f(p)
+    std::vector<T> small, large;
+    Fpe fpe;
+
+    // x = ⌊N/i⌋ における Σ_{p<=x} f(p)
+    T prime_sum(long long x) const { return x <= sq ? small[x] : large[N / x]; }
+
+    void build(std::vector<Min25Term<T>> &terms) {
+        sq = (long long)std::sqrt((long double)N);
+        while (sq > 0 && sq * sq > N) --sq;
+        while ((sq + 1) * (sq + 1) <= N) ++sq;
+
+        std::vector<bool> composite(sq + 1, false);
+        for (long long i = 2; i <= sq; ++i) {
+            if (composite[i]) continue;
+            primes.emplace_back(i);
+            for (long long j = i * i; j <= sq; j += i) composite[j] = true;
+        }
+
+        const int m = (int)terms.size();
+        // gs[t][v] = Σ_{i<=v} i^pw（合成数を篩い落とすと素数のみの和になる）
+        std::vector<std::vector<T>> gs(m, std::vector<T>(sq + 1)), gl(m, std::vector<T>(sq + 1));
+        for (int t = 0; t < m; ++t) {
+            for (long long v = 1; v <= sq; ++v) gs[t][v] = terms[t].prefix(v) - T(1);
+            for (long long i = 1; i <= sq; ++i) gl[t][i] = terms[t].prefix(N / i) - T(1);
+        }
+
+        for (long long p : primes) {
+            const long long p2 = p * p;
+            if (p2 > N) break;
+            const long long lim = std::min(N / p2, sq);  // 値 N/i >= p^2 となる i の上限
+            for (int t = 0; t < m; ++t) {
+                T pk = T(1);
+                for (int e = 0; e < terms[t].pw; ++e) pk *= T(p);
+                const T psub = gs[t][p - 1];  // 素数 < p の p^pw 和
+                auto &Gs = gs[t];
+                auto &Gl = gl[t];
+                // 大きい値側（N/i > sq になりうる）を i 昇順 = 値 降順 で更新
+                for (long long i = 1; i <= lim; ++i) {
+                    const long long d = (N / i) / p;
+                    const T sub = (d <= sq) ? Gs[d] : Gl[N / d];
+                    Gl[i] -= pk * (sub - psub);
+                }
+                // 小さい値側を v 降順で更新（v/p < v は未更新の状態を読む）
+                for (long long v = sq; v >= p2; --v) Gs[v] -= pk * (Gs[v / p] - psub);
+            }
+        }
+
+        small.assign(sq + 1, T(0));
+        large.assign(sq + 1, T(0));
+        for (int t = 0; t < m; ++t) {
+            const T c = terms[t].coef;
+            for (long long v = 1; v <= sq; ++v) small[v] += c * gs[t][v];
+            for (long long i = 1; i <= sq; ++i) large[i] += c * gl[t][i];
+        }
+    }
+
+    // n 以下で最小素因数が primes[j] 以上の合成数・素数についての f の和（i=1 は含めない）
+    T rec(long long n, int j) {
+        if (n <= 1) return T(0);
+        // i が素数（primes[j] <= p <= n）の寄与
+        T res = prime_sum(n) - (j == 0 ? T(0) : prime_sum(primes[j - 1]));
+        for (int k = j; k < (int)primes.size() && primes[k] * primes[k] <= n; ++k) {
+            const long long p = primes[k];
+            long long pe = p;
+            for (int e = 1; pe * p <= n; ++e) {
+                // f(p^e)·(より大きい素因数からなる部分) ＋ 素数冪 p^{e+1} そのもの
+                res += fpe(p, e, pe) * rec(n / pe, k + 1) + fpe(p, e + 1, pe * p);
+                pe *= p;
+            }
+        }
+        return res;
+    }
+};
+
+/// @brief Min_25 篩で S(N) = Σ_{i=1}^{N} f(i) を計算する（型推論用ヘルパ）
+template <class T, class Fpe>
+T min25_sum(long long n, std::vector<Min25Term<T>> terms, Fpe fpe) {
+    return Min25Sieve<T, Fpe>(n, std::move(terms), std::move(fpe)).sum();
+}

--- a/lib/number_theory/min25_sieve.hpp
+++ b/lib/number_theory/min25_sieve.hpp
@@ -1,8 +1,22 @@
 #pragma once
 #include <cmath>
+#include <cstdint>
 #include <functional>
 #include <utility>
 #include <vector>
+
+namespace internal {
+
+// 固定除数 p に対する floor(a / p) を、事前計算した M = floor(2^64 / p) で
+// 乗算に置き換えて求める（Barrett 風）。a, p は非負で a < 2^63、p >= 2。
+inline long long fast_div(long long a, long long p, std::uint64_t M) {
+    std::uint64_t q = (std::uint64_t)(((__uint128_t)M * (std::uint64_t)a) >> 64);
+    long long r = a - (long long)q * p;
+    while (r >= p) ++q, r -= p;
+    return (long long)q;
+}
+
+}  // namespace internal
 
 /// @brief f(p) の素数項 coef * p^pw を表す
 ///
@@ -30,6 +44,7 @@ struct Min25Sieve {
   private:
     long long N, sq = 0;
     std::vector<long long> primes;
+    std::vector<std::uint64_t> inv_p;  // inv_p[k] = ⌊2^64 / primes[k]⌋（Barrett 用）
     // small[v] = Σ_{p<=v} f(p)（v <= sq）、large[i] = Σ_{p<=N/i} f(p)
     std::vector<T> small, large;
     Fpe fpe;
@@ -48,33 +63,53 @@ struct Min25Sieve {
             primes.emplace_back(i);
             for (long long j = i * i; j <= sq; j += i) composite[j] = true;
         }
+        inv_p.resize(primes.size());
+        for (std::size_t k = 0; k < primes.size(); ++k)
+            inv_p[k] = (std::uint64_t)((__uint128_t(1) << 64) / (std::uint64_t)primes[k]);
 
         const int m = (int)terms.size();
-        // gs[t][v] = Σ_{i<=v} i^pw（合成数を篩い落とすと素数のみの和になる）
-        std::vector<std::vector<T>> gs(m, std::vector<T>(sq + 1)), gl(m, std::vector<T>(sq + 1));
+        // 項をインタリーブした flat 配列で持つ（同じ値 v の全項が連続 → キャッシュ効率）。
+        // gs[v*m + t] = Σ_{i<=v} i^pw（合成数を篩い落とすと素数のみの和になる）
+        std::vector<T> gs((sq + 1) * m, T(0)), gl((sq + 1) * m, T(0));
         for (int t = 0; t < m; ++t) {
-            for (long long v = 1; v <= sq; ++v) gs[t][v] = terms[t].prefix(v) - T(1);
-            for (long long i = 1; i <= sq; ++i) gl[t][i] = terms[t].prefix(N / i) - T(1);
+            for (long long v = 1; v <= sq; ++v) gs[v * m + t] = terms[t].prefix(v) - T(1);
+            for (long long i = 1; i <= sq; ++i) gl[i * m + t] = terms[t].prefix(N / i) - T(1);
         }
 
+        // 項ごとの p^pw と「素数 < p の p^pw 和」。インデックス計算を全項で共有するため
+        // ループは値（i, v）を外側にして全項をまとめて更新する（除算の重複を避ける）。
+        // pw==0（π(x) 相当）の項は pk==1 なので乗算を省く。
+        std::vector<T> pk(m), psub(m);
+        std::vector<char> nomul(m);
+        for (int t = 0; t < m; ++t) nomul[t] = (terms[t].pw == 0);
         for (long long p : primes) {
             const long long p2 = p * p;
             if (p2 > N) break;
             const long long lim = std::min(N / p2, sq);  // 値 N/i >= p^2 となる i の上限
             for (int t = 0; t < m; ++t) {
-                T pk = T(1);
-                for (int e = 0; e < terms[t].pw; ++e) pk *= T(p);
-                const T psub = gs[t][p - 1];  // 素数 < p の p^pw 和
-                auto &Gs = gs[t];
-                auto &Gl = gl[t];
-                // 大きい値側（N/i > sq になりうる）を i 昇順 = 値 降順 で更新
-                for (long long i = 1; i <= lim; ++i) {
-                    const long long d = (N / i) / p;
-                    const T sub = (d <= sq) ? Gs[d] : Gl[N / d];
-                    Gl[i] -= pk * (sub - psub);
+                T v = T(1);
+                for (int e = 0; e < terms[t].pw; ++e) v *= T(p);
+                pk[t] = v;
+                psub[t] = gs[(p - 1) * m + t];  // 素数 < p の p^pw 和
+            }
+            // 大きい値側（N/i > sq になりうる）を i 昇順 = 値 降順 で更新
+            for (long long i = 1; i <= lim; ++i) {
+                const long long d = (N / i) / p;
+                const T *src = (d <= sq) ? &gs[d * m] : &gl[(N / d) * m];
+                T *dst = &gl[i * m];
+                for (int t = 0; t < m; ++t) {
+                    const T diff = src[t] - psub[t];
+                    dst[t] -= nomul[t] ? diff : pk[t] * diff;
                 }
-                // 小さい値側を v 降順で更新（v/p < v は未更新の状態を読む）
-                for (long long v = sq; v >= p2; --v) Gs[v] -= pk * (Gs[v / p] - psub);
+            }
+            // 小さい値側を v 降順で更新（v/p < v は未更新の状態を読む）
+            for (long long v = sq; v >= p2; --v) {
+                const T *src = &gs[(v / p) * m];
+                T *dst = &gs[v * m];
+                for (int t = 0; t < m; ++t) {
+                    const T diff = src[t] - psub[t];
+                    dst[t] -= nomul[t] ? diff : pk[t] * diff;
+                }
             }
         }
 
@@ -82,8 +117,8 @@ struct Min25Sieve {
         large.assign(sq + 1, T(0));
         for (int t = 0; t < m; ++t) {
             const T c = terms[t].coef;
-            for (long long v = 1; v <= sq; ++v) small[v] += c * gs[t][v];
-            for (long long i = 1; i <= sq; ++i) large[i] += c * gl[t][i];
+            for (long long v = 1; v <= sq; ++v) small[v] += c * gs[v * m + t];
+            for (long long i = 1; i <= sq; ++i) large[i] += c * gl[i * m + t];
         }
     }
 
@@ -94,11 +129,18 @@ struct Min25Sieve {
         T res = prime_sum(n) - (j == 0 ? T(0) : prime_sum(primes[j - 1]));
         for (int k = j; k < (int)primes.size() && primes[k] * primes[k] <= n; ++k) {
             const long long p = primes[k];
-            long long pe = p;
-            for (int e = 1; pe * p <= n; ++e) {
+            const std::uint64_t M = inv_p[k];
+            const long long np = internal::fast_div(n, p, M);  // n/p。pe*p<=n は pe<=np と同値
+            long long pe = p;                                  // p^e
+            long long nq = np;                                 // n/p^e（e=1 で n/p）
+            T fe = fpe(p, 1, p);                               // f(p^e) を持ち回して fpe 呼び出しを半減する
+            for (int e = 1; pe <= np; ++e) {
+                const long long pe1 = pe * p;  // p^{e+1}（pe <= np より n 以下）
+                const T fe1 = fpe(p, e + 1, pe1);
                 // f(p^e)·(より大きい素因数からなる部分) ＋ 素数冪 p^{e+1} そのもの
-                res += fpe(p, e, pe) * rec(n / pe, k + 1) + fpe(p, e + 1, pe * p);
-                pe *= p;
+                res += fe * rec(nq, k + 1) + fe1;
+                pe = pe1, fe = fe1;
+                nq = internal::fast_div(nq, p, M);  // n/p^{e+1}
             }
         }
         return res;

--- a/lib/number_theory/min25_sieve.hpp
+++ b/lib/number_theory/min25_sieve.hpp
@@ -9,10 +9,10 @@ namespace internal {
 
 // 固定除数 p に対する floor(a / p) を、事前計算した M = floor(2^64 / p) で
 // 乗算に置き換えて求める（Barrett 風）。a, p は非負で a < 2^63、p >= 2。
+// M = floor(2^64/p) >= 2^64/p - 1 より q は真値か真値-1 なので補正は 1 回で十分。
 inline long long fast_div(long long a, long long p, std::uint64_t M) {
     std::uint64_t q = (std::uint64_t)(((__uint128_t)M * (std::uint64_t)a) >> 64);
-    long long r = a - (long long)q * p;
-    while (r >= p) ++q, r -= p;
+    if ((long long)(a - (long long)q * p) >= p) ++q;
     return (long long)q;
 }
 
@@ -45,6 +45,7 @@ struct Min25Sieve {
     long long N, sq = 0;
     std::vector<long long> primes;
     std::vector<std::uint64_t> inv_p;  // inv_p[k] = ⌊2^64 / primes[k]⌋（Barrett 用）
+    std::vector<T> fp1, fp2;           // fp1[k]=f(primes[k])、fp2[k]=f(primes[k]^2)（再帰のホットパス用）
     // small[v] = Σ_{p<=v} f(p)（v <= sq）、large[i] = Σ_{p<=N/i} f(p)
     std::vector<T> small, large;
     Fpe fpe;
@@ -64,8 +65,17 @@ struct Min25Sieve {
             for (long long j = i * i; j <= sq; j += i) composite[j] = true;
         }
         inv_p.resize(primes.size());
-        for (std::size_t k = 0; k < primes.size(); ++k)
-            inv_p[k] = (std::uint64_t)((__uint128_t(1) << 64) / (std::uint64_t)primes[k]);
+        fp1.resize(primes.size());
+        fp2.resize(primes.size());
+        for (std::size_t k = 0; k < primes.size(); ++k) {
+            const long long p = primes[k];
+            inv_p[k] = (std::uint64_t)((__uint128_t(1) << 64) / (std::uint64_t)p);
+            fp1[k] = fpe(p, 1, p);
+            fp2[k] = fpe(p, 2, p * p);
+        }
+
+        std::vector<long long> quot(sq + 1);
+        for (long long i = 1; i <= sq; ++i) quot[i] = N / i;
 
         const int m = (int)terms.size();
         // 項をインタリーブした flat 配列で持つ（同じ値 v の全項が連続 → キャッシュ効率）。
@@ -73,7 +83,7 @@ struct Min25Sieve {
         std::vector<T> gs((sq + 1) * m, T(0)), gl((sq + 1) * m, T(0));
         for (int t = 0; t < m; ++t) {
             for (long long v = 1; v <= sq; ++v) gs[v * m + t] = terms[t].prefix(v) - T(1);
-            for (long long i = 1; i <= sq; ++i) gl[i * m + t] = terms[t].prefix(N / i) - T(1);
+            for (long long i = 1; i <= sq; ++i) gl[i * m + t] = terms[t].prefix(quot[i]) - T(1);
         }
 
         // 項ごとの p^pw と「素数 < p の p^pw 和」。インデックス計算を全項で共有するため
@@ -94,7 +104,7 @@ struct Min25Sieve {
             }
             // 大きい値側（N/i > sq になりうる）を i 昇順 = 値 降順 で更新
             for (long long i = 1; i <= lim; ++i) {
-                const long long d = (N / i) / p;
+                const long long d = quot[i] / p;
                 const T *src = (d <= sq) ? &gs[d * m] : &gl[(N / d) * m];
                 T *dst = &gl[i * m];
                 for (int t = 0; t < m; ++t) {
@@ -123,22 +133,36 @@ struct Min25Sieve {
     }
 
     // n 以下で最小素因数が primes[j] 以上の合成数・素数についての f の和（i=1 は含めない）
+    // 呼び出しの大半は「葉」（k ループが空回りし prime_sum 差だけ返す）なので、
+    // 子が葉になる場合は再帰せずインライン展開して関数呼び出しを省く。
     T rec(long long n, int j) {
         if (n <= 1) return T(0);
+        const int sz = (int)primes.size();
+        // pref = prime_sum(primes[k-1])（素数順の prefix を持ち回し、葉での配列読みを消す）
+        T pref = (j == 0) ? T(0) : prime_sum(primes[j - 1]);
         // i が素数（primes[j] <= p <= n）の寄与
-        T res = prime_sum(n) - (j == 0 ? T(0) : prime_sum(primes[j - 1]));
-        for (int k = j; k < (int)primes.size() && primes[k] * primes[k] <= n; ++k) {
+        T res = prime_sum(n) - pref;
+        for (int k = j; k < sz; ++k) {
             const long long p = primes[k];
+            if (p * p > n) break;
             const std::uint64_t M = inv_p[k];
             const long long np = internal::fast_div(n, p, M);  // n/p。pe*p<=n は pe<=np と同値
-            long long pe = p;                                  // p^e
-            long long nq = np;                                 // n/p^e（e=1 で n/p）
-            T fe = fpe(p, 1, p);                               // f(p^e) を持ち回して fpe 呼び出しを半減する
-            for (int e = 1; pe <= np; ++e) {
-                const long long pe1 = pe * p;  // p^{e+1}（pe <= np より n 以下）
-                const T fe1 = fpe(p, e + 1, pe1);
-                // f(p^e)·(より大きい素因数からなる部分) ＋ 素数冪 p^{e+1} そのもの
-                res += fe * rec(nq, k + 1) + fe1;
+            // 子 rec(nq, k+1) が葉になる閾値。次の素数が無ければ常にインライン（nq < n+1）。
+            const long long next2 = (k + 1 < sz) ? primes[k + 1] * primes[k + 1] : n + 1;
+            long long pe = p;            // p^e
+            long long nq = np;           // n/p^e（e=1 で n/p）
+            T fe = fp1[k];               // f(p)（事前計算）。持ち回して fpe 呼び出しを減らす
+            const T psum_p = pref + fe;  // prime_sum(p) = prime_sum(primes[k-1]) + f(p)
+            pref = psum_p;
+            // 大半の素数は e=1 で終わる。継続するときだけ nq を更新し無駄な除算を省く。
+            for (int e = 1;; ++e) {
+                const long long pe1 = pe * p;                          // p^{e+1}（pe <= np より n 以下）
+                const T fe1 = (e == 1) ? fp2[k] : fpe(p, e + 1, pe1);  // f(p^{e+1})
+                // f(p^e)·(より大きい素因数からなる部分) ＋ 素数冪 p^{e+1} そのもの。
+                // nq >= next2 のときだけ非葉なので再帰、それ以外は葉をインライン。
+                const T sub = (nq >= next2) ? rec(nq, k + 1) : prime_sum(nq) - psum_p;
+                res += fe * sub + fe1;
+                if (pe1 > np) break;  // 次の指数 e+1 は p^{e+2} > n となり打ち切り
                 pe = pe1, fe = fe1;
                 nq = internal::fast_div(nq, p, M);  // n/p^{e+1}
             }

--- a/lib/number_theory/multiplicative_function.hpp
+++ b/lib/number_theory/multiplicative_function.hpp
@@ -1,5 +1,7 @@
 #pragma once
+#include <cmath>
 #include <cstdint>
+#include <utility>
 #include <vector>
 
 /// @brief 乗法的関数の値を線形篩で一括計算する
@@ -75,4 +77,101 @@ std::vector<std::int64_t> divisor_sum_table(int n) {
         for (int i = 0; i < k; ++i) sum += (cur *= p);
         return sum;
     });
+}
+
+/// @brief 乗法的関数の累積和を劣線形で計算する（杜教筛 / Dirichlet 双曲線法）
+///
+/// 乗法的関数 f の累積和 S(n) = Σ_{i=1}^{n} f(i) を O(n^{2/3}) で求める。
+/// f とディリクレ畳み込み f*g がともに累積和を計算しやすい g を選び、
+/// 恒等式 Σ_{i=1}^{m} (f*g)(i) = Σ_{d=1}^{m} g(d) S(⌊m/d⌋) から
+/// g(1)S(m) = H(m) - Σ_{d=2}^{m} g(d) S(⌊m/d⌋) を再帰的に解く。
+/// @tparam T 値の型（modint や整数型）
+/// @tparam Gsum (long long m) -> T。G(m) = Σ_{i=1}^{m} g(i)。
+/// @tparam Hsum (long long m) -> T。H(m) = Σ_{i=1}^{m} (f*g)(i)。
+template <class T, class Gsum, class Hsum>
+struct MultiplicativeSum {
+    /// @param n 上限
+    /// @param f_prefix f の累積和。f_prefix[k] = Σ_{i=1}^{k} f(i)（k <= threshold）。
+    ///   threshold は n^{2/3} 程度を推奨（base case の打ち切り）。
+    /// @param g1 g(1)（多くの場合 1）
+    /// @param G G(m) = Σ_{i=1}^{m} g(i)
+    /// @param H H(m) = Σ_{i=1}^{m} (f*g)(i)
+    MultiplicativeSum(long long n, std::vector<T> f_prefix, T g1, Gsum G, Hsum H)
+        : n(n), threshold((long long)f_prefix.size() - 1), small(std::move(f_prefix)), g1(g1), G(G), H(H) {
+        long long size = threshold > 0 ? n / threshold + 1 : 1;
+        large.assign(size, T());
+        done.assign(size, false);
+    }
+
+    /// @brief S(n) = Σ_{i=1}^{n} f(i)
+    T sum() { return get(n); }
+
+    /// @brief S(m) = Σ_{i=1}^{m} f(i)（m <= n）
+    T get(long long m) {
+        if (m <= threshold) return small[m];
+        // m > threshold の値は m = ⌊n/idx⌋ の形なので idx をキーにメモ化する。
+        long long idx = n / m;
+        if (done[idx]) return large[idx];
+        T res = H(m);
+        for (long long d = 2, nd; d <= m; d = nd + 1) {
+            long long q = m / d;
+            nd = m / q;  // ⌊m/d⌋ == q となる d の最大値
+            res -= (G(nd) - G(d - 1)) * get(q);
+        }
+        if (!(g1 == T(1))) res = res / g1;
+        large[idx] = res;
+        done[idx] = true;
+        return res;
+    }
+
+  private:
+    long long n, threshold;
+    std::vector<T> small, large;
+    std::vector<bool> done;
+    T g1;
+    Gsum G;
+    Hsum H;
+};
+
+namespace internal {
+
+// n^{2/3} 程度の打ち切り点（base case のサイズ）。正しさは任意の打ち切りで
+// 保たれるため近似で十分。n*n のオーバーフローを避けて double で計算する。
+inline long long sublinear_threshold(long long n) {
+    if (n <= 1) return n < 0 ? 0 : n;
+    long long t = (long long)std::cbrt((double)n * (double)n);
+    return std::min(n, std::max<long long>(1, t));
+}
+
+}  // namespace internal
+
+/// @brief Σ_{i=1}^{n} φ(i) を O(n^{2/3}) で計算する
+///
+/// φ*1 = Id（恒等関数）より H(m) = m(m+1)/2、g = 1 で杜教筛を回す。
+template <class T>
+T totient_sum(long long n) {
+    if (n <= 0) return T(0);
+    long long th = internal::sublinear_threshold(n);
+    auto phi = euler_phi_table((int)th);
+    std::vector<T> pre(th + 1, T(0));
+    for (long long i = 1; i <= th; ++i) pre[i] = pre[i - 1] + T(phi[i]);
+    const T inv2 = T(1) / T(2);
+    auto G = [](long long m) { return T(m); };
+    auto H = [inv2](long long m) { return T(m) * T(m + 1) * inv2; };
+    return MultiplicativeSum<T, decltype(G), decltype(H)>(n, std::move(pre), T(1), G, H).sum();
+}
+
+/// @brief メルテンス関数 Σ_{i=1}^{n} μ(i) を O(n^{2/3}) で計算する
+///
+/// μ*1 = ε（単位元）より H(m) = 1、g = 1 で杜教筛を回す。
+template <class T>
+T mobius_sum(long long n) {
+    if (n <= 0) return T(0);
+    long long th = internal::sublinear_threshold(n);
+    auto mu = mobius_table((int)th);
+    std::vector<T> pre(th + 1, T(0));
+    for (long long i = 1; i <= th; ++i) pre[i] = pre[i - 1] + T(mu[i]);
+    auto G = [](long long m) { return T(m); };
+    auto H = [](long long) { return T(1); };
+    return MultiplicativeSum<T, decltype(G), decltype(H)>(n, std::move(pre), T(1), G, H).sum();
 }

--- a/lib/number_theory/multiplicative_function.hpp
+++ b/lib/number_theory/multiplicative_function.hpp
@@ -1,0 +1,78 @@
+#pragma once
+#include <cstdint>
+#include <vector>
+
+/// @brief 乗法的関数の値を線形篩で一括計算する
+///
+/// 乗法的関数 f（f(1)=1, gcd(m,n)=1 で f(mn)=f(m)f(n)）の f(1), ..., f(n) を
+/// O(n) で構築する。素数冪での値 f(p^k) を返す callable を渡す。
+/// @tparam T 値の型（modint や整数型）
+/// @tparam F (int p, int k, int pk) -> T を満たす callable。pk == p^k。
+/// @param n 上限（n >= 0）
+/// @param fpk f(p^k) を返す関数。p は素数、k >= 1、pk = p^k。
+/// @return f[i] = f(i)（0 <= i <= n）。f[0] = T()、f[1] = T(1)。
+template <class T, class F>
+std::vector<T> multiplicative_table(int n, F fpk) {
+    std::vector<T> f(n + 1, T());
+    if (n >= 1) f[1] = T(1);
+    std::vector<int> primes;
+    std::vector<bool> composite(n + 1, false);
+    // cnt[i]: i の最小素因数 p の指数、pk[i]: p^cnt[i]
+    std::vector<int> cnt(n + 1, 0), pk(n + 1, 0);
+    for (int i = 2; i <= n; ++i) {
+        if (!composite[i]) {
+            primes.emplace_back(i);
+            cnt[i] = 1, pk[i] = i;
+            f[i] = fpk(i, 1, i);
+        }
+        for (int p : primes) {
+            const std::int64_t ip = (std::int64_t)i * p;
+            if (ip > n) break;
+            const int j = (int)ip;
+            composite[j] = true;
+            if (i % p == 0) {
+                // p は i の最小素因数。指数が 1 増える。
+                cnt[j] = cnt[i] + 1, pk[j] = pk[i] * p;
+                // i = pk[i] * (i / pk[i])、後者は p と互いに素。
+                f[j] = f[i / pk[i]] * fpk(p, cnt[j], pk[j]);
+                break;
+            }
+            // gcd(i, p) = 1。
+            cnt[j] = 1, pk[j] = p;
+            f[j] = f[i] * f[p];
+        }
+    }
+    return f;
+}
+
+/// @brief オイラーのトーシェント関数 φ(1), ..., φ(n)
+///
+/// φ(p^k) = p^k - p^(k-1)。
+std::vector<int> euler_phi_table(int n) {
+    return multiplicative_table<int>(n, [](int p, int, int pk) { return pk - pk / p; });
+}
+
+/// @brief メビウス関数 μ(1), ..., μ(n)
+///
+/// μ(p) = -1、μ(p^k) = 0 (k >= 2)。
+std::vector<int> mobius_table(int n) {
+    return multiplicative_table<int>(n, [](int, int k, int) { return k == 1 ? -1 : 0; });
+}
+
+/// @brief 約数の個数 σ_0(1), ..., σ_0(n)
+///
+/// σ_0(p^k) = k + 1。
+std::vector<int> divisor_count_table(int n) {
+    return multiplicative_table<int>(n, [](int, int k, int) { return k + 1; });
+}
+
+/// @brief 約数の総和 σ_1(1), ..., σ_1(n)
+///
+/// σ_1(p^k) = 1 + p + ... + p^k。
+std::vector<std::int64_t> divisor_sum_table(int n) {
+    return multiplicative_table<std::int64_t>(n, [](int p, int k, int) {
+        std::int64_t sum = 1, cur = 1;
+        for (int i = 0; i < k; ++i) sum += (cur *= p);
+        return sum;
+    });
+}

--- a/lib/number_theory/multiplicative_function.hpp
+++ b/lib/number_theory/multiplicative_function.hpp
@@ -18,30 +18,36 @@ std::vector<T> multiplicative_table(int n, F fpk) {
     std::vector<T> f(n + 1, T());
     if (n >= 1) f[1] = T(1);
     std::vector<int> primes;
-    std::vector<bool> composite(n + 1, false);
-    // cnt[i]: i の最小素因数 p の指数、pk[i]: p^cnt[i]
-    std::vector<int> cnt(n + 1, 0), pk(n + 1, 0);
+    // π(n) ≈ n/(ln n - 1.1)。小さい n では分母が非正になり得るので大きいときのみ予約。
+    if (n >= 16) primes.reserve((std::size_t)(n / (std::log((double)n) - 1.1)) + 16);
+    // low[i] = {最小素因数 p の指数 cnt, p^cnt}。cnt と pk を 1 構造体にまとめると
+    // j = i*p への散在書き込みが 1 キャッシュラインに収まり篩が速くなる。pk==0 が
+    // 未確定（素数）の印を兼ねるので別途 composite 配列は持たない。
+    struct Low {
+        int cnt, pk;
+    };
+    std::vector<Low> low(n + 1, {0, 0});
     for (int i = 2; i <= n; ++i) {
-        if (!composite[i]) {
+        if (low[i].pk == 0) {  // i は素数
             primes.emplace_back(i);
-            cnt[i] = 1, pk[i] = i;
+            low[i] = {1, i};
             f[i] = fpk(i, 1, i);
         }
+        const int ci = low[i].cnt, pki = low[i].pk;  // i の最小素因数の指数と冪
+        const T fi = f[i];
         for (int p : primes) {
             const std::int64_t ip = (std::int64_t)i * p;
             if (ip > n) break;
             const int j = (int)ip;
-            composite[j] = true;
             if (i % p == 0) {
-                // p は i の最小素因数。指数が 1 増える。
-                cnt[j] = cnt[i] + 1, pk[j] = pk[i] * p;
-                // i = pk[i] * (i / pk[i])、後者は p と互いに素。
-                f[j] = f[i / pk[i]] * fpk(p, cnt[j], pk[j]);
+                // p は i の最小素因数。指数が 1 増える。i = pki * (i/pki)、後者は p と互いに素。
+                low[j] = {ci + 1, pki * p};
+                f[j] = f[i / pki] * fpk(p, ci + 1, pki * p);
                 break;
             }
             // gcd(i, p) = 1。
-            cnt[j] = 1, pk[j] = p;
-            f[j] = f[i] * f[p];
+            low[j] = {1, p};
+            f[j] = fi * f[p];
         }
     }
     return f;
@@ -97,40 +103,39 @@ struct MultiplicativeSum {
     /// @param G G(m) = Σ_{i=1}^{m} g(i)
     /// @param H H(m) = Σ_{i=1}^{m} (f*g)(i)
     MultiplicativeSum(long long n, std::vector<T> f_prefix, T g1, Gsum G, Hsum H)
-        : n(n), threshold((long long)f_prefix.size() - 1), small(std::move(f_prefix)), g1(g1), G(G), H(H) {
-        long long size = threshold > 0 ? n / threshold + 1 : 1;
-        large.assign(size, T());
-        done.assign(size, false);
+        : n(n), threshold((long long)f_prefix.size() - 1), small(std::move(f_prefix)) {
+        // large[i] = S(⌊n/i⌋)。⌊n/i⌋ が閾値超えの i についてのみ持つ。
+        const long long L = threshold > 0 ? n / threshold : 0;
+        large.assign(L + 1, T());
+        const bool g1_one = (g1 == T(1));
+        // m = ⌊n/i⌋ 昇順（i 降順）に計算する。各 S(q)（q < m）は small か計算済み large から
+        // 引けるので再帰不要・メモ判定不要。葉 q<=threshold は small を直接参照する。
+        for (long long i = L; i >= 1; --i) {
+            const long long m = n / i;
+            if (m <= threshold) continue;  // small で足りる
+            T res = H(m);
+            T gprev = G(1);  // d-1 = 1 の G 値（次反復の G(d-1) を持ち回す）
+            for (long long d = 2, nd; d <= m; d = nd + 1) {
+                const long long q = m / d;
+                nd = m / q;  // ⌊m/d⌋ == q となる d の最大値
+                const T gnd = G(nd);
+                const T sq = (q <= threshold) ? small[q] : large[n / q];  // q < m なので算出済み
+                res -= (gnd - gprev) * sq;
+                gprev = gnd;
+            }
+            large[i] = g1_one ? res : res / g1;
+        }
     }
 
     /// @brief S(n) = Σ_{i=1}^{n} f(i)
-    T sum() { return get(n); }
+    T sum() const { return get(n); }
 
-    /// @brief S(m) = Σ_{i=1}^{m} f(i)（m <= n）
-    T get(long long m) {
-        if (m <= threshold) return small[m];
-        // m > threshold の値は m = ⌊n/idx⌋ の形なので idx をキーにメモ化する。
-        long long idx = n / m;
-        if (done[idx]) return large[idx];
-        T res = H(m);
-        for (long long d = 2, nd; d <= m; d = nd + 1) {
-            long long q = m / d;
-            nd = m / q;  // ⌊m/d⌋ == q となる d の最大値
-            res -= (G(nd) - G(d - 1)) * get(q);
-        }
-        if (!(g1 == T(1))) res = res / g1;
-        large[idx] = res;
-        done[idx] = true;
-        return res;
-    }
+    /// @brief S(m) = Σ_{i=1}^{m} f(i)（m <= n、⌊n/i⌋ の形の値）
+    T get(long long m) const { return m <= threshold ? small[m] : large[n / m]; }
 
   private:
     long long n, threshold;
     std::vector<T> small, large;
-    std::vector<bool> done;
-    T g1;
-    Gsum G;
-    Hsum H;
 };
 
 namespace internal {

--- a/test/yosupo/number_theory/sum_of_multiplicative_function.test.cpp
+++ b/test/yosupo/number_theory/sum_of_multiplicative_function.test.cpp
@@ -1,0 +1,26 @@
+// competitive-verifier: PROBLEM https://judge.yosupo.jp/problem/sum_of_multiplicative_function
+#include <iostream>
+#include <utility>
+#include <vector>
+#include "math/modint.hpp"
+#include "number_theory/min25_sieve.hpp"
+
+// f は f(p^e) = a*e + b*p を満たす乗法的関数。f(p) = a + b*p。
+using Mint = static_modint<469762049>;
+
+int main() {
+    int t;
+    std::cin >> t;
+    const Mint inv2 = Mint(1) / Mint(2);
+    while (t--) {
+        long long n, a, b;
+        std::cin >> n >> a >> b;
+        std::vector<Min25Term<Mint>> terms = {
+            {Mint(a), 0, [](long long x) { return Mint(x); }},
+            {Mint(b), 1, [inv2](long long x) { return Mint(x) * Mint(x + 1) * inv2; }},
+        };
+        auto fpe = [a, b](long long p, int e, long long) { return Mint(a) * Mint(e) + Mint(b) * Mint(p); };
+        std::cout << min25_sum<Mint>(n, std::move(terms), fpe) << '\n';
+    }
+    return 0;
+}

--- a/test/yosupo/number_theory/sum_of_multiplicative_function_large.test.cpp
+++ b/test/yosupo/number_theory/sum_of_multiplicative_function_large.test.cpp
@@ -1,0 +1,26 @@
+// competitive-verifier: PROBLEM https://judge.yosupo.jp/problem/sum_of_multiplicative_function_large
+#include <iostream>
+#include <utility>
+#include <vector>
+#include "math/modint.hpp"
+#include "number_theory/min25_sieve.hpp"
+
+// f は f(p^e) = a*e + b*p を満たす乗法的関数。f(p) = a + b*p。
+using Mint = static_modint<469762049>;
+
+int main() {
+    int t;
+    std::cin >> t;
+    const Mint inv2 = Mint(1) / Mint(2);
+    while (t--) {
+        long long n, a, b;
+        std::cin >> n >> a >> b;
+        std::vector<Min25Term<Mint>> terms = {
+            {Mint(a), 0, [](long long x) { return Mint(x); }},
+            {Mint(b), 1, [inv2](long long x) { return Mint(x) * Mint(x + 1) * inv2; }},
+        };
+        auto fpe = [a, b](long long p, int e, long long) { return Mint(a) * Mint(e) + Mint(b) * Mint(p); };
+        std::cout << min25_sum<Mint>(n, std::move(terms), fpe) << '\n';
+    }
+    return 0;
+}

--- a/test/yosupo/number_theory/sum_of_totient_function.test.cpp
+++ b/test/yosupo/number_theory/sum_of_totient_function.test.cpp
@@ -1,0 +1,13 @@
+// competitive-verifier: PROBLEM https://judge.yosupo.jp/problem/sum_of_totient_function
+#include <iostream>
+#include "math/modint.hpp"
+#include "number_theory/multiplicative_function.hpp"
+
+using Mint = modint998;
+
+int main() {
+    long long n;
+    std::cin >> n;
+    std::cout << totient_sum<Mint>(n) << '\n';
+    return 0;
+}


### PR DESCRIPTION
## 概要

乗法的関数まわりを 3 段構えで追加。

- **O(N) 表** `multiplicative_function.hpp` … 汎用線形篩 `multiplicative_table(n, fpk)` と `euler_phi_table` / `mobius_table` / `divisor_count_table` / `divisor_sum_table`。
- **杜教筛 O(N^{2/3})** … `MultiplicativeSum` と `totient_sum<T>(n)` / `mobius_sum<T>(n)`（メルテンス）。
- **Min_25 篩 O(N^{3/4}/log N)** `min25_sieve.hpp` … 素数での値が p の多項式 Σ coef·p^pw で表せる乗法的関数の累積和 `min25_sum<T>(n, terms, fpe)`。

## verify

| 問題 | 関数 | 制約 | 計測 |
|---|---|---|---|
| [sum_of_totient_function](https://judge.yosupo.jp/problem/sum_of_totient_function) | `totient_sum` | N≤1e10 | 0.17s |
| [sum_of_multiplicative_function](https://judge.yosupo.jp/problem/sum_of_multiplicative_function) | `min25_sum` | N≤1e11 | 0.5s |
| [sum_of_multiplicative_function_large](https://judge.yosupo.jp/problem/sum_of_multiplicative_function_large) | `min25_sum` | N≤1e13, TL30s | 15s |

`mobius_sum`（メルテンス）は対応する判定問題が見当たらず verify 保留（M(1e5)=-48, M(1e6)=212 等の既知値・naive と一致を確認済み）。

## 検証

- 線形篩 naive（gcd 列挙・試し割り）と表・累積和を突き合わせ。
- 独立実装どうしのクロスチェック: 杜教筛 `totient_sum` と Min_25（φ 設定）が N≤1e10 で完全一致。
- Library Checker 公式サンプル一致。

## 高速化

- Min_25: f(p)・f(p²) を build 時に事前計算して再帰ホットパスの fpe 約20億回を削減、葉のインライン化、N/i 事前計算等で **N=1e13 を 26s→15s**。
- 線形篩: cnt+pk を構造体結合し散在書き込みを 1 キャッシュライン化。杜教筛: 再帰を反復計算化。