### PR TITLE
部分永続配列 PartiallyPersistentArray を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ g++ -std=c++23 -I lib your_solution.cpp
 | [`lib/ordered_set/`](lib/ordered_set/)       | 順序集合・多重集合（AVL 木）・Binary Trie・Patricia Binary Trie・64 分木                  |
 | [`lib/union_find/`](lib/union_find/)         | Union-Find（重み付き・undo・動的・永続・offline dynamic connectivity）                    |
 | [`lib/heap/`](lib/heap/)                     | Binary / Fibonacci / Leftist / Skew / Radix / Interval ヒープ・削除可能 PQ・k 番目和      |
-| [`lib/persistent_ds/`](lib/persistent_ds/)   | 永続配列・永続セグメント木・永続スタック/キュー                                           |
+| [`lib/persistent_ds/`](lib/persistent_ds/)   | 永続配列・部分永続配列・永続セグメント木・永続スタック/キュー                             |
 | [`lib/dp/`](lib/dp/)                         | Convex Hull Trick・Li Chao Tree・Slope Trick・monotone minima                             |
 | [`lib/number_theory/`](lib/number_theory/)   | modint・多倍長整数・分数・素数判定/列挙・篩・素因数分解・CRT・floor sum・mod 平方根 など  |
 | [`lib/combinatorics/`](lib/combinatorics/)   | 二項係数・スターリング数等の列挙・ベル数・分割数・offline binomial sum                    |

--- a/docs/persistent_ds/partially_persistent_array.md
+++ b/docs/persistent_ds/partially_persistent_array.md
@@ -1,0 +1,74 @@
+---
+title: 部分永続配列 (PartiallyPersistentArray)
+documentation_of: //lib/persistent_ds/partially_persistent_array.hpp
+compile_example: true
+---
+
+更新は最新時刻に対してのみ行い、参照は任意の過去時刻に対して行える配列。各要素が
+`(時刻, 値)` の履歴を昇順に持つ fat node 方式で、更新は履歴末尾への追加、参照は履歴の
+二分探索になる。
+
+「時系列順に配列を書き換えながら、途中の任意の時点の値を後から問い合わせる」場面で使う。
+版が分岐する（過去の版を基点に更新する）用途には使えず、その場合は完全永続な
+`persistent_ds/persistent_array.hpp` を使う。
+
+## 使い方
+
+```cpp
+#include <vector>
+#include "persistent_ds/partially_persistent_array.hpp"
+
+std::vector<int> a = {3, 1, 4};
+PartiallyPersistentArray<int> ppa(a);
+
+ppa.set(0, 10);         // 時刻 1: a = {10, 1, 4}
+ppa.set(2, 20);         // 時刻 2: a = {10, 1, 20}
+
+int x = ppa.get(0, 0);  // 3   （時刻 0 の値）
+int y = ppa.get(2, 1);  // 4   （時刻 1 の値）
+int z = ppa[2];         // 20  （現在時刻の値）
+
+// 外部の時刻を割り当てると、同一時刻に複数要素を更新できる
+PartiallyPersistentArray<int> events(3, 0);
+events.set(0, 5, 100);
+events.set(1, 7, 100);       // 同じ時刻 100 での更新
+int w = events.get(1, 100);  // 7
+```
+
+## API
+
+| API | 内容 | 計算量 |
+| --- | --- | --- |
+| `PartiallyPersistentArray()` | 空の配列を構築する | $O(1)$ |
+| `PartiallyPersistentArray(int n, T val = T())` | n 個の val を時刻 0 の状態として作る | $O(n)$ |
+| `template <class U> PartiallyPersistentArray(const std::vector<U> &v)` | 列 v を時刻 0 の状態として作る | $O(n)$ |
+| `int size() const` | 要素数を返す | $O(1)$ |
+| `int now() const` | 現在時刻を返す | $O(1)$ |
+| `T operator[](int k) const` | 現在時刻における k 番目の値を返す | $O(\log q)$ |
+| `T at(int k) const` | `operator[](k)` の別名 | $O(\log q)$ |
+| `T get(int k) const` | `operator[](k)` の別名 | $O(\log q)$ |
+| `T get(int k, int t) const` | 時刻 t における k 番目の値を返す。t が現在時刻を超える場合は最新の値を返す | $O(\log q)$ |
+| `T at(int k, int t) const` | `get(k, t)` の別名 | $O(\log q)$ |
+| `int set(int k, T val)` | 時刻を 1 進めて k 番目を val に変更する<br>**戻り値:** 更新後の時刻 | 償却 $O(1)$ |
+| `void set(int k, T val, int t)` | 現在時刻以上の時刻 t で k 番目を val に変更し、現在時刻を t にする<br>**備考:** 同一時刻に同じ要素を複数回更新した場合は最後の値が採用される | 償却 $O(1)$ |
+| `std::vector<T> to_vector() const` | 現在時刻における配列全体を返す | $O(n\log q)$ |
+| `std::vector<T> to_vector(int t) const` | 時刻 t における配列全体を返す | $O(n\log q)$ |
+
+## 補足
+
+- 計算量の $n$ は要素数、$q$ は該当する 1 要素の更新回数を表す。
+- 初期状態の時刻は 0。`set(k, val)` は時刻を 1 進めるので、$i$ 回目の更新直後の時刻は $i$ になる。
+- 時刻の割り当て方は 2 通りあり、混在させてもよい。`set(k, val)` は現在時刻 + 1 を使い、
+  `set(k, val, t)` は指定した t を使う。どちらも時刻が非減少であることを `assert` で要求する。
+- `get(k, t)` は t が現在時刻を超えていても有効で、最新の値を返す。外部の時刻をそのまま
+  問い合わせに使える。負の t は `assert` で弾く。
+- 空間計算量は総更新回数を $Q$ として $O(n + Q)$。値を複製するのは更新した要素だけで、
+  永続配列のような経路上のノード複製は発生しない。
+- `T` に要求するのはコピー構築と代入のみ。順序や演算は不要。
+- 同じく過去参照のみを許す設計として `union_find/partially_persistent_union_find.hpp` がある。
+  こちらも `f(x, t)` の形で時刻を最後の引数に取る。
+
+## 検証
+
+- 素直に対応する検証問題がないため competitive-verifier での verify は保留。naive 実装との
+  ランダム比較で、自動時刻進行・外部時刻の割り当て・同一時刻の複数更新・現在時刻を超える参照を確認している。

