### PR TITLE
ローカルのスタックサイズ制限を緩和し、AOJ 2559 を再帰版に戻す

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -215,6 +215,11 @@ run = """
 #!/bin/bash
 mise run build "$usage_src" || exit 1
 
+# システムデフォルト（多くの Linux 環境で 8MB）だと再帰の深い解法が
+# ローカルでだけ SIGSEGV しうる。ulimit はプロセスに継承されるので、
+# ここで上げておけば oj t が fork/exec するジャッジ対象バイナリにも効く。
+ulimit -s unlimited 2>/dev/null || ulimit -s 1048576
+
 oj_args=(-N)
 [[ "$usage_error" == "true" ]] && oj_args+=(-e 1e-9)
 oj t "${oj_args[@]}"
@@ -294,6 +299,10 @@ oj_compile() {
 [[ -f "$usage_src" ]] || { echo "$usage_src が見つかりません" >&2; exit 1; }
 oj_bundle "$usage_src" >main.cpp || exit 1
 oj_compile main.cpp || exit 1
+# システムデフォルト（多くの Linux 環境で 8MB）だと再帰の深い解法が
+# ローカルでだけ SIGSEGV しうる。ulimit は子プロセスに継承されるので、
+# ここで上げておけば checker が fork/exec する解答バイナリにも効く。
+ulimit -s unlimited 2>/dev/null || ulimit -s 1048576
 (
   cd checker || exit 1
   [[ -f test.cpp ]] || exit 1

--- a/test/aoj/challenge/2559.2.test.cpp
+++ b/test/aoj/challenge/2559.2.test.cpp
@@ -45,40 +45,20 @@ int main(void) {
         if (!used[i]) ans[i] = sum;
     }
     uf = union_find(n);
-    // 反復 DFS（再帰だと深い木でスタックオーバーフローしうる）。
-    // 帰りがけに親側の辺を辿って heap の pop/meld と ans の更新を行う。
-    std::vector<int> par(n, -1), pe(n, -1);
-    struct frame {
-        int v, p, idx;
-    };
-    std::vector<frame> stk;
-    stk.reserve(n);
-    stk.push_back({0, -1, 0});
-    while (!stk.empty()) {
-        frame &f = stk.back();
-        int x = f.v;
-        if (f.idx < (int)g[x].size()) {
-            int i = f.idx++;
-            auto e = g[x][i];
-            if (e.to() == f.p) continue;
-            par[e.to()] = x;
-            pe[e.to()] = i;
-            stk.push_back({e.to(), x, 0});
-        } else {
-            int p = par[x];
-            stk.pop_back();
-            if (p != -1) {
-                auto e = g[p][pe[x]];
-                while (!heap[x].empty() && uf.same(x, heap[x].top().second)) heap[x].pop();
-                if (!heap[x].empty()) {
-                    auto [u, v, w] = edges[e.weight()];
-                    ans[e.weight()] = sum - w + heap[x].top().first;
-                }
-                heap[p].meld(heap[x]);
-                uf.unite(p, x);
+    auto dfs = [&](auto self, int x, int p) -> void {
+        for (auto e : g[x]) {
+            if (e.to() == p) continue;
+            self(self, e.to(), x);
+            while (!heap[e.to()].empty() && uf.same(e.to(), heap[e.to()].top().second)) heap[e.to()].pop();
+            if (!heap[e.to()].empty()) {
+                auto [u, v, w] = edges[e.weight()];
+                ans[e.weight()] = sum - w + heap[e.to()].top().first;
             }
+            heap[x].meld(heap[e.to()]);
+            uf.unite(x, e.to());
         }
-    }
+    };
+    dfs(dfs, 0, -1);
     for (int i = 0; i < m; ++i) std::cout << ans[i] << '\n';
 
     return 0;

--- a/test/aoj/challenge/2559.test.cpp
+++ b/test/aoj/challenge/2559.test.cpp
@@ -45,40 +45,20 @@ int main(void) {
         if (!used[i]) ans[i] = sum;
     }
     uf = union_find(n);
-    // 反復 DFS（再帰だと深い木でスタックオーバーフローしうる）。
-    // 帰りがけに親側の辺を辿って heap の pop/meld と ans の更新を行う。
-    std::vector<int> par(n, -1), pe(n, -1);
-    struct frame {
-        int v, p, idx;
-    };
-    std::vector<frame> stk;
-    stk.reserve(n);
-    stk.push_back({0, -1, 0});
-    while (!stk.empty()) {
-        frame &f = stk.back();
-        int x = f.v;
-        if (f.idx < (int)g[x].size()) {
-            int i = f.idx++;
-            auto e = g[x][i];
-            if (e.to() == f.p) continue;
-            par[e.to()] = x;
-            pe[e.to()] = i;
-            stk.push_back({e.to(), x, 0});
-        } else {
-            int p = par[x];
-            stk.pop_back();
-            if (p != -1) {
-                auto e = g[p][pe[x]];
-                while (!heap[x].empty() && uf.same(x, heap[x].top().second)) heap[x].pop();
-                if (!heap[x].empty()) {
-                    auto [u, v, w] = edges[e.weight()];
-                    ans[e.weight()] = sum - w + heap[x].top().first;
-                }
-                heap[p].meld(heap[x]);
-                uf.unite(p, x);
+    auto dfs = [&](auto self, int x, int p) -> void {
+        for (auto e : g[x]) {
+            if (e.to() == p) continue;
+            self(self, e.to(), x);
+            while (!heap[e.to()].empty() && uf.same(e.to(), heap[e.to()].top().second)) heap[e.to()].pop();
+            if (!heap[e.to()].empty()) {
+                auto [u, v, w] = edges[e.weight()];
+                ans[e.weight()] = sum - w + heap[e.to()].top().first;
             }
+            heap[x].meld(heap[e.to()]);
+            uf.unite(x, e.to());
         }
-    }
+    };
+    dfs(dfs, 0, -1);
     for (int i = 0; i < m; ++i) std::cout << ans[i] << '\n';
 
     return 0;


### PR DESCRIPTION
## Summary
- `mise.toml` の `test`（ojt）/`random-check`（ojrc）タスクで `ulimit -s unlimited`（不可なら1GBへフォールバック）を実行前に効かせるようにした。システム既定（多くの Linux 環境で8MB）だと再帰の深い解法がローカルでだけ SIGSEGV しうるため。`-Wl,-z,stack-size=N` は Linux では実際には無視されることを実験で確認済み（有効なのは ulimit のみ）。
- 上記によりローカルでは再帰版でも通るようになったため、AOJ 2559（`test/aoj/challenge/2559.test.cpp` / `2559.2.test.cpp`）の DFS を可読性の高い再帰版に戻した。

## ⚠️ CI についての注意
この revert は **CI を落とす可能性があります**。`ulimit` の修正は `mise.toml` の `ojt`/`ojrc` タスク（ローカルのワークスペース作業用）のみに効くもので、このリポジトリの実際の CI（`.github/workflows/verify.yml`、`competitive-verifier/actions` というサードパーティ Action 経由）には影響しません。CI ランナーの既定スタックサイズがローカルと同じく小さい場合、`90_antidfs.in` / `91_antiRecHeap.in` で以前と同じ SIGSEGV が再発する可能性があります。CI 側にスタックサイズを上げる簡単な差し込み口は見当たらず、今回は未対応です。

## Test plan
- [x] ローカルで `mise run test`（ulimit 修正込み）を実行し、AOJ 2559 の実データ37ケース（対象2ケース含む）で AC を確認
- [ ] CI（competitive-verifier）で実際に該当2ケースが通るか要確認 — 落ちた場合は追加対応が必要