### PR TITLE
refactor: Trie を整理し count/depth を追加

### DIFF
--- a/lib/string/trie.hpp
+++ b/lib/string/trie.hpp
@@ -9,65 +9,70 @@
 template <int char_size = 96, int base = ' '>
 struct Trie {
   private:
-    struct _node {
+    struct Node {
         std::vector<int> next_node;
-        _node() : next_node(char_size, -1) {}
+        int count;
+        int depth;
+        Node() : next_node(char_size, -1), count(0), depth(0) {}
     };
 
-  public:
-    using node_type = _node;
+    static int to_index(char ch) {
+        int c = ch - base;
+        assert(0 <= c && c < char_size);
+        return c;
+    }
 
-    Trie() : root(0), nodes() { nodes.emplace_back(); }
+  public:
+    using node_type = Node;
+
+    Trie() : nodes() { nodes.emplace_back(); }
 
     int size() const { return nodes.size(); }
 
     /// @brief ノード node_id の子 ch をたどる。無ければ新規作成する。
     /// @return 子ノードの id
+    /// @note 到達した子ノードの count を1増やす（その接頭辞を持つ文字列の本数になる）。
+    ///       新規作成時は depth（根からの接頭辞長）も設定する。
     int add(int node_id, char ch) {
         assert(0 <= node_id && node_id < (int)nodes.size());
-        int c = ch - base;
-        assert(0 <= c && c < char_size);
+        int c = to_index(ch);
         int &next_id = nodes[node_id].next_node[c];
         if (next_id == -1) {
             next_id = nodes.size();
             nodes.emplace_back();
+            nodes[next_id].depth = nodes[node_id].depth + 1;
         }
+        ++nodes[next_id].count;
         return next_id;
     }
 
     std::vector<int> insert(const std::string &word) {
         std::vector<int> res;
+        res.reserve(word.size());
         int node_id = 0;
-        for (int i = 0; i < (int)word.size(); ++i) {
-            int c = word[i] - base;
-            int &next_id = nodes[node_id].next_node[c];
-            if (next_id == -1) {
-                next_id = nodes.size();
-                nodes.emplace_back();
-            }
-            node_id = next_id;
+        for (char ch : word) {
+            node_id = add(node_id, ch);
             res.emplace_back(node_id);
         }
         return res;
     }
 
-    int search_id(const std::string &word) {
+    int search_id(const std::string &word) const {
         int node_id = 0;
-        for (int i = 0; i < (int)word.size(); ++i) {
-            int c = word[i] - base;
-            int &next_id = nodes[node_id].next_node[c];
+        for (char ch : word) {
+            int c = to_index(ch);
+            int next_id = nodes[node_id].next_node[c];
             if (next_id == -1) return -1;
             node_id = next_id;
         }
         return node_id;
     }
 
-    node_type get_node(int node_id) const {
+    const node_type &get_node(int node_id) const {
         assert(0 <= node_id && node_id < (int)nodes.size());
         return nodes[node_id];
     }
 
   private:
-    int root;
     std::vector<node_type> nodes;
 };


### PR DESCRIPTION
- 未使用の root を削除、insert が add を再利用するよう重複を解消
- search_id/add に共通の範囲チェックを追加、search_id を const 化
- get_node の不要なコピーを削減、_node を Node に改名
- Node に count(その接頭辞を持つ文字列数)と depth(接頭辞長)を追加
