### PR TITLE
CI: verify の実行時間の変化をジョブサマリーに表示

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -196,6 +196,22 @@ jobs:
         with:
           fetch-depth: 2147483647
 
+      # 実行時間サマリーの比較対象。常に main の最新結果を基準にするので、
+      # PR では「main と比べてどう変わったか」になる。cache/restore は保存時と
+      # 同じパスへ展開するため、Merge results が書く merged-result.json と
+      # 衝突しないよう先に退避しておく。
+      - name: Restore baseline result (main)
+        uses: actions/cache/restore@v6
+        id: restore-baseline
+        with:
+          path: ${{github.workspace}}/merged-result.json
+          key: ${{ runner.os }}-verify-result-main-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-verify-result-main-
+      - name: Set aside baseline result
+        if: steps.restore-baseline.outputs.cache-matched-key != ''
+        run: mv merged-result.json baseline-result.json
+
       - name: Download verify_files.json and all artifacts
         id: all-artifacts
         uses: competitive-verifier/actions/download-verify-artifact@v2
@@ -357,6 +373,16 @@ jobs:
           else:
               print("All verifications passed.")
           PY
+        env:
+          MERGED: ${{github.workspace}}/merged-result.json
+      # Informational only: runner timings vary by ~2x between identical runs,
+      # so this never gates the run. Baseline は上で退避した main の結果
+      # （無ければ差分なしで合計・上位のみ出力）。
+      - name: Report timing summary
+        run: >-
+          python3 tools/verify_timing_summary.py
+          --result "$MERGED"
+          --baseline "${{github.workspace}}/baseline-result.json"
         env:
           MERGED: ${{github.workspace}}/merged-result.json
       # Always save: competitive-verifier re-verifies "failure" tests on the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,9 @@ g++ -std=c++23 -I lib -Wall -Wextra -fsyntax-only <test_file>
   「どのテストが落ちたか」は merged check の `N file(s) still failing` 行で特定。`--log` の全シャードループは避ける。
 - 巨大ログ・数十 KB を超える外部ファイル（ミニファイ JS 等）を精読せざるを得ない時は
   **サブエージェントに委譲**（生データは子のコンテキストに留め、結論だけ受け取る）。
+- **実行時間は `docs-and-check` ジョブのサマリーで確認**（`tools/verify_timing_summary.py` が
+  `main` の結果キャッシュと比較して合計・最悪ケース・再実行された test の差分を出力）。
+  共有 runner のばらつきが大きいので参考値であり、ゲートではない。
 - CI はポーリングせず auto-merge に任せる。
 - **同一 URL への curl は結果を使い回し、再フェッチしない**（GitHub Pages のドキュメント確認等）。
 