--- a/docs/reference.toml
+++ b/docs/reference.toml
@@ -5,9 +5,9 @@ excluded_directories = ["internal", "template"]
 
 # 現在値を下限として、説明の削除や文書化されていない公開ヘッダの増加を防ぐ。
 # 詳細ページを追加したら minimum_reference_pages も同じPRで引き上げる。
-minimum_doxygen_headers = 143
-minimum_reference_pages = 164
-minimum_compiled_examples = 164
+minimum_doxygen_headers = 144
+minimum_reference_pages = 165
+minimum_compiled_examples = 165
 maximum_undocumented_headers = 0
 
 [style]

--- a/lib/persistent_ds/partially_persistent_array.hpp
+++ b/lib/persistent_ds/partially_persistent_array.hpp
@@ -1,0 +1,95 @@
+#pragma once
+#include <algorithm>
+#include <cassert>
+#include <iterator>
+#include <utility>
+#include <vector>
+
+/// @brief 部分永続配列
+/// @tparam T 要素型
+/// @note 更新は最新時刻に対してのみ行えるが、参照は任意の過去時刻に対して行える。各要素が
+///       (時刻, 値) の履歴を持つ fat node 方式で、更新のたびに履歴を 1 つ末尾に積む。
+/// @note 時刻は更新のたびに 1 進む。`set(k, val, t)` を使うと外部の時刻（非減少）をそのまま
+///       割り当てられ、同一時刻に複数要素を更新できる。
+/// @complexity 構築は $O(n)$、更新は償却 $O(1)$、参照は該当要素の更新回数を $q$ として $O(\log q)$
+template <class T>
+struct PartiallyPersistentArray {
+    /// @brief 空の配列を構築する
+    /// @complexity $O(1)$
+    PartiallyPersistentArray() : _now(0) {}
+
+    /// @brief n 個の val を時刻 0 の状態として作る
+    /// @complexity $O(n)$
+    PartiallyPersistentArray(int n, T val = T()) : _now(0), _data(n, std::vector<std::pair<int, T>>(1, {0, val})) {}
+
+    /// @brief 列 v を時刻 0 の状態として作る
+    /// @complexity $O(n)$
+    template <class U>
+    PartiallyPersistentArray(const std::vector<U> &v) : _now(0), _data(v.size()) {
+        for (int i = 0; i < (int)v.size(); ++i) _data[i].emplace_back(0, T(v[i]));
+    }
+
+    /// @brief 要素数を返す
+    /// @complexity $O(1)$
+    int size() const { return _data.size(); }
+
+    /// @brief 現在時刻を返す
+    /// @complexity $O(1)$
+    int now() const { return _now; }
+
+    /// @brief 現在時刻における k 番目の値を返す
+    /// @complexity $O(\log q)$
+    T operator[](int k) const { return get(k, _now); }
+    /// @brief `operator[](k)` の別名
+    /// @complexity $O(\log q)$
+    T at(int k) const { return get(k, _now); }
+    /// @brief `operator[](k)` の別名
+    /// @complexity $O(\log q)$
+    T get(int k) const { return get(k, _now); }
+
+    /// @brief 時刻 t における k 番目の値を返す。t が現在時刻を超える場合は最新の値を返す
+    /// @complexity $O(\log q)$
+    T get(int k, int t) const {
+        assert(0 <= k && k < size());
+        assert(0 <= t);
+        const auto &history = _data[k];
+        return std::prev(std::ranges::upper_bound(history, t, {}, &std::pair<int, T>::first))->second;
+    }
+    /// @brief `get(k, t)` の別名
+    /// @complexity $O(\log q)$
+    T at(int k, int t) const { return get(k, t); }
+
+    /// @brief 時刻を 1 進めて k 番目を val に変更する
+    /// @return 更新後の時刻
+    /// @complexity 償却 $O(1)$
+    int set(int k, T val) {
+        set(k, val, _now + 1);
+        return _now;
+    }
+
+    /// @brief 現在時刻以上の時刻 t で k 番目を val に変更し、現在時刻を t にする
+    /// @note 同一時刻に同じ要素を複数回更新した場合は最後の値が採用される
+    /// @complexity 償却 $O(1)$
+    void set(int k, T val, int t) {
+        assert(0 <= k && k < size());
+        assert(_now <= t);
+        _now = t;
+        _data[k].emplace_back(t, val);
+    }
+
+    /// @brief 現在時刻における配列全体を返す
+    /// @complexity $O(n\log q)$
+    std::vector<T> to_vector() const { return to_vector(_now); }
+
+    /// @brief 時刻 t における配列全体を返す
+    /// @complexity $O(n\log q)$
+    std::vector<T> to_vector(int t) const {
+        std::vector<T> res(size());
+        for (int i = 0; i < size(); ++i) res[i] = get(i, t);
+        return res;
+    }
+
+  private:
+    int _now;
+    std::vector<std::vector<std::pair<int, T>>> _data;
+};


