### PR TITLE
refactor/ordered multiset rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ g++ -std=c++23 -I lib your_solution.cpp
 | [`lib/fenwick/`](lib/fenwick/)               | Fenwick Tree（点更新区間和・区間加算区間和）                                              |
 | [`lib/sparse_table/`](lib/sparse_table/)     | Sparse Table・Disjoint Sparse Table・線形 Sparse Table                                    |
 | [`lib/wavelet/`](lib/wavelet/)               | Wavelet Matrix（圧縮版・動的版・矩形和）                                                  |
-| [`lib/ordered_set/`](lib/ordered_set/)       | 順序付き多重集合（AVL 木）・Binary Trie・Patricia Binary Trie・64 分木                    |
+| [`lib/ordered_set/`](lib/ordered_set/)       | 順序集合・多重集合（AVL 木）・Binary Trie・Patricia Binary Trie・64 分木                  |
 | [`lib/union_find/`](lib/union_find/)         | Union-Find（重み付き・undo・動的・永続・offline dynamic connectivity）                    |
 | [`lib/heap/`](lib/heap/)                     | Binary / Fibonacci / Leftist / Skew / Radix / Interval ヒープ・削除可能 PQ・k 番目和      |
 | [`lib/persistent_ds/`](lib/persistent_ds/)   | 永続配列・永続セグメント木・永続スタック/キュー                                           |

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ g++ -std=c++23 -I lib your_solution.cpp
 | [`lib/fenwick/`](lib/fenwick/)               | Fenwick Tree（点更新区間和・区間加算区間和）                                              |
 | [`lib/sparse_table/`](lib/sparse_table/)     | Sparse Table・Disjoint Sparse Table・線形 Sparse Table                                    |
 | [`lib/wavelet/`](lib/wavelet/)               | Wavelet Matrix（圧縮版・動的版・矩形和）                                                  |
-| [`lib/ordered_set/`](lib/ordered_set/)       | 平衡二分探索木（AVL / Treap / Splay / Scapegoat）・順序集合・Binary Trie・Skip List       |
+| [`lib/ordered_set/`](lib/ordered_set/)       | 順序付き多重集合（AVL 木）・Binary Trie・Patricia Binary Trie・64 分木                    |
 | [`lib/union_find/`](lib/union_find/)         | Union-Find（重み付き・undo・動的・永続・offline dynamic connectivity）                    |
 | [`lib/heap/`](lib/heap/)                     | Binary / Fibonacci / Leftist / Skew / Radix / Interval ヒープ・削除可能 PQ・k 番目和      |
 | [`lib/persistent_ds/`](lib/persistent_ds/)   | 永続配列・永続セグメント木・永続スタック/キュー                                           |

--- a/lib/ordered_set/ordered_multiset.hpp
+++ b/lib/ordered_set/ordered_multiset.hpp
@@ -5,7 +5,7 @@
 #include <vector>
 
 template <class T>
