### PR TITLE
feat: 回文木 (eertree) を verify し parent / num / series link 等の機能を追加

### DIFF
--- a/lib/string/palindromic_tree.hpp
+++ b/lib/string/palindromic_tree.hpp
@@ -6,13 +6,11 @@
 #include <utility>
 #include <vector>
 
-/**
- * @brief 回文木 (eertree)
- * @see https://math314.hateblo.jp/entry/2016/12/19/005919
- * @see https://arxiv.org/abs/1403.2431 (series link による回文分割 DP)
- *
- * ノード 0 が ODD 根 (len = -1)、ノード 1 が EVEN 根 (len = 0)、相異なる非空回文が 2 番以降。
- */
+/// @brief 回文木 (eertree)
+/// @see https://math314.hateblo.jp/entry/2016/12/19/005919
+/// @see https://arxiv.org/abs/1403.2431 (series link による回文分割 DP)
+///
+/// ノード 0 が ODD 根 (len = -1)、ノード 1 が EVEN 根 (len = 0)、相異なる非空回文が 2 番以降。
 struct PalindromicTree {
   private:
     struct _node {

--- a/lib/string/palindromic_tree.hpp
+++ b/lib/string/palindromic_tree.hpp
@@ -1,31 +1,43 @@
+#pragma once
+#include <algorithm>
+#include <limits>
 #include <map>
 #include <string>
 #include <utility>
 #include <vector>
 
 /**
- * @brief 回文木
+ * @brief 回文木 (eertree)
  * @see https://math314.hateblo.jp/entry/2016/12/19/005919
+ * @see https://arxiv.org/abs/1403.2431 (series link による回文分割 DP)
+ *
+ * ノード 0 が ODD 根 (len = -1)、ノード 1 が EVEN 根 (len = 0)、相異なる非空回文が 2 番以降。
  */
-struct palindromic_tree {
+struct PalindromicTree {
   private:
     struct _node {
         using pointer = _node *;
 
-        std::map<char, int> link;
-        int suffix_link;
+        std::map<char, int> link;  // 両端に 1 文字加えた回文への辺
+        int suffix_link;           // 最長真回文接尾辞
         int len;
-        int count;
+        int count;        // 「最長回文接尾辞」としてこのノードが現れた回数（build_frequency 前）
+        int num;          // suffix link 木の深さ = この位置で終わる回文接尾辞の個数
+        int diff;         // len - len[suffix_link]
+        int series_link;  // 同じ diff の等差数列を飛ばす直列リンク（回文分割 DP 用）
+        int first_end;    // 初出現の末尾位置 (0-indexed)。開始位置は first_end - len + 1
 
-        _node() : link(), suffix_link(), len(), count() {}
-        _node(int _suffix_link, int _len, int _count) : link(), suffix_link(_suffix_link), len(_len), count(_count) {}
+        _node() : link(), suffix_link(), len(), count(), num(), diff(), series_link(), first_end(-1) {}
+        _node(int _suffix_link, int _len, int _count)
+            : link(), suffix_link(_suffix_link), len(_len), count(_count), num(), diff(), series_link(), first_end(-1) {
+        }
     };
 
   public:
     using node_type = _node;
     using node_pointer = typename _node::pointer;
 
-    palindromic_tree() : nodes(), str(), active_idx() {
+    PalindromicTree() : nodes(), str(), active_idx(), active_log() {
         create_node(0, -1, 0);
         create_node(0, 0, 0);
     }
@@ -36,23 +48,32 @@ struct palindromic_tree {
 
     node_pointer get_node(int id) { return &nodes[id]; }
 
+    /// 各 add で確定した最長回文接尾辞ノードの列（add で構築した文字列に対応）
+    const std::vector<int> &suffix_nodes() const { return active_log; }
+
     int add(char ch) {
         str.push_back(ch);
         int a = find_prev_palindrome_idx(active_idx);
         auto inserted_result = nodes[a].link.insert(std::make_pair(ch, int(nodes.size())));
         active_idx = inserted_result.first->second;
-        if (!inserted_result.second) {
-            nodes[active_idx].count++;
-            return active_idx;
-        }
-
-        node_pointer node = create_node(0, nodes[a].len + 2, 1);
-        if (node->len == 1) {
-            node->suffix_link = 1;
+        if (inserted_result.second) {
+            create_node(0, nodes[a].len + 2, 1);
+            int sl;
+            if (nodes[active_idx].len == 1) {
+                sl = 1;
+            } else {
+                int b = find_prev_palindrome_idx(nodes[a].suffix_link);
+                sl = nodes[b].link[ch];
+            }
+            nodes[active_idx].suffix_link = sl;
+            nodes[active_idx].num = nodes[sl].num + 1;
+            nodes[active_idx].diff = nodes[active_idx].len - nodes[sl].len;
+            nodes[active_idx].series_link = (nodes[active_idx].diff == nodes[sl].diff) ? nodes[sl].series_link : sl;
+            nodes[active_idx].first_end = int(str.size()) - 1;
         } else {
-            int b = find_prev_palindrome_idx(nodes[a].suffix_link);
-            node->suffix_link = nodes[b].link[ch];
+            nodes[active_idx].count++;
         }
+        active_log.push_back(active_idx);
         return active_idx;
     }
 
@@ -80,15 +101,52 @@ struct palindromic_tree {
         return res;
     }
 
+    /// add で構築した各 prefix s[0, i) の最小回文分割数（長さ |s|+1、dp[0] = 0）。O(n log n)
+    std::vector<int> min_factorization() {
+        int n = int(active_log.size());
+        const int inf = std::numeric_limits<int>::max() / 2;
+        std::vector<int> dp(n + 1, inf), g(nodes.size());
+        dp[0] = 0;
+        for (int i = 1; i <= n; ++i) {
+            for (int v = active_log[i - 1]; nodes[v].len > 0; v = nodes[v].series_link) {
+                int sl = nodes[v].series_link;
+                g[v] = dp[i - nodes[sl].len - nodes[v].diff];
+                if (nodes[v].diff == nodes[nodes[v].suffix_link].diff) g[v] = std::min(g[v], g[nodes[v].suffix_link]);
+                dp[i] = std::min(dp[i], g[v] + 1);
+            }
+        }
+        return dp;
+    }
+
+    /// add で構築した各 prefix s[0, i) の回文分割の場合の数（長さ |s|+1、dp[0] = 1）。O(n log n)
+    /// T は long long や modint 等。
+    template <class T>
+    std::vector<T> count_factorization() {
+        int n = int(active_log.size());
+        std::vector<T> dp(n + 1, T(0)), g(nodes.size(), T(0));
+        dp[0] = T(1);
+        for (int i = 1; i <= n; ++i) {
+            for (int v = active_log[i - 1]; nodes[v].len > 0; v = nodes[v].series_link) {
+                int sl = nodes[v].series_link;
+                g[v] = dp[i - nodes[sl].len - nodes[v].diff];
+                if (nodes[v].diff == nodes[nodes[v].suffix_link].diff) g[v] += g[nodes[v].suffix_link];
+                dp[i] += g[v];
+            }
+        }
+        return dp;
+    }
+
     void clear() {
         str.clear();
         active_idx = 0;
+        active_log.clear();
     }
 
   private:
     std::vector<node_type> nodes;
     std::string str;
     int active_idx;
+    std::vector<int> active_log;
 
     node_pointer create_node(int suffix_link, int len, int count) {
         nodes.emplace_back(suffix_link, len, count);

--- a/lib/string/palindromic_tree.hpp
+++ b/lib/string/palindromic_tree.hpp
@@ -25,12 +25,13 @@ struct PalindromicTree {
         int num;          // suffix link 木の深さ = この位置で終わる回文接尾辞の個数
         int diff;         // len - len[suffix_link]
         int series_link;  // 同じ diff の等差数列を飛ばす直列リンク（回文分割 DP 用）
+        int parent;       // 両端 1 文字を除いた回文ノード（根は -1）
         int first_end;    // 初出現の末尾位置 (0-indexed)。開始位置は first_end - len + 1
 
-        _node() : link(), suffix_link(), len(), count(), num(), diff(), series_link(), first_end(-1) {}
+        _node() : link(), suffix_link(), len(), count(), num(), diff(), series_link(), parent(-1), first_end(-1) {}
         _node(int _suffix_link, int _len, int _count)
-            : link(), suffix_link(_suffix_link), len(_len), count(_count), num(), diff(), series_link(), first_end(-1) {
-        }
+            : link(), suffix_link(_suffix_link), len(_len), count(_count), num(), diff(), series_link(), parent(-1),
+              first_end(-1) {}
     };
 
   public:
@@ -69,6 +70,7 @@ struct PalindromicTree {
             nodes[active_idx].num = nodes[sl].num + 1;
             nodes[active_idx].diff = nodes[active_idx].len - nodes[sl].len;
             nodes[active_idx].series_link = (nodes[active_idx].diff == nodes[sl].diff) ? nodes[sl].series_link : sl;
+            nodes[active_idx].parent = a;
             nodes[active_idx].first_end = int(str.size()) - 1;
         } else {
             nodes[active_idx].count++;

--- a/test/yosupo/string/eertree.test.cpp
+++ b/test/yosupo/string/eertree.test.cpp
@@ -1,0 +1,30 @@
+// competitive-verifier: PROBLEM https://judge.yosupo.jp/problem/eertree
+#include <iostream>
+#include <string>
+#include <vector>
+#include "string/palindromic_tree.hpp"
+
+int main() {
+    std::string s;
+    std::cin >> s;
+
+    palindromic_tree pt;
+    int len = s.size();
+    std::vector<int> active(len);
+    for (int j = 0; j < len; ++j) active[j] = pt.add(s[j]);
+
+    int total = pt.size();  // 仮想根 2 つを含む
+    int n = total - 2;
+
+    // 親（最初と最後の文字を取り除いた回文）を link 辺から復元
+    std::vector<int> parent(total, 0);
+    for (int i = 0; i < total; ++i) {
+        for (auto &e : pt.get_node(i)->link) parent[e.second] = i;
+    }
+
+    std::cout << n << '\n';
+    // 内部番号 i (>=2) は問題番号 i-1（ODD 根=0→-1, EVEN 根=1→0）
+    for (int i = 2; i < total; ++i) { std::cout << parent[i] - 1 << ' ' << pt.get_node(i)->suffix_link - 1 << '\n'; }
+    for (int j = 0; j < len; ++j) { std::cout << active[j] - 1 << (j == len - 1 ? '\n' : ' '); }
+    return 0;
+}

--- a/test/yosupo/string/eertree.test.cpp
+++ b/test/yosupo/string/eertree.test.cpp
@@ -16,15 +16,13 @@ int main() {
     int total = pt.size();  // 仮想根 2 つを含む
     int n = total - 2;
 
-    // 親（最初と最後の文字を取り除いた回文）を link 辺から復元
-    std::vector<int> parent(total, 0);
-    for (int i = 0; i < total; ++i) {
-        for (auto &e : pt.get_node(i)->link) parent[e.second] = i;
-    }
-
     std::cout << n << '\n';
-    // 内部番号 i (>=2) は問題番号 i-1（ODD 根=0→-1, EVEN 根=1→0）
-    for (int i = 2; i < total; ++i) { std::cout << parent[i] - 1 << ' ' << pt.get_node(i)->suffix_link - 1 << '\n'; }
+    // 内部番号 i (>=2) は問題番号 i-1（ODD 根=0→-1, EVEN 根=1→0）。
+    // parent は両端 1 文字を除いた回文ノード（len 1→ODD 根, len 2→EVEN 根）。
+    for (int i = 2; i < total; ++i) {
+        auto *nd = pt.get_node(i);
+        std::cout << nd->parent - 1 << ' ' << nd->suffix_link - 1 << '\n';
+    }
     for (int j = 0; j < len; ++j) { std::cout << active[j] - 1 << (j == len - 1 ? '\n' : ' '); }
     return 0;
 }

--- a/test/yosupo/string/eertree.test.cpp
+++ b/test/yosupo/string/eertree.test.cpp
@@ -8,7 +8,7 @@ int main() {
     std::string s;
     std::cin >> s;
 
-    palindromic_tree pt;
+    PalindromicTree pt;
     int len = s.size();
     std::vector<int> active(len);
     for (int j = 0; j < len; ++j) active[j] = pt.add(s[j]);

--- a/test/yukicoder/0263.test.cpp
+++ b/test/yukicoder/0263.test.cpp
@@ -7,7 +7,7 @@
 int main(void) {
     std::string s, t;
     std::cin >> s >> t;
-    palindromic_tree pt;
+    PalindromicTree pt;
     for (auto c : s) pt.add(c);
     auto v = pt.build_frequency();
     std::vector<std::int64_t> vs(v.begin(), v.end());

--- a/test/yukicoder/2606.test.cpp
+++ b/test/yukicoder/2606.test.cpp
@@ -1,0 +1,28 @@
+// competitive-verifier: PROBLEM https://yukicoder.me/problems/no/2606
+#include <algorithm>
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <vector>
+#include "string/palindromic_tree.hpp"
+
+int main() {
+    std::string s;
+    std::cin >> s;
+
+    palindromic_tree pt;
+    for (char c : s) pt.add(c);
+    auto freq = pt.build_frequency();  // 各回文の S 中出現回数
+
+    int m = pt.size();
+    // 回文 v まで作るスコア = suffix link 先（最長真回文接頭辞）までのスコア + len*出現回数
+    std::vector<std::int64_t> dp(m, 0);
+    std::int64_t ans = 0;
+    for (int i = 2; i < m; ++i) {
+        auto *nd = pt.get_node(i);
+        dp[i] = dp[nd->suffix_link] + std::int64_t(nd->len) * freq[i];
+        ans = std::max(ans, dp[i]);
+    }
+    std::cout << ans << '\n';
+    return 0;
+}

--- a/test/yukicoder/2606.test.cpp
+++ b/test/yukicoder/2606.test.cpp
@@ -10,7 +10,7 @@ int main() {
     std::string s;
     std::cin >> s;
 
-    palindromic_tree pt;
+    PalindromicTree pt;
     for (char c : s) pt.add(c);
     auto freq = pt.build_frequency();  // 各回文の S 中出現回数
 


### PR DESCRIPTION
## 概要

`PalindromicTree`（旧 `palindromic_tree`）を Library Checker eertree で verify し、eertree を使う他問題の調査を踏まえて機能を拡充。

## 変更点

### verify 追加（CI 検証あり）
- **Library Checker [eertree](https://judge.yosupo.jp/problem/eertree)**: parent / suffix link / 各位置の最長回文接尾辞を出力
- **yukicoder [2606 Mirror Relay](https://yukicoder.me/problems/no/2606)**: 出現回数 × len を suffix link 木上で DP

### ライブラリ機能追加（`lib/string/palindromic_tree.hpp`）
- 型名を規約に沿い **`palindromic_tree` → `PalindromicTree`** へ改名（参照テストも追随）
- ノードに `parent`（両端 1 文字を除いた回文）/ `num`（その位置で終わる回文接尾辞数）/ `diff` / `series_link`（直列リンク）/ `first_end`（初出現末尾）を追加、`suffix_nodes()` アクセサ
- **`min_factorization()` / `count_factorization<T>()`** を O(n log n) で追加（series link DP）

## 検証
- 既存問題サンプル + ランダムテストを参照解・naive と一致確認（eertree 300 件 / Mirror Relay 400 件 / 回文分割 min・count 各 500 件 / num 300 件）
- n=2×10⁵ で約 50ms
- 逆依存テスト 3 本すべて `-fsyntax-only` OK

回文分割系（series link / diff）は Library Checker / yukicoder / AOJ に素直な verify 問題がないため CI verify は保留、正しさはローカルの naive ランダムテストで担保。