### PR DESCRIPTION
## 概要

`lib/persistent_ds/partially_persistent_array.hpp` を追加。更新は最新時刻に対してのみ行い、
参照は任意の過去時刻に対して行える配列。各要素が `(時刻, 値)` の履歴を昇順に持つ fat node 方式で、
更新は履歴末尾への追加、参照は履歴の二分探索になる。

- 構築 $O(n)$ / 更新 償却 $O(1)$ / 参照 $O(\log q)$（$q$ は該当要素の更新回数）/ 空間 $O(n + Q)$
- 既存の `persistent_ds/persistent_array.hpp`（完全永続・版が分岐可能）とは用途が別なので併設。

## API 設計

- 時刻を最後の引数に取る `get(k, t)` の形は、既存の `partially_persistent_union_find` の
  `root(x, t)` / `same(x, y, t)` に揃えた。
- 更新は 2 通りで混在可。`set(k, val)` は時刻を 1 進めて新時刻を返し、`set(k, val, t)` は
  外部の非減少な時刻をそのまま割り当てる（同一時刻の複数要素更新に対応、最後の書き込みが勝つ）。
- `get(k, t)` は t が現在時刻を超えていても最新の値を返す。外部時刻をそのまま問い合わせに
  使えるようにするため。負の t は `assert` で弾く。

## 検証

素直に対応する検証問題がないため competitive-verifier での verify は保留（Library Checker の
Persistent Unionfind / Persistent Queue はいずれも版が分岐する完全永続で意味論が合わない）。
代わりに naive 実装とのランダム比較を ASan/UBSan 付きで実行して確認した。

- 自動時刻進行モード 300 ケース: 全時刻 × 全添字を naive のスナップショット列と照合
- 明示時刻モード 300 ケース: 時刻の据え置き・スキップ、同一時刻の複数更新
- `std::string` 要素、空配列、時刻 0 での上書き、現在時刻を超える参照

## その他

- 手書きリファレンス `docs/persistent_ds/partially_persistent_array.md` を追加（時刻モデルが
  API の要なので、コンパイル検証付きの使用例を置いた）。`mise run docs-check` 通過。
- `docs/reference.toml` の下限を pages / examples 164→165、doxygen 143→144 に引き上げ。
- README の `lib/persistent_ds/` 行に「部分永続配列」を追記。

🤖 Generated with [Claude Code](https://claude.com/claude-code)