### PR TITLE
feat: Link/Cut/Evert 対応の Dynamic Top Tree を追加し point_set_tree_path_composite_sum を解く

### DIFF
--- a/lib/tree/dynamic_top_tree.hpp
+++ b/lib/tree/dynamic_top_tree.hpp
@@ -1,0 +1,301 @@
+#pragma once
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+/// @brief Dynamic Top Tree（Link/Cut/Evert に対応した全方位木 DP）
+/// @details LCT の compress パス（splay 木）に加え、各頂点にぶら下がる軽辺
+///          （rake 対象の部分木）を別の splay 木で束ねて expose のたびに
+///          O(log n) 償却で繋ぎ替える。evert によるパス反転に対応するため、
+///          パス集約を正方向 sum・逆方向 mus の 2 本立てで保持する（compress
+///          が非可換なため、反転を高速に行うにはこの複製が必要）。
+///          TreeDP のインターフェースは static_top_tree_dp と共通：
+///          `Path vertex(int u)` / `Path add_vertex(Path d, Light l)` /
+///          `Light add_edge(Path d)` / `Light rake(Light l, Light r)` /
+///          `Path compress(Path p, Path c)`。
+template <class TreeDP>
+struct DynamicTopTree {
+    using Path = typename TreeDP::Path;
+    using Light = typename TreeDP::Light;
+
+    DynamicTopTree() = default;
+    explicit DynamicTopTree(int n, const TreeDP &_dp = TreeDP()) : dp(_dp), nodes(n) {
+        for (int i = 0; i < n; ++i) nodes[i].id = i;
+        for (int i = 0; i < n; ++i) pull(&nodes[i]);
+    }
+
+    /// @brief c を子、p を親として連結する（内部で c を自身の根に evert してから繋ぐ）
+    void link(int c, int p) {
+        Node *pc = &nodes[c], *pp = &nodes[p];
+        evert(c);
+        expose(pp);
+        expose(pc);
+        pc->p = pp;
+        pp->r = pc;
+        pull(pp);
+    }
+
+    /// @brief c を親から切り離す
+    void cut(int c) {
+        Node *pc = &nodes[c];
+        expose(pc);
+        Node *l = pc->l;
+        pc->l = nullptr;
+        l->p = nullptr;
+        pull(pc);
+    }
+
+    /// @brief 辺 (u, v) を切り離す
+    void cut(int u, int v) {
+        evert(u);
+        cut(v);
+    }
+
+    /// @brief u を全体の根にする
+    void evert(int u) {
+        Node *t = &nodes[u];
+        expose(t);
+        toggle(t);
+        push(t);
+    }
+
+    /// @brief 頂点 u の情報が変化した後に呼び、集約を再計算する
+    void update(int u) {
+        Node *t = &nodes[u];
+        expose(t);
+        pull(t);
+    }
+
+    /// @brief u を根としたときの木全体の集約値
+    Path query(int u) {
+        evert(u);
+        return nodes[u].sum;
+    }
+
+    /// @brief root を根としたときの、u を根とする部分木の集約値
+    Path query_subtree(int root, int u) {
+        evert(root);
+        Node *t = &nodes[u];
+        expose(t);
+        Node *l = t->l;
+        t->l = nullptr;
+        pull(t);
+        Path res = t->sum;
+        t->l = l;
+        pull(t);
+        return res;
+    }
+
+  private:
+    struct LightNode {
+        LightNode *l, *r, *p;
+        Light key, sum;
+
+        explicit LightNode(const Light &v) : l(), r(), p(), key(v), sum(v) {}
+
+        static constexpr std::size_t chunk_size = 1 << 16;
+        static inline std::vector<LightNode *> chunks;
+        static inline std::size_t chunk_pos = 0;
+        static void *operator new(std::size_t) {
+            if (chunks.empty() || chunk_pos == chunk_size) {
+                chunks.push_back(static_cast<LightNode *>(::operator new(chunk_size * sizeof(LightNode))));
+                chunk_pos = 0;
+            }
+            return chunks.back() + (chunk_pos++);
+        }
+        static void operator delete(void *) noexcept {}
+    };
+
+    struct Node {
+        Node *l = nullptr, *r = nullptr, *p = nullptr;
+        bool rev = false;
+        int id = 0;
+        Path key, sum, mus;
+        LightNode *light = nullptr;   // 自分にぶら下がる軽辺部分木の集約 splay 木の根
+        LightNode *belong = nullptr;  // 自分が属する compress splay 木の根であるときの、親の軽辺 splay 木上の対応ノード
+    };
+
+    TreeDP dp;
+    std::vector<Node> nodes;
+
+    static bool is_root(Node *t) { return !t->p || (t->p->l != t && t->p->r != t); }
+
+    void pull(Node *t) {
+        Path base = dp.vertex(t->id);
+        Path key = t->light ? dp.add_vertex(base, t->light->sum) : base;
+        Path sum = key, mus = key;
+        if (t->l) {
+            sum = dp.compress(t->l->sum, sum);
+            mus = dp.compress(mus, t->l->mus);
+        }
+        if (t->r) {
+            sum = dp.compress(sum, t->r->sum);
+            mus = dp.compress(t->r->mus, mus);
+        }
+        t->key = key;
+        t->sum = sum;
+        t->mus = mus;
+    }
+
+    void toggle(Node *t) {
+        std::swap(t->l, t->r);
+        std::swap(t->sum, t->mus);
+        t->rev = !t->rev;
+    }
+
+    void push(Node *t) {
+        if (t->rev) {
+            if (t->l) toggle(t->l);
+            if (t->r) toggle(t->r);
+            t->rev = false;
+        }
+    }
+
+    void propagate_all(Node *t) {
+        if (!is_root(t)) propagate_all(t->p);
+        push(t);
+    }
+
+    void rotate(Node *t) {
+        Node *pa = t->p, *gp = pa->p;
+        bool is_right_child = (pa->r == t);
+        Node *ch = is_right_child ? t->l : t->r;
+
+        if (!is_root(pa)) {
+            if (gp->r == pa) gp->r = t;
+            else gp->l = t;
+        }
+        t->p = gp;
+
+        if (is_right_child) {
+            pa->r = ch;
+            t->l = pa;
+        } else {
+            pa->l = ch;
+            t->r = pa;
+        }
+        if (ch) ch->p = pa;
+        pa->p = t;
+
+        pull(pa);
+        pull(t);
+    }
+
+    void splay(Node *t) {
+        Node *rt = t;
+        while (!is_root(rt)) rt = rt->p;
+        t->belong = rt->belong;
+        if (t != rt) rt->belong = nullptr;
+
+        propagate_all(t);
+        while (!is_root(t)) {
+            Node *pa = t->p;
+            if (!is_root(pa)) {
+                Node *gp = pa->p;
+                if ((gp->r == pa) == (pa->r == t)) rotate(pa);
+                else rotate(t);
+            }
+            rotate(t);
+        }
+    }
+
+    Node *expose(Node *t) {
+        Node *rp = nullptr;
+        for (Node *cur = t; cur; cur = cur->p) {
+            splay(cur);
+            if (cur->r) {
+                cur->light = light_insert(cur->light, dp.add_edge(cur->r->sum));
+                cur->r->belong = cur->light;
+            }
+            cur->r = rp;
+            if (cur->r) {
+                light_splay(cur->r->belong);
+                push(cur->r);
+                cur->light = light_erase(cur->r->belong);
+            }
+            pull(cur);
+            rp = cur;
+        }
+        splay(t);
+        return rp;
+    }
+
+    void light_pull(LightNode *t) {
+        Light s = t->key;
+        if (t->l) s = dp.rake(s, t->l->sum);
+        if (t->r) s = dp.rake(s, t->r->sum);
+        t->sum = s;
+    }
+
+    void light_rotate(LightNode *t) {
+        LightNode *x = t->p, *y = x->p;
+        bool is_right_child = (x->r == t);
+        LightNode *ch = is_right_child ? t->l : t->r;
+
+        if (is_right_child) {
+            x->r = ch;
+            t->l = x;
+        } else {
+            x->l = ch;
+            t->r = x;
+        }
+        if (ch) ch->p = x;
+        x->p = t;
+
+        light_pull(x);
+        light_pull(t);
+        if ((t->p = y)) {
+            if (y->l == x) y->l = t;
+            else if (y->r == x) y->r = t;
+        }
+    }
+
+    void light_splay(LightNode *t) {
+        while (t->p) {
+            LightNode *q = t->p;
+            if (q->p) {
+                LightNode *r = q->p;
+                if ((r->l == q) == (q->l == t)) light_rotate(q);
+                else light_rotate(t);
+            }
+            light_rotate(t);
+        }
+    }
+
+    static LightNode *light_rightmost(LightNode *t) {
+        while (t->r) t = t->r;
+        return t;
+    }
+
+    LightNode *light_insert(LightNode *root, const Light &v) {
+        LightNode *z = new LightNode(v);
+        if (!root) return z;
+        LightNode *cur = light_rightmost(root);
+        light_splay(cur);
+        z->p = cur;
+        cur->r = z;
+        light_pull(cur);
+        light_splay(z);
+        return z;
+    }
+
+    LightNode *light_erase(LightNode *t) {
+        light_splay(t);
+        LightNode *x = t->l, *y = t->r;
+        if (!x) {
+            if (y) y->p = nullptr;
+            return y;
+        }
+        if (!y) {
+            x->p = nullptr;
+            return x;
+        }
+        x->p = nullptr;
+        LightNode *w = light_rightmost(x);
+        light_splay(w);
+        w->r = y;
+        y->p = w;
+        light_pull(w);
+        return w;
+    }
+};

