### PR TITLE
fix/doc title asciimath collision

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,15 +21,16 @@ g++ -std=c++23 -I lib -Wall -Wextra -fsyntax-only <test_file>
 
 ### CI 調査・トークン節約
 
-- **ヘッダ変更は push 前に逆依存テストをローカル syntax-check**（CI 往復をまるごと削減）。
+- **push/CI ログ取得より先にローカル `-fsyntax-only` で再現**（ヘッダ変更時の逆依存チェックにも
+  verify 失敗の再現にも共通。失敗の大半はコンパイルエラーなのでこれで即再現できる）。
   `grep -rl <header_basename> lib test | grep '\.test\.cpp$' | xargs -I{} g++ -std=c++23 -I lib -fsyntax-only {}`。
   transitive 依存は `oj-bundle <test>` で展開して確認（ローカルに `oj-verify`/`oj-bundle`/`oj` あり）。
-- **verify 失敗は CI ログを取りに行く前にローカル再現**。失敗の大半はコンパイルエラーで、
-  上記 `-fsyntax-only` で即再現できる。
 - どうしても CI を見る時は**狭く**: 状態は `gh ... --json … -q`、エラーは `--log-failed` で**1 ジョブのみ**、
   「どのテストが落ちたか」は merged check の `N file(s) still failing` 行で特定。`--log` の全シャードループは避ける。
-- 巨大ログを精読せざるを得ない時は**サブエージェントに委譲**（生ログは子のコンテキストに留め、結論だけ受け取る）。
+- 巨大ログ・数十 KB を超える外部ファイル（ミニファイ JS 等）を精読せざるを得ない時は
+  **サブエージェントに委譲**（生データは子のコンテキストに留め、結論だけ受け取る）。
 - CI はポーリングせず auto-merge に任せる。
+- **同一 URL への curl は結果を使い回し、再フェッチしない**（GitHub Pages のドキュメント確認等）。
 
 ## コーディング規約
 

--- a/lib/algorithm/doubling.hpp
+++ b/lib/algorithm/doubling.hpp
@@ -7,7 +7,7 @@
 #include <vector>
 #include "segtree/monoid.hpp"
 
-/// @brief ダブリングで `M` が取れる型か（`void` または `monoid`）
+/// @brief ダブリングで `M` が取れる型か（void または monoid）
 /// @details `void` は集約なし（遷移先のみ）、`monoid` は遷移に沿った値の集約を表す。
 template <class M>
 concept doubling_monoid = std::is_void_v<M> || monoid<M>;

--- a/lib/flow/bipartite_graph_matching.hpp
+++ b/lib/flow/bipartite_graph_matching.hpp
@@ -6,7 +6,7 @@
 #include "flow/bipartite_matching.hpp"
 #include "graph/graph.hpp"
 
-/// @brief 2 彩色済みの一般の無向グラフを二部マッチング本体（`BipartiteMatching`）に橋渡しするアダプタ
+/// @brief 2 彩色済みの一般の無向グラフを二部マッチング本体（BipartiteMatching）に橋渡しするアダプタ
 /// @details `bipartite_coloring(g)` の結果をそのまま渡して構築し、
 ///          最大マッチング・最小頂点被覆・最大独立集合を元のグラフの頂点 id で取得する。
 ///

--- a/lib/graph/shortest_path.hpp
+++ b/lib/graph/shortest_path.hpp
@@ -6,7 +6,7 @@
 #include <vector>
 #include "graph/graph.hpp"
 
-/// @brief shortest_path の既定ヒープ（`std::priority_queue` ベースの最小ヒープ）
+/// @brief shortest_path の既定ヒープ（std::priority_queue ベースの最小ヒープ）
 /// @details 順序基準 `Key`（距離）・付随データ `Value`（頂点）を受け取り、`Key` 最小を
 ///          ルートにする。`binary_heap` / `fibonacci_heap` と同じ template-template 形式
 ///          （`Heap<Key, Value, Comp>`）で渡せるよう薄く包む。decrease-key は持たない。


### PR DESCRIPTION
- **docs: @brief 内 backtick 単語と AsciiMath 予約語の衝突を回避**
- **docs: CI調査節のトークン節約 Tips を整理・追記**
