### PR TITLE
perf: oj-resolve で read_macros を無効化

### DIFF
--- a/.verify-helper/config.toml
+++ b/.verify-helper/config.toml
@@ -1,3 +1,8 @@
+[languages.cpp]
+# test は全ファイル special comments 済みで未使用。lib ヘッダ側の
+# 無駄な `g++ -dM -E` 呼び出し（oj-resolve の主要コスト）を避ける。
+read_macros = false
+
 [[languages.cpp.environments]]
 CXX = "g++"
 CXXFLAGS = [


### PR DESCRIPTION
## Summary
- `oj-resolve`（setup ジョブ）は全 C++ ファイルに対し逐次で `g++ -MM`（依存解決）に加え、special comments が無いファイルには属性抽出用の `g++ -dM -E` を実行している。
- 本リポジトリでは test 側は全ファイル special comments 済みでこの経路に乗らない一方、`lib/*.hpp`（173ファイル）は special comments を持たないため無駄に `-dM -E` が走っていた。
- `.verify-helper/config.toml` に `read_macros = false` を追加し、この無駄な呼び出しを止める（[upstream issue #223](https://github.com/competitive-verifier/competitive-verifier/issues/223) で追加されたオプション）。

## Test plan
- [x] ローカルに `competitive-verifier` を pip インストールし、変更前後で `oj-resolve` を実行して `verify_files.json` を比較 → `dependencies` / `verification` は完全一致（差分は docs 生成で未参照の内部マーカー属性のみ）
- [x] ローカル実行時間: 約24.1s → 約14.8s（約40%短縮）
- [ ] CI（setup ジョブの oj-resolve ステップ）で同様の短縮を確認

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>