### PR TITLE
chore: AtCoder の C++23 環境更新に合わせて -flto=auto を削除

### DIFF
--- a/.verify-helper/config.toml
+++ b/.verify-helper/config.toml
@@ -7,7 +7,6 @@ CXXFLAGS = [
     "-fconstexpr-depth=1024",
     "-fconstexpr-loop-limit=524288",
     "-fconstexpr-ops-limit=2097152",
-    "-flto=auto",
     "-march=native",
     "-pthread",
     "-std=gnu++23",

--- a/mise.toml
+++ b/mise.toml
@@ -185,7 +185,7 @@ oj_bundle() {
 }
 oj_compile() {
   # 共通フラグ。デバッグ時は最適化・LTO を外しサニタイザを足す。
-  local opt_args=(-O2 -flto=auto -ftrivial-auto-var-init=zero)
+  local opt_args=(-O2 -ftrivial-auto-var-init=zero)
   if [[ "$usage_debug" == "true" ]]; then
     opt_args=(-O1 -g -fsanitize=address,undefined -D_GLIBCXX_DEBUG)
   fi
@@ -288,7 +288,7 @@ oj_compile() {
     -DUSE_MATH_OPT -DUSE_PDLP -DUSE_SCIP \\
     -O2 -Wall -Wextra \\
     -fconstexpr-depth=1024 -fconstexpr-loop-limit=524288 -fconstexpr-ops-limit=2097152 \\
-    -flto=auto -ftrivial-auto-var-init=zero -march=native -pthread \\
+    -ftrivial-auto-var-init=zero -march=native -pthread \\
     -std=gnu++23 -Wl,--as-needed -fopenmp
 }
 [[ -f "$usage_src" ]] || { echo "$usage_src が見つかりません" >&2; exit 1; }


### PR DESCRIPTION
## Summary
- AtCoder が C++23 (GCC 15.2.0) のコンパイルオプションから `-flto=auto` を削除したお知らせに合わせ、`.verify-helper/config.toml` の verify 環境設定から `-flto=auto` を削除
- 同オプションを含む `mise.toml` の `build`/`random-check` タスク（AtCoder 提出環境を模したローカルビルド）からも追従して削除

## Test plan
- [ ] CI（competitive-verifier）の通過を確認