### PR TITLE
refactor: internal::graph_csr を internal::Csr<E> に統合

### DIFF
--- a/lib/flow/min_cost_flow.hpp
+++ b/lib/flow/min_cost_flow.hpp
@@ -61,7 +61,7 @@ struct mcf_graph {
                 elist.emplace_back(e.from, _edge(e.to, -1, e.cap - e.flow, e.cost));
                 elist.emplace_back(e.to, _edge(e.from, -1, e.flow, -e.cost));
             }
-            auto _g = internal::csr<_edge>(_n, elist);
+            auto _g = internal::Csr<_edge>(_n, elist);
             for (int i = 0; i < m; ++i) {
                 auto e = _edges[i];
                 edge_idx[i] += _g.start[e.from];
@@ -95,7 +95,7 @@ struct mcf_graph {
         constexpr _edge(int _to, int _rev, Cap _cap, Cost _cost) : to(_to), rev(_rev), cap(_cap), cost(_cost) {}
     };
 
-    std::vector<std::pair<Cap, Cost>> slope(internal::csr<_edge> &g, int s, int t, Cap flow_limit) {
+    std::vector<std::pair<Cap, Cost>> slope(internal::Csr<_edge> &g, int s, int t, Cap flow_limit) {
         std::vector<std::pair<Cost, Cost>> dual_dist(_n);
         std::vector<int> prev_e(_n);
         std::vector<bool> vis(_n);

--- a/lib/graph/functional_graph.hpp
+++ b/lib/graph/functional_graph.hpp
@@ -22,11 +22,13 @@ struct functional_graph {
                 x = to[x];
             }
         }
+        std::vector<std::pair<int, int>> edges;
+        edges.reserve(_size);
         for (int i = 0; i < _size; ++i) {
-            if (_root[i] == i) g.add_edge(_size, i);
-            else g.add_edge(to[i], i);
+            if (_root[i] == i) edges.emplace_back(_size, i);
+            else edges.emplace_back(to[i], i);
         }
-        g.build();
+        g = internal::Csr<int>(_size + 1, edges);
         hld = heavy_light_decomposition(g, _size);
     }
 
@@ -47,12 +49,12 @@ struct functional_graph {
     std::vector<int> jump_all(std::uint64_t step) const {
         std::vector<int> res(_size, -1);
         std::vector<std::pair<int, int>> query;
-        internal::graph_csr csr(_size);
+        std::vector<std::pair<int, int>> edges;
         for (int v = 0; v < _size; ++v) {
             int d = hld.get_depth(v);
             int r = _root[v];
             if ((std::uint64_t)d - 1 > step) {
-                csr.add_edge(v, query.size());
+                edges.emplace_back(v, (int)query.size());
                 query.emplace_back(v, step);
             } else {
                 std::int64_t k = step - (d - 1);
@@ -63,16 +65,16 @@ struct functional_graph {
                     res[v] = r;
                     continue;
                 }
-                csr.add_edge(bottom, query.size());
+                edges.emplace_back(bottom, (int)query.size());
                 query.emplace_back(v, k - 1);
             }
         }
-        csr.build();
+        internal::Csr<int> query_csr(_size, edges);
 
         std::vector<int> path;
         auto dfs = [&](auto self, int v) -> void {
             path.emplace_back(v);
-            for (int id : csr[v]) res[query[id].first] = path[path.size() - 1 - query[id].second];
+            for (int id : query_csr[v]) res[query[id].first] = path[path.size() - 1 - query[id].second];
             for (int u : g[v]) self(self, u);
             path.pop_back();
         };
@@ -112,10 +114,10 @@ struct functional_graph {
     int _size;
     const std::vector<int> &to;
     std::vector<int> _root;
-    internal::graph_csr g;
+    internal::Csr<int> g;
     heavy_light_decomposition hld;
 
-    functional_graph(int n, const std::vector<int> &_to) : _size(n), to(_to), _root(n, -1), g(n + 1), hld() {}
+    functional_graph(int n, const std::vector<int> &_to) : _size(n), to(_to), _root(n, -1), g(), hld() {}
 
     std::vector<int> get_cycle(int v) const {
         std::vector<int> res(1, v);

--- a/lib/graph/graph.hpp
+++ b/lib/graph/graph.hpp
@@ -158,7 +158,7 @@ struct list_graph {
 ///
 /// 辺は `add_edge` / `add_edges` で蓄積したあと `build()` で確定させる。
 /// `build()` 後は構造が固定され、再度辺を追加するには `build()` をやり直す。
-/// `internal::graph_csr` とは異なり重み・辺 ID を保持する公開グラフ型である。
+/// `internal::Csr` とは異なり重み・辺 ID を保持する公開グラフ型である。
 template <class T>
 struct csr_graph {
   private:

--- a/lib/graph/scc.hpp
+++ b/lib/graph/scc.hpp
@@ -13,9 +13,10 @@ std::vector<int> scc(const G &g) {
     std::vector<int> comp(n, -1), order;
     std::vector<bool> used(n);
 
-    internal::graph_csr rg(n);
-    for (auto &e : g.all_edges()) rg.add_edge(e.to(), e.from());
-    rg.build();
+    std::vector<std::pair<int, int>> redges;
+    redges.reserve(g.edge_count());
+    for (auto &e : g.all_edges()) redges.emplace_back(e.to(), e.from());
+    internal::Csr<int> rg(n, redges);
 
     // 反復 DFS（再帰だと深いグラフでスタックオーバーフローしうる）
     // stk には頂点と隣接リストの走査位置を積む。子を処理し終えた後に
@@ -65,16 +66,17 @@ std::vector<int> scc(const G &g) {
     return comp;
 };
 
-std::vector<int> scc(const internal::graph_csr &g) {
+std::vector<int> scc(const internal::Csr<int> &g) {
     int n = g.size();
     std::vector<int> comp(n, -1), order;
     std::vector<bool> used(n);
 
-    internal::graph_csr rg(n);
+    std::vector<std::pair<int, int>> redges;
+    redges.reserve(g.elist.size());
     for (int i = 0; i < n; ++i) {
-        for (int u : g[i]) rg.add_edge(u, i);
+        for (int u : g[i]) redges.emplace_back(u, i);
     }
-    rg.build();
+    internal::Csr<int> rg(n, redges);
 
     // 反復 DFS（再帰だと深いグラフでスタックオーバーフローしうる）
     // CSR は隣接リストの走査をイテレータで進める。子を処理し終えた後に

--- a/lib/graph/two_sat.hpp
+++ b/lib/graph/two_sat.hpp
@@ -5,16 +5,16 @@
 
 /// @brief 2-SAT
 struct two_sat {
-    two_sat(int n) : _size(n), G(n * 2) {}
+    two_sat(int n) : _size(n) {}
 
     void add(int i, bool f, int j, bool g) {
         i <<= 1, j <<= 1;
-        G.add_edge(i + (f ? 0 : 1), j + (g ? 1 : 0));
-        G.add_edge(j + (g ? 0 : 1), i + (f ? 1 : 0));
+        edges.emplace_back(i + (f ? 0 : 1), j + (g ? 1 : 0));
+        edges.emplace_back(j + (g ? 0 : 1), i + (f ? 1 : 0));
     }
 
     std::vector<int> solve() {
-        G.build();
+        internal::Csr<int> G(_size * 2, edges);
         auto res = scc(G);
         return res;
     }
@@ -34,5 +34,5 @@ struct two_sat {
 
   private:
     int _size;
-    internal::graph_csr G;
+    std::vector<std::pair<int, int>> edges;
 };

--- a/lib/internal/internal_csr.hpp
+++ b/lib/internal/internal_csr.hpp
@@ -1,80 +1,45 @@
 #pragma once
-#include <iostream>
+#include <iterator>
 #include <utility>
 #include <vector>
 
 namespace internal {
 
-struct graph_csr {
-  private:
-    struct edge_list {
-        using const_iterator = std::vector<int>::const_iterator;
-
-        edge_list(const graph_csr &g, int v) : g(g), v(v) {}
-
-        const_iterator begin() const { return std::next(g.elist.begin(), g.start[v]); }
-        const_iterator end() const { return std::next(g.elist.begin(), g.start[v + 1]); }
-
-      private:
-        const graph_csr &g;
-        int v;
-    };
-
-  public:
-    graph_csr(int n) : _size(n), edges(), start(n + 1) {}
-
-    edge_list operator[](int i) const { return edge_list(*this, i); }
-
-    constexpr int size() const { return _size; }
-
-    void build() {
-        for (auto [u, v] : edges) ++start[u + 1];
-        for (int i = 0; i < _size; ++i) start[i + 1] += start[i];
-        auto counter = start;
-        elist = std::vector<int>(edges.size());
-        for (auto [u, v] : edges) elist[counter[u]++] = v;
-    }
-
-    void add_edge(int u, int v) { edges.emplace_back(u, v); }
-
-    void add_edges(int u, int v) {
-        edges.emplace_back(u, v);
-        edges.emplace_back(v, u);
-    }
-
-    void input_edge(int m, int origin = 1) {
-        for (int i = 0; i < m; ++i) {
-            int from, to;
-            std::cin >> from >> to;
-            add_edge(from - origin, to - origin);
-        }
-        build();
-    }
-
-    void input_edges(int m, int origin = 1) {
-        for (int i = 0; i < m; ++i) {
-            int from, to;
-            std::cin >> from >> to;
-            add_edges(from - origin, to - origin);
-        }
-        build();
-    }
-
-    int _size;
-    std::vector<std::pair<int, int>> edges;
-    std::vector<int> elist;
-    std::vector<int> start;
-};
-
+/// @brief CSR（Compressed Sparse Row）形式で隣接リストを保持する軽量な内部データ構造
+/// @tparam E 各辺に付随するペイロード型（`int` なら単純な隣接先のみ、任意の構造体も可）
+///
+/// 全辺が確定した状態で一括構築する（ACL 由来）。頂点ごとに動的な `vector` を持たず
+/// 1 本の連続領域に詰めるため、重み・辺 ID を保持しない用途（SCC の逆グラフ、
+/// HL 分解、2-SAT の含意グラフなど）では `list_graph<T>` / `csr_graph<T>` より軽量。
 template <class E>
-struct csr {
+struct Csr {
     std::vector<int> start;
     std::vector<E> elist;
-    explicit csr(int n, const std::vector<std::pair<int, E>> &edges) : start(n + 1), elist(edges.size()) {
-        for (auto e : edges) ++start[e.first + 1];
-        for (int i = 1; i <= n; ++i) start[i] += start[i - 1];
+
+    Csr() : start(1), elist() {}
+    explicit Csr(int n, const std::vector<std::pair<int, E>> &edges) : start(n + 1), elist(edges.size()) {
+        for (auto &e : edges) ++start[e.first + 1];
+        for (int i = 0; i < n; ++i) start[i + 1] += start[i];
         auto counter = start;
-        for (auto e : edges) elist[counter[e.first]++] = e.second;
+        for (auto &e : edges) elist[counter[e.first]++] = e.second;
+    }
+
+    /// @brief 頂点 v の隣接辺を走査する軽量 view（CSR の連続領域を指す）
+    struct adjacency {
+        using const_iterator = typename std::vector<E>::const_iterator;
+
+        adjacency(const_iterator first, const_iterator last) : _first(first), _last(last) {}
+
+        const_iterator begin() const { return _first; }
+        const_iterator end() const { return _last; }
+
+      private:
+        const_iterator _first, _last;
+    };
+
+    constexpr int size() const { return (int)start.size() - 1; }
+    adjacency operator[](int v) const {
+        return adjacency(std::next(elist.begin(), start[v]), std::next(elist.begin(), start[v + 1]));
     }
 };
 

--- a/lib/tree/hld.hpp
+++ b/lib/tree/hld.hpp
@@ -52,7 +52,7 @@ struct heavy_light_decomposition {
         }
     }
 
-    heavy_light_decomposition(const internal::graph_csr &g, int r = 0) : heavy_light_decomposition(g.size()) {
+    heavy_light_decomposition(const internal::Csr<int> &g, int r = 0) : heavy_light_decomposition(g.size()) {
         std::vector<int> heavy_path(_size, -1);
         std::vector<int> stk;
         stk.reserve(_size);


### PR DESCRIPTION
## Summary
- `graph_csr`（add_edge/build の逐次構築）と `csr<E>`（辺リスト一括構築、min_cost_flow 専用）が同じ counting sort による CSR 構築を重複実装していたため統合
- `csr<E>` に `operator[]`/`size()` を追加し、`scc` の逆グラフ・`hld`・`two_sat` の含意グラフ・`functional_graph` を「vector に辺を貯めてから一括構築」に書き換えて `graph_csr` を削除
- 未使用だった `input_edge`/`input_edges` も道連れで削除
- PascalCase 移行方針に沿って `csr<E>` → `Csr<E>` に改名（`min_cost_flow.hpp` の参照も追随）

## Test plan
- [x] 逆依存する24テストファイルすべてを `-fsyntax-only` でローカル syntax-check
- [x] `scc`/`two_sat`/`min_cost_flow`/`functional_graph`/`hld` 系テストの実バイナリコンパイル確認
- [x] `scc`/`two_sat`/`functional_graph`（`jump`/`jump_all`）を naive 実装とのランダムテストで突き合わせ、挙動が変わっていないことを確認
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)