### PR TITLE
perf/tree64 shift mask

### DIFF
--- a/lib/ordered_set/tree64.hpp
+++ b/lib/ordered_set/tree64.hpp
@@ -17,8 +17,8 @@ constexpr int calc_c(int n) {
 
 /// @brief 64分木
 template <int N>
-struct tree64 {
-    tree64() : map(0), child() {}
+struct Tree64 {
+    Tree64() : map(0), child() {}
 
     bool insert(const int key) {
         const int pos = key >> shift;
@@ -73,13 +73,13 @@ struct tree64 {
     static constexpr int mask = C - 1;
 
     std::uint64_t map;
-    std::array<tree64<C>, (N - 1) / C + 1> child;
+    std::array<Tree64<C>, (N - 1) / C + 1> child;
 };
 
 template <int N>
 requires(N <= 64)
-struct tree64<N> {
-    tree64() : map(0) {}
+struct Tree64<N> {
+    Tree64() : map(0) {}
 
     bool insert(const int key) {
         const std::uint64_t pop = 1ull << key;

--- a/lib/ordered_set/tree64.hpp
+++ b/lib/ordered_set/tree64.hpp
@@ -21,54 +21,56 @@ struct tree64 {
     tree64() : map(0), child() {}
 
     bool insert(const int key) {
-        const int pos = key / C;
+        const int pos = key >> shift;
         map |= 1ull << pos;
-        return child[pos].insert(key % C);
+        return child[pos].insert(key & mask);
     }
 
     bool erase(const int key) {
-        const int pos = key / C;
-        const bool res = child[pos].erase(key % C);
+        const int pos = key >> shift;
+        const bool res = child[pos].erase(key & mask);
         if (child[pos].get_map() == 0) map &= ~(1ull << pos);
         return res;
     }
 
-    bool contains(const int key) const { return child[key / C].contains(key % C); }
+    bool contains(const int key) const { return child[key >> shift].contains(key & mask); }
 
     int min() const {
         const int pos = std::countr_zero(map);
-        return pos * C + child[pos].min();
+        return (pos << shift) + child[pos].min();
     }
 
     int max() const {
         const int pos = std::bit_width(map) - 1;
-        return pos * C + child[pos].max();
+        return (pos << shift) + child[pos].max();
     }
 
     int pred(const int key) const {
-        const int pos = key / C;
-        const int t = child[pos].pred(key % C);
-        if (t != -1) { return pos * C + t; }
+        const int pos = key >> shift;
+        const int t = child[pos].pred(key & mask);
+        if (t != -1) { return (pos << shift) + t; }
         const std::uint64_t masked = map & ~(~0ULL << pos);
         if (masked == 0) return -1;
         const int pos2 = std::bit_width(masked) - 1;
-        return pos2 * C + child[pos2].max();
+        return (pos2 << shift) + child[pos2].max();
     }
 
     int succ(const int key) const {
-        const int pos = key / C;
-        const int t = child[pos].succ(key % C);
-        if (t != -1) return pos * C + t;
+        const int pos = key >> shift;
+        const int t = child[pos].succ(key & mask);
+        if (t != -1) return (pos << shift) + t;
         const std::uint64_t masked = map & ~(~0ULL >> (63 - pos));
         if (masked == 0) return -1;
         const int pos2 = std::countr_zero(masked);
-        return pos2 * C + child[pos2].min();
+        return (pos2 << shift) + child[pos2].min();
     }
 
     std::uint64_t get_map() const { return map; }
 
   private:
     static constexpr int C = internal::calc_c(N);
+    static constexpr int shift = std::countr_zero(static_cast<unsigned>(C));
+    static constexpr int mask = C - 1;
 
     std::uint64_t map;
     std::array<tree64<C>, (N - 1) / C + 1> child;

--- a/test/yosupo/data_structure/predecessor_problem.test.cpp
+++ b/test/yosupo/data_structure/predecessor_problem.test.cpp
@@ -8,7 +8,7 @@ int main(void) {
     std::cin >> n >> q;
     std::string t;
     std::cin >> t;
-    tree64<10000000> st;
+    Tree64<10000000> st;
     for (int i = 0; i < n; ++i) {
         if (t[i] == '1') st.insert(i);
     }


### PR DESCRIPTION
## Summary
- `Tree64`（64分木）の除算/剰余をシフト/マスク演算に置き換えて高速化
- `C` は常に64のべき乗であることを利用し、`key / C` → `key >> shift`、`key % C` → `key & mask` に変更（符号付き int の除算/剰余に伴う補正命令を削減）
- 型名を命名規約（PascalCase）に合わせて `tree64` → `Tree64` にリネーム

## Test plan
- [x] `-fsyntax-only` による逆依存チェック（`predecessor_problem.test.cpp`）
- [x] 変更前と同一の乱数操作列（2000万回の insert/erase/contains/succ/pred）で結果が完全一致することを確認
- [x] `std::set` を参照実装にした100万回のランダムストレステストで一致を確認
- [x] ベンチマークで約180ms→159ms（約12%高速化）
- [x] clang-format 準拠