--- a/test/yosupo/tree/point_set_tree_path_composite_sum.test.cpp
+++ b/test/yosupo/tree/point_set_tree_path_composite_sum.test.cpp
@@ -1,9 +1,8 @@
-// competitive-verifier: PROBLEM https://judge.yosupo.jp/problem/point_set_tree_path_composite_sum_fixed_root
+// competitive-verifier: PROBLEM https://judge.yosupo.jp/problem/point_set_tree_path_composite_sum
 #include <iostream>
 #include <vector>
-#include "graph/graph.hpp"
 #include "math/modint.hpp"
-#include "tree/static_top_tree.hpp"
+#include "tree/dynamic_top_tree.hpp"
 
 using Mint = modint998;
 
@@ -55,56 +54,33 @@ int main() {
 
     std::vector<int> U(n - 1), V(n - 1);
     std::vector<Mint> b(n - 1), c(n - 1);
-    list_graph<int> orig_g(n);
-    for (int i = 0; i < n - 1; ++i) {
-        std::cin >> U[i] >> V[i] >> b[i] >> c[i];
-        orig_g.add_edges(U[i], V[i], i);
-    }
+    for (int i = 0; i < n - 1; ++i) std::cin >> U[i] >> V[i] >> b[i] >> c[i];
 
-    std::vector<std::vector<int>> g(2 * n - 1);
-    std::vector<int> q_bfs;
-    q_bfs.push_back(0);
-    std::vector<bool> vis(n, false);
-    vis[0] = true;
-    int head = 0;
-    while (head < (int)q_bfs.size()) {
-        int u = q_bfs[head++];
-        for (auto &e : orig_g[u]) {
-            int v = e.to();
-            int idx = e.weight();
-            if (!vis[v]) {
-                vis[v] = true;
-                q_bfs.push_back(v);
-                g[u].push_back(n + idx);
-                g[n + idx].push_back(u);
-                g[n + idx].push_back(v);
-                g[v].push_back(n + idx);
-            }
-        }
-    }
-
-    static_top_tree<std::vector<std::vector<int>>> stt(g, 0);
     DP dp_obj(n, a, b, c);
-    static_top_tree_dp<std::vector<std::vector<int>>, DP> stt_dp(stt, dp_obj);
+    DynamicTopTree<DP> dtt(2 * n - 1, dp_obj);
+    for (int i = 0; i < n - 1; ++i) {
+        dtt.link(n + i, U[i]);
+        dtt.link(n + i, V[i]);
+    }
 
     for (int i = 0; i < q; ++i) {
         int type;
         std::cin >> type;
         if (type == 0) {
-            int w;
+            int w, r;
             long long x;
-            std::cin >> w >> x;
+            std::cin >> w >> x >> r;
             a[w] = x;
-            stt_dp.update(w);
-            std::cout << stt_dp.get().S << "\n";
+            dtt.update(w);
+            std::cout << dtt.query(r).S << "\n";
         } else {
-            int idx;
+            int idx, r;
             long long y, z;
-            std::cin >> idx >> y >> z;
+            std::cin >> idx >> y >> z >> r;
             b[idx] = y;
             c[idx] = z;
-            stt_dp.update(n + idx);
-            std::cout << stt_dp.get().S << "\n";
+            dtt.update(n + idx);
+            std::cout << dtt.query(r).S << "\n";
         }
     }
 

--- a/test/yosupo/tree/point_set_tree_path_composite_sum_fixed_root.test.cpp
+++ b/test/yosupo/tree/point_set_tree_path_composite_sum_fixed_root.test.cpp
@@ -53,39 +53,18 @@ int main() {
     std::vector<Mint> a(n);
     for (auto &e : a) std::cin >> e;
 
-    std::vector<int> U(n - 1), V(n - 1);
     std::vector<Mint> b(n - 1), c(n - 1);
-    list_graph<int> orig_g(n);
+    list_graph<void> g(2 * n - 1);
     for (int i = 0; i < n - 1; ++i) {
-        std::cin >> U[i] >> V[i] >> b[i] >> c[i];
-        orig_g.add_edges(U[i], V[i], i);
+        int u, v;
+        std::cin >> u >> v >> b[i] >> c[i];
+        g.add_edges(u, n + i);
+        g.add_edges(n + i, v);
     }
 
-    std::vector<std::vector<int>> g(2 * n - 1);
-    std::vector<int> q_bfs;
-    q_bfs.push_back(0);
-    std::vector<bool> vis(n, false);
-    vis[0] = true;
-    int head = 0;
-    while (head < (int)q_bfs.size()) {
-        int u = q_bfs[head++];
-        for (auto &e : orig_g[u]) {
-            int v = e.to();
-            int idx = e.weight();
-            if (!vis[v]) {
-                vis[v] = true;
-                q_bfs.push_back(v);
-                g[u].push_back(n + idx);
-                g[n + idx].push_back(u);
-                g[n + idx].push_back(v);
-                g[v].push_back(n + idx);
-            }
-        }
-    }
-
-    static_top_tree<std::vector<std::vector<int>>> stt(g, 0);
+    static_top_tree<list_graph<void>> stt(g, 0);
     DP dp_obj(n, a, b, c);
-    static_top_tree_dp<std::vector<std::vector<int>>, DP> stt_dp(stt, dp_obj);
+    static_top_tree_dp<list_graph<void>, DP> stt_dp(stt, dp_obj);
 
     for (int i = 0; i < q; ++i) {
         int type;

--- a/test/yosupo/tree/point_set_tree_path_composite_sum_fixed_root.test.cpp
+++ b/test/yosupo/tree/point_set_tree_path_composite_sum_fixed_root.test.cpp
@@ -1,5 +1,6 @@
 // competitive-verifier: PROBLEM https://judge.yosupo.jp/problem/point_set_tree_path_composite_sum_fixed_root
 #include <iostream>
+#include <utility>
 #include <vector>
 #include "graph/graph.hpp"
 #include "math/modint.hpp"
@@ -15,21 +16,11 @@ struct DP {
         Mint S, sz;
     };
 
-    int n;
-    const std::vector<Mint> &A;
-    const std::vector<Mint> &B;
-    const std::vector<Mint> &C;
+    std::vector<Path> val;
 
-    DP(int n, const std::vector<Mint> &A, const std::vector<Mint> &B, const std::vector<Mint> &C)
-        : n(n), A(A), B(B), C(C) {}
+    explicit DP(std::vector<Path> val) : val(std::move(val)) {}
 
-    Path vertex(int u) const {
-        if (u < n) {
-            return {1, 0, A[u], 1};
-        } else {
-            return {B[u - n], C[u - n], 0, 0};
-        }
-    }
+    Path vertex(int u) const { return val[u]; }
 
     Path add_vertex(Path d, Light l) const { return {d.b, d.c, (d.b * l.S + d.c * l.sz + d.S), (d.sz + l.sz)}; }
 
@@ -50,20 +41,25 @@ int main() {
     int n, q;
     std::cin >> n >> q;
 
-    std::vector<Mint> a(n);
-    for (auto &e : a) std::cin >> e;
+    std::vector<DP::Path> val(2 * n - 1);
+    for (int i = 0; i < n; ++i) {
+        Mint x;
+        std::cin >> x;
+        val[i] = {1, 0, x, 1};
+    }
 
-    std::vector<Mint> b(n - 1), c(n - 1);
     list_graph<void> g(2 * n - 1);
     for (int i = 0; i < n - 1; ++i) {
         int u, v;
-        std::cin >> u >> v >> b[i] >> c[i];
+        Mint b, c;
+        std::cin >> u >> v >> b >> c;
+        val[n + i] = {b, c, 0, 0};
         g.add_edges(u, n + i);
         g.add_edges(n + i, v);
     }
 
     static_top_tree<list_graph<void>> stt(g, 0);
-    DP dp_obj(n, a, b, c);
+    DP dp_obj(std::move(val));
     static_top_tree_dp<list_graph<void>, DP> stt_dp(stt, dp_obj);
 
     for (int i = 0; i < q; ++i) {
@@ -73,15 +69,14 @@ int main() {
             int w;
             long long x;
             std::cin >> w >> x;
-            a[w] = x;
+            stt_dp.dp.val[w] = {1, 0, x, 1};
             stt_dp.update(w);
             std::cout << stt_dp.get().S << "\n";
         } else {
             int idx;
             long long y, z;
             std::cin >> idx >> y >> z;
-            b[idx] = y;
-            c[idx] = z;
+            stt_dp.dp.val[n + idx] = {y, z, 0, 0};
             stt_dp.update(n + idx);
             std::cout << stt_dp.get().S << "\n";
         }


### PR DESCRIPTION
## Summary
- Link/Cut/Evert に対応した Dynamic Top Tree（`lib/tree/dynamic_top_tree.hpp`）を追加し、[point_set_tree_path_composite_sum](https://judge.yosupo.jp/problem/point_set_tree_path_composite_sum) を verify
- fixed_root 版テストの辺頂点化グラフ構築を、手動 BFS ではなく `list_graph` を使う形に簡潔化
- fixed_root 版テストの `DP` から `n`/`A`/`B`/`C` を除去し、頂点ごとの完成済み `Path` を持つ `val` 一本に統一

## Test plan
- [x] `g++ -std=c++23 -I lib -fsyntax-only` で両テストファイルの構文確認
- [x] yosupo judge のサンプル入出力2件をローカルでビルド・実行して一致確認（point_set_tree_path_composite_sum_fixed_root）
- [x] `clang-format --dry-run --Werror` で整形確認
- [ ] CI（competitive-verifier）の通過を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)