### PR TITLE
RollingHash を RollingHash2D と共通化し規約どおり改名

### DIFF
--- a/lib/string/hashint.hpp
+++ b/lib/string/hashint.hpp
@@ -1,7 +1,9 @@
 #pragma once
+#include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <iostream>
-#include <utility>
+#include <random>
 
 /// @brief 法 $2^{61}-1$ 上の整数型
 /// @details ローリングハッシュ向けに、加減乗除・比較・累乗・逆元を提供する。
@@ -49,11 +51,8 @@ struct HashInt {
     /// @brief `rhs` を乗算する
     /// @complexity $O(1)$
     constexpr HashInt &operator*=(const HashInt &rhs) noexcept {
-        std::uint64_t au = x >> 31, ad = x & mask31;
-        std::uint64_t bu = rhs.x >> 31, bd = rhs.x & mask31;
-        std::uint64_t mid = ad * bu + au * bd;
-        std::uint64_t midu = mid >> 30, midd = mid & mask30;
-        x = _mod(au * bu * 2 + midu + (midd << 31) + ad * bd);
+        __uint128_t t = (__uint128_t)x * rhs.x;
+        x = _mod((std::uint64_t)(t >> 61) + (std::uint64_t)(t & mod));
         return *this;
     }
     /// @brief `rhs` で除算する
@@ -173,8 +172,6 @@ struct HashInt {
     std::uint64_t x;
 
     static constexpr std::uint64_t mod = (1ul << 61) - 1;
-    static constexpr std::uint64_t mask30 = (1ul << 30) - 1;
-    static constexpr std::uint64_t mask31 = (1ul << 31) - 1;
 
     constexpr std::uint64_t _mod(std::uint64_t x) const {
         std::uint64_t xu = x >> 61, xd = x & mod;
@@ -182,4 +179,19 @@ struct HashInt {
         if (res >= mod) res -= mod;
         return res;
     }
+};
+
+/// @brief ローリングハッシュ用の乱数基数を返す
+/// @details 基数 0・1 を避けるため $[2, 2^{32}+1]$ から選ぶ。意図的な衝突を避けるため
+///          呼び出しのたびに異なる値になる。
+/// @complexity $O(1)$
+inline HashInt random_hash_base() { return HashInt((std::uint64_t)std::random_device()() + 2); }
+
+/// @brief `HashInt` を `std::unordered_set` 等のkeyにするためのhash
+/// @complexity hash値の計算は $O(1)$
+template <>
+struct std::hash<HashInt> {
+    /// @brief 正規化済みの値をhash値として返す
+    /// @complexity $O(1)$
+    std::size_t operator()(const HashInt &rhs) const noexcept { return std::hash<std::uint64_t>()(rhs.val()); }
 };

--- a/lib/string/rolling_hash.hpp
+++ b/lib/string/rolling_hash.hpp
@@ -7,13 +7,14 @@
 #include <vector>
 
 /// @brief ローリングハッシュ
+/// @details `base` はプログラム実行のたびに乱数で決まる（意図的な衝突を避けるため）。
 /// @see https://qiita.com/keymoon/items/11fac5627672a6d6a9f6
 /// @see https://yosupo.hatenablog.com/entry/2023/08/06/181942
 /// @complexity 構築は $O(n)$、部分文字列hashは $O(1)$
 struct rolling_hash {
     /// @brief 空文字列用のhashを乱数基数で構築する
     /// @complexity $O(1)$
-    rolling_hash() : _size(), base((std::uint64_t)std::random_device()() + 2), data(), p() {}
+    rolling_hash() : rolling_hash(std::string()) {}
 
     /// @brief 文字列sのprefix hashを基数baseで構築する
     /// @complexity $O(n)$
@@ -29,13 +30,24 @@ struct rolling_hash {
         }
     }
 
+    /// @brief 同じ基数で別の文字列をhash化する
+    /// @complexity $O(n)$
+    rolling_hash derive(const std::string &s) const { return rolling_hash(s, base); }
+
     /// @brief 使用中の基数を返す
     /// @complexity $O(1)$
     std::uint64_t get_base() const { return base; }
 
+    /// @brief 文字列全体のhashを返す
+    /// @complexity $O(1)$
+    std::uint64_t get() const { return data[_size]; }
+
     /// @brief prefix s[0,r)のhashを返す
     /// @complexity $O(1)$
-    std::uint64_t get(int r) const { return data[r]; }
+    std::uint64_t get(int r) const {
+        assert(0 <= r && r <= _size);
+        return data[r];
+    }
 
     /// @brief 部分文字列s[l,r)のhashを返す
     /// @complexity $O(1)$
@@ -56,30 +68,15 @@ struct rolling_hash {
 
     /// @brief pattern sとhashが一致する開始位置を列挙する
     /// @complexity 元文字列長を $n$、pattern長を $m$ として $O(n+m)$
-    std::vector<int> search(const std::string &s) {
+    std::vector<int> search(const std::string &s) const {
         std::vector<int> res;
         int n = s.size();
         if (n > _size) return res;
-        std::uint64_t x = 0, y;
-        for (char c : s) {
-            x = _mul(x, base) + c;
-            x = (__builtin_usubl_overflow(x, mod, &y) ? x : y);
-        }
+        std::uint64_t x = derive(s).get();
         for (int i = 0; i <= _size - n; ++i) {
             if (get(i, i + n) == x) res.emplace_back(i);
         }
         return res;
-    }
-
-    /// @brief 同じ基数で文字列sのhashを計算する
-    /// @complexity $O(n)$
-    std::uint64_t hash(const std::string &s) const {
-        std::uint64_t x = 0, y;
-        for (const auto c : s) {
-            x = _mul(x, base) + c;
-            x = (__builtin_usubl_overflow(x, mod, &y) ? x : y);
-        }
-        return x;
     }
 
   private:

--- a/lib/string/rolling_hash.hpp
+++ b/lib/string/rolling_hash.hpp
@@ -1,32 +1,29 @@
 #pragma once
+#include <algorithm>
 #include <cassert>
-#include <cstdint>
 #include <limits>
-#include <random>
 #include <string>
 #include <vector>
+#include "string/hashint.hpp"
 
 /// @brief ローリングハッシュ
-/// @details `base` はプログラム実行のたびに乱数で決まる（意図的な衝突を避けるため）。
+/// @details 法 $2^{61}-1$ の Horner 法で prefix hash を持つ。
+///          `base` はプログラム実行のたびに乱数で決まる（意図的な衝突を避けるため）。
 /// @see https://qiita.com/keymoon/items/11fac5627672a6d6a9f6
 /// @see https://yosupo.hatenablog.com/entry/2023/08/06/181942
 /// @complexity 構築は $O(n)$、部分文字列hashは $O(1)$
 struct rolling_hash {
-    /// @brief 空文字列用のhashを乱数基数で構築する
+    /// @brief 空文字列用のhashを構築する
     /// @complexity $O(1)$
     rolling_hash() : rolling_hash(std::string()) {}
 
-    /// @brief 文字列sのprefix hashを基数baseで構築する
+    /// @brief 文字列sのprefix hashを構築する
     /// @complexity $O(n)$
-    rolling_hash(const std::string &_s, std::uint64_t base = (std::uint64_t)std::random_device()() + 2)
-        : _size(_s.size()), base(base), data(1), p(1, 1) {
-        std::uint64_t x = 0, t = 1, y;
-        for (const auto c : _s) {
-            x = _mul(x, base) + c;
-            x = (__builtin_usubl_overflow(x, mod, &y) ? x : y);
-            data.emplace_back(x);
-            t = _mul(t, base);
-            p.emplace_back(t);
+    explicit rolling_hash(const std::string &s, HashInt base = random_hash_base())
+        : _size(s.size()), base(base), data(_size + 1), p(_size + 1, HashInt(1)) {
+        for (int i = 0; i < _size; ++i) {
+            data[i + 1] = data[i] * base + HashInt(s[i]);
+            p[i + 1] = p[i] * base;
         }
     }
 
@@ -36,34 +33,31 @@ struct rolling_hash {
 
     /// @brief 使用中の基数を返す
     /// @complexity $O(1)$
-    std::uint64_t get_base() const { return base; }
+    HashInt get_base() const { return base; }
 
     /// @brief 文字列全体のhashを返す
     /// @complexity $O(1)$
-    std::uint64_t get() const { return data[_size]; }
+    HashInt get() const { return data[_size]; }
 
     /// @brief prefix s[0,r)のhashを返す
     /// @complexity $O(1)$
-    std::uint64_t get(int r) const {
+    HashInt get(int r) const {
         assert(0 <= r && r <= _size);
         return data[r];
     }
 
     /// @brief 部分文字列s[l,r)のhashを返す
     /// @complexity $O(1)$
-    std::uint64_t get(int l, int r) const {
+    HashInt get(int l, int r) const {
         assert(0 <= l && l <= r && r <= _size);
-        std::uint64_t x = data[r] + mod - _mul(data[l], p[r - l]), y;
-        return __builtin_usubl_overflow(x, mod, &y) ? x : y;
+        return data[r] - data[l] * p[r - l];
     }
 
     /// @brief s.substr(pos,len)のhashを返す
     /// @complexity $O(1)$
-    std::uint64_t substr(int pos, int len = std::numeric_limits<int>::max()) const {
+    HashInt substr(int pos, int len = std::numeric_limits<int>::max()) const {
         assert(0 <= pos && pos <= _size);
-        len = std::min(len, _size - pos);
-        std::uint64_t x = data[pos + len] + mod - _mul(data[pos], p[len]), y;
-        return __builtin_usubl_overflow(x, mod, &y) ? x : y;
+        return get(pos, pos + std::min(len, _size - pos));
     }
 
     /// @brief pattern sとhashが一致する開始位置を列挙する
@@ -72,7 +66,7 @@ struct rolling_hash {
         std::vector<int> res;
         int n = s.size();
         if (n > _size) return res;
-        std::uint64_t x = derive(s).get();
+        HashInt x = derive(s).get();
         for (int i = 0; i <= _size - n; ++i) {
             if (get(i, i + n) == x) res.emplace_back(i);
         }
@@ -80,22 +74,7 @@ struct rolling_hash {
     }
 
   private:
-    static constexpr std::uint64_t mod = (1ul << 61) - 1;
     int _size;
-    std::uint64_t base;
-    std::vector<std::uint64_t> data, p;
-
-    constexpr std::uint64_t _mul(std::uint64_t a, std::uint64_t b) const {
-        __uint128_t t = (__uint128_t)a * b;
-        a = (t >> 61) + (t & mod);
-        return __builtin_usubl_overflow(a, mod, &b) ? a : b;
-    }
-    constexpr std::uint64_t _pow(std::uint64_t x, std::uint64_t k) const {
-        std::uint64_t res = 1;
-        for (; k; k >>= 1) {
-            if (k & 1) res = _mul(res, x);
-            x = _mul(x, x);
-        }
-        return res;
-    }
+    HashInt base;
+    std::vector<HashInt> data, p;
 };

--- a/lib/string/rolling_hash.hpp
+++ b/lib/string/rolling_hash.hpp
@@ -12,14 +12,14 @@
 /// @see https://qiita.com/keymoon/items/11fac5627672a6d6a9f6
 /// @see https://yosupo.hatenablog.com/entry/2023/08/06/181942
 /// @complexity 構築は $O(n)$、部分文字列hashは $O(1)$
-struct rolling_hash {
+struct RollingHash {
     /// @brief 空文字列用のhashを構築する
     /// @complexity $O(1)$
-    rolling_hash() : rolling_hash(std::string()) {}
+    RollingHash() : RollingHash(std::string()) {}
 
     /// @brief 文字列sのprefix hashを構築する
     /// @complexity $O(n)$
-    explicit rolling_hash(const std::string &s, HashInt base = random_hash_base())
+    explicit RollingHash(const std::string &s, HashInt base = random_hash_base())
         : _size(s.size()), base(base), data(_size + 1), p(_size + 1, HashInt(1)) {
         for (int i = 0; i < _size; ++i) {
             data[i + 1] = data[i] * base + HashInt(s[i]);
@@ -29,7 +29,7 @@ struct rolling_hash {
 
     /// @brief 同じ基数で別の文字列をhash化する
     /// @complexity $O(n)$
-    rolling_hash derive(const std::string &s) const { return rolling_hash(s, base); }
+    RollingHash derive(const std::string &s) const { return RollingHash(s, base); }
 
     /// @brief 使用中の基数を返す
     /// @complexity $O(1)$

--- a/lib/string/rolling_hash_2d.hpp
+++ b/lib/string/rolling_hash_2d.hpp
@@ -1,7 +1,6 @@
 #pragma once
 #include <cassert>
-#include <cstdint>
-#include <random>
+#include <cstddef>
 #include <string>
 #include <vector>
 #include "string/hashint.hpp"
@@ -18,9 +17,8 @@ struct RollingHash2D {
     /// @brief 二次元列gridのhashを構築する
     /// @complexity $O(hw)$
     template <class T>
-    explicit RollingHash2D(const std::vector<std::vector<T>> &grid,
-                           HashInt base_x = (std::uint64_t)std::random_device()() + 2,
-                           HashInt base_y = (std::uint64_t)std::random_device()() + 2)
+    explicit RollingHash2D(const std::vector<std::vector<T>> &grid, HashInt base_x = random_hash_base(),
+                           HashInt base_y = random_hash_base())
         : _h(grid.size()), _w(_h ? grid[0].size() : 0), base_x(base_x), base_y(base_y),
           data(_h + 1, std::vector<HashInt>(_w + 1)), px(_h + 1, HashInt(1)), py(_w + 1, HashInt(1)) {
         for (int i = 1; i <= _h; ++i) px[i] = px[i - 1] * base_x;
@@ -35,9 +33,8 @@ struct RollingHash2D {
 
     /// @brief 文字列行列gridのhashを構築する
     /// @complexity $O(hw)$
-    explicit RollingHash2D(const std::vector<std::string> &grid,
-                           HashInt base_x = (std::uint64_t)std::random_device()() + 2,
-                           HashInt base_y = (std::uint64_t)std::random_device()() + 2)
+    explicit RollingHash2D(const std::vector<std::string> &grid, HashInt base_x = random_hash_base(),
+                           HashInt base_y = random_hash_base())
         : RollingHash2D(to_grid(grid), base_x, base_y) {}
 
     /// @brief 同じ基数で別の二次元列をhash化する

--- a/test/aoj/challenge/2863.test.cpp
+++ b/test/aoj/challenge/2863.test.cpp
@@ -18,7 +18,7 @@ Mint solve_rolling_hash(int m, const std::vector<std::string> &t, const std::str
     std::unordered_set<std::uint64_t> st;
     std::vector<int> lens;
     for (int i = 0; i < m; ++i) {
-        st.emplace(rh.hash(t[i]));
+        st.emplace(rh.derive(t[i]).get());
         lens.emplace_back(t[i].size());
     }
     std::sort(lens.begin(), lens.end());

--- a/test/aoj/challenge/2863.test.cpp
+++ b/test/aoj/challenge/2863.test.cpp
@@ -7,6 +7,7 @@
 #include <vector>
 #include "number_theory/modint.hpp"
 #include "string/aho_corasick.hpp"
+#include "string/hashint.hpp"
 #include "string/rolling_hash.hpp"
 #include "tree/tree_function.hpp"
 
@@ -15,7 +16,7 @@ using Mint = modint107;
 // ローリングハッシュで単語集合をハッシュ集合として持ち、部分文字列一致を判定する版。
 Mint solve_rolling_hash(int m, const std::vector<std::string> &t, const std::string &s) {
     rolling_hash rh;
-    std::unordered_set<std::uint64_t> st;
+    std::unordered_set<HashInt> st;
     std::vector<int> lens;
     for (int i = 0; i < m; ++i) {
         st.emplace(rh.derive(t[i]).get());

--- a/test/aoj/challenge/2863.test.cpp
+++ b/test/aoj/challenge/2863.test.cpp
@@ -15,7 +15,7 @@ using Mint = modint107;
 
 // ローリングハッシュで単語集合をハッシュ集合として持ち、部分文字列一致を判定する版。
 Mint solve_rolling_hash(int m, const std::vector<std::string> &t, const std::string &s) {
-    rolling_hash rh;
+    RollingHash rh;
     std::unordered_set<HashInt> st;
     std::vector<int> lens;
     for (int i = 0; i < m; ++i) {
@@ -24,7 +24,7 @@ Mint solve_rolling_hash(int m, const std::vector<std::string> &t, const std::str
     }
     std::sort(lens.begin(), lens.end());
     lens.erase(std::unique(lens.begin(), lens.end()), lens.end());
-    rolling_hash rhs(s, rh.get_base());
+    RollingHash rhs(s, rh.get_base());
     int n = s.size();
     std::vector<Mint> dp(n + 1);
     dp[0] = 1;

--- a/test/aoj/course/ALDS1_14_B.test.cpp
+++ b/test/aoj/course/ALDS1_14_B.test.cpp
@@ -17,7 +17,7 @@ int main(void) {
         if (match[i] == (int)t.size()) pos_kmp.emplace_back(i - (int)t.size() + 1);
     }
 
-    rolling_hash rh(s);
+    RollingHash rh(s);
     auto pos_hash = rh.search(t);
 
     assert(pos_kmp == pos_hash);

--- a/test/aoj/jag/rolling_hash.test.cpp
+++ b/test/aoj/jag/rolling_hash.test.cpp
@@ -10,7 +10,7 @@ int main(void) {
     std::cin >> n >> q;
     std::string s, t;
     std::cin >> s;
-    rolling_hash rh(s);
+    RollingHash rh(s);
     int l = 0, r = 1;
     std::unordered_set<HashInt> st;
     while (q--) {

--- a/test/aoj/jag/rolling_hash.test.cpp
+++ b/test/aoj/jag/rolling_hash.test.cpp
@@ -1,8 +1,8 @@
 // competitive-verifier: PROBLEM https://onlinejudge.u-aizu.ac.jp/problems/2444
-#include <cstdint>
 #include <iostream>
 #include <string>
 #include <unordered_set>
+#include "string/hashint.hpp"
 #include "string/rolling_hash.hpp"
 
 int main(void) {
@@ -12,7 +12,7 @@ int main(void) {
     std::cin >> s;
     rolling_hash rh(s);
     int l = 0, r = 1;
-    std::unordered_set<std::uint64_t> st;
+    std::unordered_set<HashInt> st;
     while (q--) {
         std::cin >> t;
         if (t == "L++") ++l;

--- a/test/yosupo/string/suffix_array.test.cpp
+++ b/test/yosupo/string/suffix_array.test.cpp
@@ -16,7 +16,7 @@ int main(void) {
     auto sa = suffix_array(s);
 
     std::string s2 = s + "$";
-    rolling_hash rh(s2);
+    RollingHash rh(s2);
     std::vector<int> ord(n);
     std::iota(ord.begin(), ord.end(), 0);
     std::sort(ord.begin(), ord.end(), [&](int x, int y) {

--- a/test/yosupo/string/zalgorithm.test.cpp
+++ b/test/yosupo/string/zalgorithm.test.cpp
@@ -15,7 +15,7 @@ int main(void) {
 
     auto z = z_algorithm(s);
 
-    rolling_hash rh(s);
+    RollingHash rh(s);
     std::vector<int> z_hash = {n};
     std::unordered_set<HashInt> st;
     for (int i = 1; i <= n; ++i) st.emplace(rh.get(0, i));

--- a/test/yosupo/string/zalgorithm.test.cpp
+++ b/test/yosupo/string/zalgorithm.test.cpp
@@ -1,10 +1,10 @@
 // competitive-verifier: PROBLEM https://judge.yosupo.jp/problem/zalgorithm
 #include <cassert>
-#include <cstdint>
 #include <iostream>
 #include <string>
 #include <unordered_set>
 #include <vector>
+#include "string/hashint.hpp"
 #include "string/rolling_hash.hpp"
 #include "string/z_algorithm.hpp"
 
@@ -17,7 +17,7 @@ int main(void) {
 
     rolling_hash rh(s);
     std::vector<int> z_hash = {n};
-    std::unordered_set<std::uint64_t> st;
+    std::unordered_set<HashInt> st;
     for (int i = 1; i <= n; ++i) st.emplace(rh.get(0, i));
     for (int i = 1; i < n; ++i) {
         int l = 0, r = n - i + 1;


### PR DESCRIPTION
`rolling_hash` と `RollingHash2D` が、同じローリングハッシュなのに API の流儀も内部演算も揃っていなかったので統一する。

## 1. 同一基数のhash化を `derive` に統一

| 旧 | 新 | 対応する 2D 側 |
| --- | --- | --- |
| `hash(s) -> std::uint64_t` | `derive(s) -> RollingHash` | `RollingHash2D::derive(grid)` |
| （なし） | `get()`（全体hash） | `RollingHash2D::get()` |

`hash()` は「同じ基数で別の列を hash 化する」操作なのに 2D 側と名前も戻り値も違い、使うたびにどちらの流儀か思い出す必要があった。

ついでに `get(r)` へ範囲 assert を追加し、`search` を `derive(s).get()` 経由にして const 化（pattern hash の重複実装を削除）。デフォルト構築は `data` が空で `get()`/`get(0)` が範囲外アクセスになっていたので `RollingHash("")` への委譲に変更。

## 2. 法 $2^{61}-1$ の演算を `HashInt` に共通化

| 重複していたもの | 共通化先 |
| --- | --- |
| `mod` 定数・`_mul`・未使用の `_pow`（生 `uint64_t` 実装） | `HashInt` の演算子（削除） |
| `(std::uint64_t)std::random_device()() + 2` × 6 箇所 | `random_hash_base()` |

`RollingHash` の内部表現・公開 API の戻り値を `HashInt` に変更。実装本体は `data[i+1] = data[i] * base + HashInt(s[i])` と `get(l,r) = data[r] - data[l] * p[r-l]` に縮んだ。

- `HashInt::operator*=` を `RollingHash` が持っていた `__uint128_t` 版に差し替え（31bit 分割の 4 乗算 → 1 乗算）。1D を `HashInt` に載せ替える際の定数倍悪化を防ぐためで、2D 側も速くなる
- hash 値を unordered 連想コンテナのkeyにするのは本来の用途なので `std::hash<HashInt>` を追加し、test 3 件を `unordered_set<std::uint64_t>` → `unordered_set<HashInt>` に追随
- 暗黙依存していた標準ヘッダを明示 include（`<algorithm>`・`<cstddef>`・`<functional>`・`<random>`）

## 3. 規約どおり `RollingHash` に改名

型は PascalCase という規約に対し `rolling_hash` は snake_case の名残だった。ファイル名 `rolling_hash.hpp` と test 内の関数 `solve_rolling_hash` はファイル・関数なので snake_case のまま。

## 検証

- 新旧 `HashInt::operator*=` が境界値 100 組 + 乱数 200 万組で完全一致（`pow`・`inv` も突き合わせ）
- `RollingHash` を naive と照合: 部分列一致 ⇔ hash 一致、`search`、`derive` の基数共有、空文字列
- `RollingHash2D` を naive と照合（全矩形ペアの一致判定）。さらに 1D と 2D で基数を揃えた 1 行盤面で `r2.get(0,1,l,r) == r1.get(l,r)` を確認 — 両者が本当に同じ演算を共有していることの裏取り
- `static_assert` で `__uint128_t` 乗算が定数式評価を通ることを確認
- 400 万文字の構築ベンチで退行なし（旧 50–73ms / 新 46–47ms）
- 関連 6 test を `-Wall -Wextra -fsyntax-only` で通過、`mise run docs-check` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)