--- a/tools/tests/test_verify_timing_summary.py
+++ b/tools/tests/test_verify_timing_summary.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from verify_timing_summary import (  # noqa: E402
+    aggregate,
+    collect,
+    format_change,
+    format_seconds,
+    is_regression,
+    reexecuted,
+    render,
+)
+
+
+def verification(
+    *,
+    status: str = "success",
+    elapsed: float = 1.0,
+    slowest: float | None = 0.5,
+    executed_at: str | None = "2026-08-04T12:00:00Z",
+    name: str | None = "g++",
+) -> dict[str, object]:
+    return {
+        "verification_name": name,
+        "status": status,
+        "elapsed": elapsed,
+        "slowest": slowest,
+        "last_execution_time": executed_at,
+    }
+
+
+def result(files: dict[str, list[dict[str, object]]]) -> dict[str, object]:
+    return {"files": {path: {"verifications": vs} for path, vs in files.items()}}
+
+
+class CollectTest(unittest.TestCase):
+    def test_skips_verifications_without_timings(self) -> None:
+        document = result(
+            {
+                "test/a.test.cpp": [verification(elapsed=2.0)],
+                # A skipped verification only carries bookkeeping overhead.
+                "test/b.test.cpp": [
+                    verification(status="skipped", elapsed=3e-06, slowest=None)
+                ],
+            }
+        )
+
+        timings = collect(document)
+
+        self.assertEqual([t.path for t in timings.values()], ["test/a.test.cpp"])
+
+    def test_keeps_every_verification_of_a_file_apart(self) -> None:
+        document = result(
+            {
+                "test/a.test.cpp": [
+                    verification(name="g++", elapsed=1.0),
+                    verification(name="clang++", elapsed=2.0),
+                ]
+            }
+        )
+
+        timings = collect(document)
+
+        self.assertEqual(len(timings), 2)
+        self.assertEqual(
+            sorted(t.label for t in timings.values()),
+            ["a", "a (clang++)"],
+        )
+
+
+class AggregateTest(unittest.TestCase):
+    def test_sums_elapsed_and_picks_the_worst_testcase(self) -> None:
+        document = result(
+            {
+                "test/a.test.cpp": [verification(elapsed=2.0, slowest=0.5)],
+                "test/b.test.cpp": [verification(elapsed=3.0, slowest=1.5)],
+                "test/c.test.cpp": [verification(elapsed=1.0, slowest=None)],
+            }
+        )
+
+        totals = aggregate(collect(document).values())
+
+        self.assertEqual(totals.count, 3)
+        self.assertAlmostEqual(totals.total, 6.0)
+        self.assertIsNotNone(totals.worst)
+        assert totals.worst is not None
+        self.assertEqual(totals.worst.path, "test/b.test.cpp")
+
+
+class ReexecutedTest(unittest.TestCase):
+    def test_carried_over_timings_are_not_reported_as_changes(self) -> None:
+        base = collect(
+            result({"test/a.test.cpp": [verification(executed_at="2026-07-30T00:00:00Z")]})
+        )
+        now = collect(
+            result({"test/a.test.cpp": [verification(executed_at="2026-07-30T00:00:00Z")]})
+        )
+
+        self.assertEqual(reexecuted(now, base), [])
+
+    def test_reports_a_rerun_even_when_the_timing_is_unchanged(self) -> None:
+        base = collect(
+            result({"test/a.test.cpp": [verification(executed_at="2026-07-30T00:00:00Z")]})
+        )
+        now = collect(
+            result({"test/a.test.cpp": [verification(executed_at="2026-08-04T00:00:00Z")]})
+        )
+
+        rows = reexecuted(now, base)
+
+        self.assertEqual(len(rows), 1)
+        self.assertIsNotNone(rows[0][1])
+
+    def test_new_tests_have_no_baseline_counterpart(self) -> None:
+        rows = reexecuted(collect(result({"test/a.test.cpp": [verification()]})), {})
+
+        self.assertEqual(len(rows), 1)
+        self.assertIsNone(rows[0][1])
+
+    def test_orders_rows_by_absolute_total_change(self) -> None:
+        base = collect(
+            result(
+                {
+                    "test/small.test.cpp": [
+                        verification(elapsed=1.0, executed_at="2026-07-30T00:00:00Z")
+                    ],
+                    "test/big.test.cpp": [
+                        verification(elapsed=10.0, executed_at="2026-07-30T00:00:00Z")
+                    ],
+                }
+            )
+        )
+        now = collect(
+            result(
+                {
+                    "test/small.test.cpp": [
+                        verification(elapsed=1.5, executed_at="2026-08-04T00:00:00Z")
+                    ],
+                    "test/big.test.cpp": [
+                        verification(elapsed=4.0, executed_at="2026-08-04T00:00:00Z")
+                    ],
+                }
+            )
+        )
+
+        self.assertEqual(
+            [row[0].label for row in reexecuted(now, base)],
+            ["big", "small"],
+        )
+
+
+class FormattingTest(unittest.TestCase):
+    def test_formats_seconds_by_magnitude(self) -> None:
+        self.assertEqual(format_seconds(0.0021), "2ms")
+        self.assertEqual(format_seconds(1.234), "1.23s")
+        self.assertEqual(format_seconds(48.886), "48.9s")
+        self.assertEqual(format_seconds(300.4), "300s")
+
+    def test_marks_a_missing_baseline_instead_of_pretending_no_change(self) -> None:
+        self.assertEqual(format_change(22.86, None), "22.9s（基準なし）")
+        self.assertEqual(format_change(None, 1.0), "—")
+        self.assertEqual(format_change(80.9, 48.9), "48.9s → 80.9s (+65%)")
+
+    def test_regression_needs_both_a_relative_and_an_absolute_jump(self) -> None:
+        self.assertTrue(is_regression(2.88, 1.0))
+        # Large ratio but a few milliseconds of runner noise.
+        self.assertFalse(is_regression(0.003, 0.002))
+        # Large absolute jump on an already slow test.
+        self.assertFalse(is_regression(101.0, 100.0))
+        self.assertFalse(is_regression(1.0, 2.0))
+
+
+class RenderTest(unittest.TestCase):
+    def test_diff_report_lists_only_reexecuted_tests(self) -> None:
+        base = result(
+            {
+                "test/slow.test.cpp": [
+                    verification(
+                        elapsed=48.9, slowest=2.88, executed_at="2026-07-30T00:00:00Z"
+                    )
+                ],
+                "test/stable.test.cpp": [
+                    verification(
+                        elapsed=1.0, slowest=0.5, executed_at="2026-07-30T00:00:00Z"
+                    )
+                ],
+            }
+        )
+        now = result(
+            {
+                "test/slow.test.cpp": [
+                    verification(
+                        elapsed=80.9, slowest=5.29, executed_at="2026-08-04T00:00:00Z"
+                    )
+                ],
+                "test/stable.test.cpp": [
+                    verification(
+                        elapsed=1.0, slowest=0.5, executed_at="2026-07-30T00:00:00Z"
+                    )
+                ],
+            }
+        )
+
+        markdown = render(now, base)
+
+        self.assertIn("48.9s → 80.9s (+65%)", markdown)
+        self.assertIn("2.88s → 5.29s (+84%)", markdown)
+        self.assertIn("⚠️ slow", markdown)
+        self.assertNotIn("stable", markdown)
+        self.assertIn("1 件 / 2 件", markdown)
+
+    def test_reports_when_nothing_was_reexecuted(self) -> None:
+        document = result(
+            {"test/a.test.cpp": [verification(executed_at="2026-07-30T00:00:00Z")]}
+        )
+
+        markdown = render(document, document)
+
+        self.assertIn("新しい計測はありません", markdown)
+
+    def test_counts_tests_that_only_exist_in_the_baseline(self) -> None:
+        base = result(
+            {
+                "test/renamed.test.cpp": [
+                    verification(executed_at="2026-07-30T00:00:00Z")
+                ]
+            }
+        )
+        now = result({"test/new_name.test.cpp": [verification()]})
+
+        markdown = render(now, base)
+
+        self.assertIn("ベースラインにのみ存在", markdown)
+
+    def test_without_a_baseline_ranks_the_slowest_tests(self) -> None:
+        document = result(
+            {
+                "test/fast.test.cpp": [verification(elapsed=1.0, slowest=0.1)],
+                "test/slow.test.cpp": [verification(elapsed=9.0, slowest=3.0)],
+            }
+        )
+
+        markdown = render(document, None, max_rows=1)
+
+        self.assertIn("最も遅い test", markdown)
+        self.assertIn("| slow ", markdown)
+        self.assertNotIn("| fast ", markdown)
+
+    def test_truncation_is_reported_instead_of_silently_dropping_rows(self) -> None:
+        base = result(
+            {
+                f"test/t{i}.test.cpp": [
+                    verification(elapsed=1.0, executed_at="2026-07-30T00:00:00Z")
+                ]
+                for i in range(3)
+            }
+        )
+        now = result(
+            {
+                f"test/t{i}.test.cpp": [
+                    verification(elapsed=2.0, executed_at="2026-08-04T00:00:00Z")
+                ]
+                for i in range(3)
+            }
+        )
+
+        markdown = render(now, base, max_rows=2)
+
+        self.assertIn("合計 3 件のうち差分の大きい 2 件のみ表示", markdown)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/verify_timing_summary.py
+++ b/tools/verify_timing_summary.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""Summarize verification timings and their change against a baseline result.
+
+The report is informational only.  Timings measured on shared GitHub runners
+vary by a factor of two between identical runs, so nothing here gates the
+workflow; the numbers exist to spot order-of-magnitude regressions.
+
+Two properties of the verification pipeline shape the output:
+
+* Tests whose previous result is still valid are skipped and their timings are
+  carried over verbatim, so a diff against the baseline lists exactly the tests
+  re-executed in this run.
+* Verifications with status ``skipped`` carry no timing at all (``elapsed`` is
+  the bookkeeping overhead and ``slowest`` is null), so they are excluded from
+  every aggregate.
+
+``elapsed`` equals the sum of the testcase timings, i.e. compilation and
+testcase downloads are not part of it; ``slowest`` is the worst single testcase.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+
+SKIPPED = "skipped"
+
+# A regression must be both relatively and absolutely large to be flagged;
+# runner noise easily reaches +80% on tests that take milliseconds.
+REGRESSION_RATIO = 0.3
+REGRESSION_ABSOLUTE = 0.5
+
+DEFAULT_MAX_ROWS = 30
+
+
+@dataclass(frozen=True)
+class Timing:
+    path: str
+    name: str | None
+    elapsed: float
+    slowest: float | None
+    last_execution_time: str | None
+    # Verifications of one file are distinguished by name, falling back to the
+    # position when a name is absent.
+    key: tuple[str, str]
+
+    @property
+    def label(self) -> str:
+        stripped = self.path.removeprefix("test/").removesuffix(".test.cpp")
+        if self.name and self.name != "g++":
+            return f"{stripped} ({self.name})"
+        return stripped
+
+
+@dataclass(frozen=True)
+class Aggregate:
+    count: int
+    total: float
+    worst: Timing | None
+
+
+def collect(result: dict[str, Any]) -> dict[tuple[str, str], Timing]:
+    """Index every timed verification of a result document by test and name."""
+    timings: dict[tuple[str, str], Timing] = {}
+    for path, file_result in (result.get("files") or {}).items():
+        for index, verification in enumerate(file_result.get("verifications") or []):
+            if verification.get("status") == SKIPPED:
+                continue
+            elapsed = verification.get("elapsed")
+            if not isinstance(elapsed, (int, float)):
+                continue
+            name = verification.get("verification_name")
+            slowest = verification.get("slowest")
+            key = (path, name or str(index))
+            timings[key] = Timing(
+                path=path,
+                name=name,
+                elapsed=float(elapsed),
+                slowest=float(slowest) if isinstance(slowest, (int, float)) else None,
+                last_execution_time=verification.get("last_execution_time"),
+                key=key,
+            )
+    return timings
+
+
+def skipped_paths(result: dict[str, Any]) -> set[str]:
+    return {
+        path
+        for path, file_result in (result.get("files") or {}).items()
+        if any(
+            verification.get("status") == SKIPPED
+            for verification in file_result.get("verifications") or []
+        )
+    }
+
+
+def aggregate(timings: Iterable[Timing]) -> Aggregate:
+    timings = list(timings)
+    worst = max(
+        (t for t in timings if t.slowest is not None),
+        key=lambda t: t.slowest or 0.0,
+        default=None,
+    )
+    return Aggregate(
+        count=len(timings),
+        total=sum(t.elapsed for t in timings),
+        worst=worst,
+    )
+
+
+def reexecuted(
+    now: dict[tuple[str, str], Timing],
+    base: dict[tuple[str, str], Timing],
+) -> list[tuple[Timing, Timing | None]]:
+    """Pair each freshly measured verification with its baseline counterpart.
+
+    Re-execution is detected via ``last_execution_time`` rather than a timing
+    comparison: an unchanged timestamp means the number was carried over, and a
+    re-run that happens to reproduce its timing exactly is still interesting.
+    """
+    rows: list[tuple[Timing, Timing | None]] = []
+    for key, timing in now.items():
+        previous = base.get(key)
+        if previous and previous.last_execution_time == timing.last_execution_time:
+            continue
+        rows.append((timing, previous))
+    rows.sort(key=lambda row: -abs(row[0].elapsed - (row[1].elapsed if row[1] else 0.0)))
+    return rows
+
+
+def format_seconds(value: float) -> str:
+    if value < 1.0:
+        return f"{value * 1000:.0f}ms"
+    if value < 10.0:
+        return f"{value:.2f}s"
+    if value < 100.0:
+        return f"{value:.1f}s"
+    return f"{value:.0f}s"
+
+
+def format_ratio(new: float, old: float) -> str:
+    if old <= 0.0:
+        return "新規" if new > 0.0 else "±0%"
+    return f"{(new - old) / old * 100:+.0f}%"
+
+
+def format_change(new: float | None, old: float | None) -> str:
+    if new is None:
+        return "—"
+    if old is None:
+        return f"{format_seconds(new)}（基準なし）"
+    return f"{format_seconds(old)} → {format_seconds(new)} ({format_ratio(new, old)})"
+
+
+def is_regression(new: float | None, old: float | None) -> bool:
+    if new is None or old is None or old <= 0.0:
+        return False
+    return new - old >= REGRESSION_ABSOLUTE and (new - old) / old >= REGRESSION_RATIO
+
+
+def render_diff_rows(
+    rows: list[tuple[Timing, Timing | None]],
+    max_rows: int,
+) -> list[str]:
+    lines = ["| test | 合計 | 最悪ケース |", "| --- | --- | --- |"]
+    for timing, previous in rows[:max_rows]:
+        base_elapsed = previous.elapsed if previous else None
+        base_slowest = previous.slowest if previous else None
+        flagged = is_regression(timing.elapsed, base_elapsed) or is_regression(
+            timing.slowest, base_slowest
+        )
+        label = f"⚠️ {timing.label}" if flagged else timing.label
+        lines.append(
+            f"| {label} "
+            f"| {format_change(timing.elapsed, base_elapsed)} "
+            f"| {format_change(timing.slowest, base_slowest)} |"
+        )
+    if len(rows) > max_rows:
+        lines.append("")
+        lines.append(f"（合計 {len(rows)} 件のうち差分の大きい {max_rows} 件のみ表示）")
+    return lines
+
+
+def render_slowest_rows(timings: Iterable[Timing], max_rows: int) -> list[str]:
+    ranked = sorted(timings, key=lambda t: -(t.slowest or 0.0))[:max_rows]
+    lines = ["| test | 合計 | 最悪ケース |", "| --- | --- | --- |"]
+    for timing in ranked:
+        lines.append(
+            f"| {timing.label} "
+            f"| {format_seconds(timing.elapsed)} "
+            f"| {format_seconds(timing.slowest) if timing.slowest is not None else '—'} |"
+        )
+    return lines
+
+
+def render(
+    result: dict[str, Any],
+    baseline: dict[str, Any] | None,
+    max_rows: int = DEFAULT_MAX_ROWS,
+) -> str:
+    now = collect(result)
+    current = aggregate(now.values())
+    skipped_now = skipped_paths(result)
+
+    lines = ["## ⏱ 実行時間", ""]
+
+    if baseline is None:
+        lines.append(
+            "ベースライン（`main` の verify 結果キャッシュ）が無いため差分は表示しません。"
+        )
+        lines.append("")
+        lines.append(
+            f"- 合計（テストケース実行時間の総和, {current.count} 件）: "
+            f"{format_seconds(current.total)}"
+        )
+        if current.worst is not None:
+            lines.append(
+                f"- 最悪ケース: {format_seconds(current.worst.slowest or 0.0)}"
+                f" — `{current.worst.label}`"
+            )
+        if skipped_now:
+            lines.append(f"- skip（計測なし・集計除外）: {len(skipped_now)} 件")
+        lines.append("")
+        lines.append(f"### 最も遅い test（上位 {max_rows} 件）")
+        lines.append("")
+        lines.extend(render_slowest_rows(now.values(), max_rows))
+        lines.append("")
+        return "\n".join(lines) + "\n"
+
+    base = collect(baseline)
+    previous = aggregate(base.values())
+    rows = reexecuted(now, base)
+
+    total_delta = current.total - previous.total
+    lines.append(
+        f"- 合計（テストケース実行時間の総和, {current.count} 件）: "
+        f"{format_seconds(previous.total)} → {format_seconds(current.total)} "
+        f"({total_delta:+.1f}s, {format_ratio(current.total, previous.total)})"
+    )
+    if current.worst is not None:
+        worst_base = base.get(current.worst.key)
+        worst_before = worst_base.slowest if worst_base else None
+        lines.append(
+            f"- 最悪ケース: {format_change(current.worst.slowest, worst_before)}"
+            f" — `{current.worst.label}`"
+        )
+    lines.append(f"- この run で再実行された test: {len(rows)} 件 / {current.count} 件")
+
+    disappeared = sorted({key[0] for key in base.keys() - now.keys()})
+    if disappeared:
+        lines.append(
+            f"- ベースラインにのみ存在（改名・削除・今回 skip）: {len(disappeared)} 件"
+            f" — 合計の差はこの分を含む"
+        )
+    lines.append("")
+
+    if rows:
+        lines.extend(render_diff_rows(rows, max_rows))
+    else:
+        lines.append("すべての test が前回結果を再利用したため、新しい計測はありません。")
+    lines.append("")
+    lines.append(
+        "共有 runner の実行時間は同一コードでも 2 倍程度ばらつくため参考値。"
+        "合計には前回結果を再利用した test の持ち越し値も含む。"
+        f"⚠️ は +{REGRESSION_RATIO:.0%} 以上かつ +{REGRESSION_ABSOLUTE:g}s 以上の悪化。"
+    )
+    lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+def load(path: Path) -> dict[str, Any]:
+    with path.open() as f:
+        return json.load(f)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--result", required=True, type=Path, help="merged-result.json")
+    parser.add_argument(
+        "--baseline",
+        type=Path,
+        help="比較対象の merged-result.json（存在しなければ差分なしで出力）",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="追記先（既定: $GITHUB_STEP_SUMMARY があればそこ）",
+    )
+    parser.add_argument("--max-rows", type=int, default=DEFAULT_MAX_ROWS)
+    args = parser.parse_args(argv)
+
+    if not args.result.exists():
+        print(f"{args.result} が無いため実行時間サマリーを省略します。", file=sys.stderr)
+        return 0
+
+    baseline = None
+    if args.baseline is not None and args.baseline.exists():
+        baseline = load(args.baseline)
+
+    markdown = render(load(args.result), baseline, max_rows=args.max_rows)
+    print(markdown, end="")
+
+    output = args.output
+    if output is None:
+        summary = os.environ.get("GITHUB_STEP_SUMMARY")
+        output = Path(summary) if summary else None
+    if output is not None:
+        with output.open("a") as f:
+            f.write(markdown)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
docs-and-check で main の結果キャッシュをベースラインとして退避し、
merged-result.json と比較して合計（テストケース実行時間の総和）・最悪
ケース・この run で再実行された test の差分を $GITHUB_STEP_SUMMARY に出す。

- prev-result で skip された test は計測値が持ち越されるため、
  last_execution_time の変化で「今回実測した test」だけを差分表に載せる
- status: skipped は elapsed がほぼ 0 で slowest が null なので集計から除外
- 共有 runner では同一コードでも 2 倍程度ばらつくので参考値扱いとし、
  +30% かつ +0.5s 以上の悪化のみ ⚠️ を付ける（ゲートにはしない）

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
