### PR TITLE
setup タスクで daily-problems-cli を最新化する

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -28,6 +28,9 @@ description = "Setup project（ツール・oj-tools・shim を一括導入）"
 run = [
     # [tools] 宣言（jq / uv / clang-format / pipx:oj 系）をまとめて導入。
     "mise install",
+    # git+ インストールはバージョン表記が常に latest のままで `mise upgrade` が
+    # 更新を検知できないため、--force で再インストールして HEAD を取り直す。
+    "mise install --force 'pipx:git+https://github.com/kuhaku-space/daily-problems-cli.git'",
     # CLI でしか入らないシステムパッケージ。
     "which xclip > /dev/null || (sudo apt update -qq && sudo apt install -qq xclip)",
     "which g++-14 > /dev/null || (sudo apt update -qq && sudo apt install -qq g++-14)",


### PR DESCRIPTION
git+ インストールはバージョン表記が常に latest のままで mise upgrade が
更新を検知できないため、setup 時に --force で再インストールして HEAD を取り直す。

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
