### PR TITLE
refactor: 呼び出し元のない graph_csr 専用オーバーロードを削除

### DIFF
--- a/lib/graph/scc.hpp
+++ b/lib/graph/scc.hpp
@@ -136,15 +136,3 @@ list_graph<graph_weight_t<G>> make_directed_acyclic_graph(const G &g, const std:
     }
     return res;
 }
-
-internal::graph_csr make_directed_acyclic_graph(internal::graph_csr &g, const std::vector<int> &v) {
-    int n = *std::max_element(v.begin(), v.end()) + 1;
-    internal::graph_csr res(n);
-    for (int i = 0; i < n; ++i) {
-        for (int u : g[i]) {
-            int x = v[i], y = v[u];
-            if (x != y) res.add_edge(x, y);
-        }
-    }
-    return res;
-}

--- a/lib/tree/euler_tour.hpp
+++ b/lib/tree/euler_tour.hpp
@@ -2,13 +2,11 @@
 #include <utility>
 #include <vector>
 #include "graph/graph.hpp"
-#include "internal/internal_csr.hpp"
 
 /// @brief オイラーツアー
 struct euler_tour {
     template <graph_type G>
     euler_tour(const G &g, int r = 0) : euler_tour(g, g.size(), r) {}
-    euler_tour(const internal::graph_csr &g, int r = 0) : euler_tour(g, g.size(), r) {}
 
     std::pair<int, int> operator[](int i) const { return std::make_pair(ls[i], rs[i]); }
 
@@ -27,13 +25,6 @@ struct euler_tour {
     int _size;
     std::vector<int> ord, ls, rs;
 
-    /// 隣接要素から行き先頂点を取り出す: list_graph<T> の辺は e.to()、CSR は int をそのまま使う。
-    static int to_of(int e) { return e; }
-    template <class E>
-    static int to_of(const E &e) {
-        return e.to();
-    }
-
     template <class G>
     euler_tour(const G &g, int n, int r) : _size(n), ord(n), ls(n, -1), rs(n) {
         int c = 0;
@@ -50,8 +41,8 @@ struct euler_tour {
             ls[x] = c;
             ord[x] = c++;
             rs[x] = c;
-            for (auto e : g[x]) {
-                int to = to_of(e);
+            for (auto &e : g[x]) {
+                int to = e.to();
                 if (ls[to] != -1) continue;
                 stk.emplace_back(~x);
                 stk.emplace_back(to);

--- a/lib/tree/linear_lca.hpp
+++ b/lib/tree/linear_lca.hpp
@@ -4,7 +4,6 @@
 #include <utility>
 #include <vector>
 #include "graph/graph.hpp"
-#include "internal/internal_csr.hpp"
 #include "sparse_table/linear_sparse_table.hpp"
 
 struct linear_lca {
@@ -42,28 +41,6 @@ struct linear_lca {
                 if (ord[e.to()] != -1) continue;
                 stk.emplace_back(~x, d);
                 stk.emplace_back(e.to(), d + 1);
-            }
-        }
-        lst = linear_sparse_table<M>(v);
-    }
-    linear_lca(const internal::graph_csr &g, int r = 0) : ord(g.size(), -1), lst() {
-        std::vector<S> v;
-        std::vector<std::pair<int, int>> stk;
-        stk.reserve(2 * g.size());
-        stk.emplace_back(r, 0);
-        while (!stk.empty()) {
-            auto [x, d] = stk.back();
-            stk.pop_back();
-            if (x < 0) {
-                v.emplace_back(d, ~x);
-                continue;
-            }
-            ord[x] = v.size();
-            v.emplace_back(d, x);
-            for (int y : g[x]) {
-                if (ord[y] != -1) continue;
-                stk.emplace_back(~x, d);
-                stk.emplace_back(y, d + 1);
             }
         }
         lst = linear_sparse_table<M>(v);


### PR DESCRIPTION
## Summary
- csr_graph<T> の追加を受けて、呼び出し元のない internal::graph_csr 専用コンストラクタ/オーバーロードを削除
  - linear_lca(const internal::graph_csr&, int) — 呼び出し元なし
  - euler_tour(const internal::graph_csr&, int) — 呼び出し元なし（併せて不要になった to_of ディスパッチも削除）
  - make_directed_acyclic_graph(internal::graph_csr&, ...) — 呼び出し元なし
- heavy_light_decomposition / scc の internal::graph_csr 専用オーバーロードは functional_graph / two_sat から実際に使われており、
  辺 ID・重みを一切参照しない用途のため csr_graph<T> より軽量な internal::graph_csr のままとした（維持）

## Test plan
- [x] 変更ヘッダの逆依存テストを `-fsyntax-only` で全件 syntax check
- [x] clang-format --dry-run --Werror で整形確認
- [x] two_sat / scc / functional_graph(jump_all) は Library Checker のサンプルをダウンロードして実行し出力一致を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)