### PR TITLE
feat: 原始根 primitive_root

### DIFF
--- a/lib/number_theory/factorize.hpp
+++ b/lib/number_theory/factorize.hpp
@@ -42,6 +42,18 @@ std::uint64_t pollard_rho(std::uint64_t n) {
     return g;
 }
 
+/// @return `(x ** n) % mod`（`mod < 2^32` で安全）
+std::uint64_t pow_mod_u64(std::uint64_t x, std::uint64_t n, std::uint64_t mod) {
+    x %= mod;
+    std::uint64_t r = 1;
+    while (n) {
+        if (n & 1) r = (__uint128_t)r * x % mod;
+        x = (__uint128_t)x * x % mod;
+        n >>= 1;
+    }
+    return r;
+}
+
 std::vector<std::uint64_t> inner_factorize(std::uint64_t n) {
     if (n <= 1) return {};
     std::uint64_t p = pollard_rho(n);
@@ -77,3 +89,22 @@ std::uint64_t number_of_divisors(std::vector<std::uint64_t> v) {
 }
 
 std::uint64_t number_of_divisors(std::uint64_t n) { return number_of_divisors(internal::inner_factorize(n)); }
+
+/// @brief 原始根
+/// @param p 素数
+/// @return p の最小の原始根
+std::uint64_t primitive_root(std::uint64_t p) {
+    if (p == 2) return 1;
+    auto pf = factorize(p - 1);
+    pf.erase(std::unique(pf.begin(), pf.end()), pf.end());
+    for (std::uint64_t g = 2;; ++g) {
+        bool ok = true;
+        for (auto q : pf) {
+            if (internal::pow_mod_u64(g, (p - 1) / q, p) == 1) {
+                ok = false;
+                break;
+            }
+        }
+        if (ok) return g;
+    }
+}

--- a/test/yosupo/number_theory/primitive_root.test.cpp
+++ b/test/yosupo/number_theory/primitive_root.test.cpp
@@ -1,0 +1,16 @@
+// competitive-verifier: PROBLEM https://judge.yosupo.jp/problem/primitive_root
+#include <cstdint>
+#include <iostream>
+#include "number_theory/factorize.hpp"
+
+int main(void) {
+    int q;
+    std::cin >> q;
+    while (q--) {
+        std::uint64_t p;
+        std::cin >> p;
+        std::cout << primitive_root(p) << '\n';
+    }
+
+    return 0;
+}


### PR DESCRIPTION
素数 p に対し最小の原始根を返す primitive_root を factorize.hpp に追加。
p-1 を factorize で素因数分解し、各素因数 q について g^((p-1)/q) != 1 を
満たす最小の g を線形探索する。素因数分解の応用なので number_of_divisors と
同じく factorize.hpp に同居。mod < 2^32 で安全な pow_mod_u64 を internal に用意。

Library Checker primitive_root を verify。

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