-struct ordered_set {
+struct OrderedMultiset {
   private:
     struct node_t {
         using pointer = node_t *;
@@ -48,8 +48,8 @@ struct ordered_set {
     using node_type = node_t;
     using node_ptr = typename node_t::pointer;
 
-    constexpr ordered_set() : root(nullptr) {}
-    constexpr ordered_set(const std::vector<T> &v) : root(nullptr) {
+    constexpr OrderedMultiset() : root(nullptr) {}
+    constexpr OrderedMultiset(const std::vector<T> &v) : root(nullptr) {
         auto build = [&v](auto self, int l, int r) -> node_ptr {
             if (l == r) return nullptr;
             int m = (l + r) >> 1;

--- a/lib/ordered_set/ordered_multiset.hpp
+++ b/lib/ordered_set/ordered_multiset.hpp
@@ -49,7 +49,8 @@ struct OrderedMultiset {
     using node_ptr = typename Node::pointer;
 
     constexpr OrderedMultiset() : root(nullptr) {}
-    constexpr OrderedMultiset(const std::vector<T> &v) : root(nullptr) {
+    constexpr OrderedMultiset(std::vector<T> v) : root(nullptr) {
+        std::sort(v.begin(), v.end());
         auto build = [&v](auto self, int l, int r) -> node_ptr {
             if (l == r) return nullptr;
             int m = (l + r) >> 1;

--- a/lib/ordered_set/ordered_multiset.hpp
+++ b/lib/ordered_set/ordered_multiset.hpp
@@ -7,36 +7,36 @@
 template <class T>
 struct OrderedMultiset {
   private:
-    struct node_t {
-        using pointer = node_t *;
+    struct Node {
+        using pointer = Node *;
 
         T val, sum;
         int height, size;
         pointer left, right;
 
-        constexpr node_t(T _val) : val(_val), sum(_val), height(1), size(1), left(nullptr), right(nullptr) {}
+        constexpr Node(T _val) : val(_val), sum(_val), height(1), size(1), left(nullptr), right(nullptr) {}
 
         static constexpr T get_sum(pointer node) { return node == nullptr ? T() : node->sum; }
         static constexpr int get_height(pointer node) { return node == nullptr ? 0 : node->height; }
         static constexpr int get_size(pointer node) { return node == nullptr ? 0 : node->size; }
         static constexpr int get_balance_factor(pointer node) {
-            return node == nullptr ? 0 : node_t::get_height(node->left) - node_t::get_height(node->right);
+            return node == nullptr ? 0 : Node::get_height(node->left) - Node::get_height(node->right);
         }
 
         constexpr void recompute() {
-            sum = node_t::get_sum(left) + val + node_t::get_sum(right);
-            height = std::max(node_t::get_height(left), node_t::get_height(right)) + 1;
-            size = node_t::get_size(left) + node_t::get_size(right) + 1;
+            sum = Node::get_sum(left) + val + Node::get_sum(right);
+            height = std::max(Node::get_height(left), Node::get_height(right)) + 1;
+            size = Node::get_size(left) + Node::get_size(right) + 1;
         }
 
         // erase したノードは再利用しないため、確保のみ行うバンプアロケータで malloc 呼び出し回数を減らす
         static constexpr std::size_t chunk_size = 1 << 16;
-        static inline std::vector<node_t *> chunks;
+        static inline std::vector<Node *> chunks;
         static inline std::size_t chunk_pos = 0;
 
         static void *operator new(std::size_t) {
             if (chunks.empty() || chunk_pos == chunk_size) {
-                chunks.push_back(static_cast<node_t *>(::operator new(chunk_size * sizeof(node_t))));
+                chunks.push_back(static_cast<Node *>(::operator new(chunk_size * sizeof(Node))));
                 chunk_pos = 0;
             }
             return chunks.back() + (chunk_pos++);
@@ -45,15 +45,15 @@ struct OrderedMultiset {
     };
 
   public:
-    using node_type = node_t;
-    using node_ptr = typename node_t::pointer;
+    using node_type = Node;
+    using node_ptr = typename Node::pointer;
 
     constexpr OrderedMultiset() : root(nullptr) {}
     constexpr OrderedMultiset(const std::vector<T> &v) : root(nullptr) {
         auto build = [&v](auto self, int l, int r) -> node_ptr {
             if (l == r) return nullptr;
             int m = (l + r) >> 1;
-            auto node = new node_t(v[m]);
+            auto node = new Node(v[m]);
             node->left = self(self, l, m);
             node->right = self(self, m + 1, r);
             node->recompute();
@@ -63,7 +63,7 @@ struct OrderedMultiset {
     }
 
     constexpr bool empty() const { return root == nullptr; }
-    constexpr int size() const { return node_t::get_size(root); }
+    constexpr int size() const { return Node::get_size(root); }
 
     void insert(T val) { root = insert(root, val); }
 
@@ -89,7 +89,7 @@ struct OrderedMultiset {
         assert(0 <= k && k < size());
         node_ptr node = root;
         while (true) {
-            int c = node_t::get_size(node->left);
+            int c = Node::get_size(node->left);
             if (c == k) break;
             if (k < c) node = node->left;
             else node = node->right, k -= c + 1;
@@ -110,7 +110,7 @@ struct OrderedMultiset {
         node_ptr node = root;
         while (node) {
             if (!(node->val < val)) node = node->left;
-            else res += node_t::get_size(node->left) + 1, node = node->right;
+            else res += Node::get_size(node->left) + 1, node = node->right;
         }
         return res;
     }
@@ -120,7 +120,7 @@ struct OrderedMultiset {
         node_ptr node = root;
         while (node) {
             if (val < node->val) node = node->left;
-            else res += node_t::get_size(node->left) + 1, node = node->right;
+            else res += Node::get_size(node->left) + 1, node = node->right;
         }
         return res;
     }
@@ -147,15 +147,15 @@ struct OrderedMultiset {
 
     T prefix_sum(int k) const {
         assert(0 <= k && k <= size());
-        if (k == size()) return node_t::get_sum(root);
+        if (k == size()) return Node::get_sum(root);
         T res{};
         node_ptr node = root;
         while (node && k) {
-            int c = node_t::get_size(node->left);
+            int c = Node::get_size(node->left);
             if (k < c) {
                 node = node->left;
             } else {
-                res += node_t::get_sum(node->left);
+                res += Node::get_sum(node->left);
                 if (k == c) break;
                 res += node->val;
                 node = node->right, k -= c + 1;
@@ -166,15 +166,15 @@ struct OrderedMultiset {
 
     T suffix_sum(int k) const {
         assert(0 <= k && k <= size());
-        if (k == size()) return node_t::get_sum(root);
+        if (k == size()) return Node::get_sum(root);
         T res{};
         node_ptr node = root;
         while (node && k) {
-            int c = node_t::get_size(node->right);
+            int c = Node::get_size(node->right);
             if (k < c) {
                 node = node->right;
             } else {
-                res += node_t::get_sum(node->right);
+                res += Node::get_sum(node->right);
                 if (k == c) break;
                 res += node->val;
                 node = node->left, k -= c + 1;
@@ -227,12 +227,12 @@ struct OrderedMultiset {
     }
 
     constexpr node_ptr rebalance(node_ptr node) {
-        int bf = node_type::get_balance_factor(node);
+        int bf = Node::get_balance_factor(node);
         if (bf < -1) {
-            if (node_type::get_balance_factor(node->right) >= 1) node = rotate_right_left(node);
+            if (Node::get_balance_factor(node->right) >= 1) node = rotate_right_left(node);
             else node = rotate_left(node);
         } else if (bf > 1) {
-            if (node_type::get_balance_factor(node->left) <= -1) node = rotate_left_right(node);
+            if (Node::get_balance_factor(node->left) <= -1) node = rotate_left_right(node);
             else node = rotate_right(node);
         } else {
             node->recompute();
@@ -241,7 +241,7 @@ struct OrderedMultiset {
     }
 
     constexpr node_ptr insert(node_ptr node, T val) {
-        if (node == nullptr) return new node_t(val);
+        if (node == nullptr) return new Node(val);
         if (val < node->val) node->left = insert(node->left, val);
         else node->right = insert(node->right, val);
         return rebalance(node);

--- a/lib/ordered_set/ordered_set.hpp
+++ b/lib/ordered_set/ordered_set.hpp
@@ -4,8 +4,9 @@
 #include <optional>
 #include <vector>
 
-template <class T>
-struct OrderedMultiset {
+/// @brief 順序集合・多重集合（AVL 木）
+template <class T, bool Multi = false>
+struct OrderedSet {
   private:
     struct Node {
         using pointer = Node *;
@@ -48,9 +49,10 @@ struct OrderedMultiset {
     using node_type = Node;
     using node_ptr = typename Node::pointer;
 
-    constexpr OrderedMultiset() : root(nullptr) {}
-    constexpr OrderedMultiset(std::vector<T> v) : root(nullptr) {
+    constexpr OrderedSet() : root(nullptr) {}
+    constexpr OrderedSet(std::vector<T> v) : root(nullptr) {
         std::sort(v.begin(), v.end());
+        if constexpr (!Multi) v.erase(std::unique(v.begin(), v.end()), v.end());
         auto build = [&v](auto self, int l, int r) -> node_ptr {
             if (l == r) return nullptr;
             int m = (l + r) >> 1;
@@ -66,7 +68,12 @@ struct OrderedMultiset {
     constexpr bool empty() const { return root == nullptr; }
     constexpr int size() const { return Node::get_size(root); }
 
-    void insert(T val) { root = insert(root, val); }
+    void insert(T val) {
+        if constexpr (!Multi) {
+            if (contains(val)) return;
+        }
+        root = insert(root, val);
+    }
 
     void erase(T val) { root = erase(root, val); }
 

--- a/test/yosupo/data_structure/orderd_set.test.cpp
+++ b/test/yosupo/data_structure/orderd_set.test.cpp
@@ -1,18 +1,18 @@
 // competitive-verifier: PROBLEM https://judge.yosupo.jp/problem/ordered_set
 #include <iostream>
-#include "ordered_set/ordered_multiset.hpp"
+#include "ordered_set/ordered_set.hpp"
 
 int main(void) {
     int n, q;
     std::cin >> n >> q;
     std::vector<int> a(n);
     for (auto &e : a) std::cin >> e;
-    OrderedMultiset<int> tr(a);
+    OrderedSet<int> tr(a);
     while (q--) {
         int t, x;
         std::cin >> t >> x;
         if (t == 0) {
-            if (!tr.contains(x)) tr.insert(x);
+            tr.insert(x);
         } else if (t == 1) {
             tr.erase(x);
         } else if (t == 2) {

--- a/test/yosupo/data_structure/orderd_set.test.cpp
+++ b/test/yosupo/data_structure/orderd_set.test.cpp
@@ -1,13 +1,13 @@
 // competitive-verifier: PROBLEM https://judge.yosupo.jp/problem/ordered_set
 #include <iostream>
-#include "ordered_set/ordered_set.hpp"
+#include "ordered_set/ordered_multiset.hpp"
 
 int main(void) {
     int n, q;
     std::cin >> n >> q;
     std::vector<int> a(n);
     for (auto &e : a) std::cin >> e;
-    ordered_set<int> tr(a);
+    OrderedMultiset<int> tr(a);
     while (q--) {
         int t, x;
         std::cin >> t >> x;


### PR DESCRIPTION
## Summary
- `ordered_set` (実態は重複を許す多重集合) を `OrderedMultiset` へ改名し、private nested `node_t` も `Node` に PascalCase 化
- コンストラクタが `v` のソート済み前提に依存していた不具合を修正（値渡し + 内部 `std::sort` で解消）
- `lib/ordered_set/` 内の `binary_trie`/`patricia_binary_trie` と同じ `bool Multi = false` を導入し、デフォルトで重複なしの集合として動作するよう変更。実態が集合になったため名前を `OrderedSet` に戻し、多重集合が必要な場合は `OrderedSet<T, true>` を使う形にした
- 参照側 (`test/yosupo/data_structure/orderd_set.test.cpp`) と README の該当説明を追随・更新

## Test plan
- [x] `g++ -std=c++23 -I lib -Wall -Wextra -fsyntax-only lib/ordered_set/ordered_set.hpp`
- [x] `g++ -std=c++23 -I lib -Wall -Wextra -fsyntax-only test/yosupo/data_structure/orderd_set.test.cpp`
- [x] `std::set`/`std::multiset` に対するランダムテスト（`Multi=false`/`Multi=true` 双方、シャッフル済み未ソート入力を含む）で一致を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)