### PR TITLE
StaticTopTree を規約準拠にし構築を O(n) 化

### DIFF
--- a/lib/tree/dynamic_top_tree.hpp
+++ b/lib/tree/dynamic_top_tree.hpp
@@ -9,7 +9,7 @@
 ///          O(log n) 償却で繋ぎ替える。evert によるパス反転に対応するため、
 ///          パス集約を正方向 sum・逆方向 mus の 2 本立てで保持する（compress
 ///          が非可換なため、反転を高速に行うにはこの複製が必要）。
-///          TreeDP のインターフェースは static_top_tree_dp と共通：
+///          TreeDP のインターフェースは `StaticTopTreeDP`（`tree_dp` concept）と共通：
 ///          `Path vertex(int u)` / `Path add_vertex(Path d, Light l)` /
 ///          `Light add_edge(Path d)` / `Light rake(Light l, Light r)` /
 ///          `Path compress(Path p, Path c)`。

--- a/lib/tree/static_top_tree.hpp
+++ b/lib/tree/static_top_tree.hpp
@@ -1,236 +1,262 @@
 #pragma once
 #include <algorithm>
+#include <cassert>
+#include <concepts>
 #include <utility>
 #include <vector>
+#include "graph/graph.hpp"
 
-/// @brief Static Top Treeと点更新可能な全方位木DP
-/// @details `static_top_tree` が木をrake/compressの二分木へ分解し、
-/// `static_top_tree_dp` がTreeDPの演算で集約値を管理する。
-/// @complexity 構築と全計算は $O(n\log n)$、点更新は $O(\log n)$、
-/// 全体値の取得は $O(1)$
+/// @brief Static Top Tree（木を rake / compress の二分木へ分解する）
+/// @details 木を HL 分解し、heavy path 上のクラスタを compress で連結、頂点にぶら下がる
+///          軽辺部分木を重み二分の rake で束ねることで、高さ $O(\log n)$ の二分木を作る。
+///          この形状に `StaticTopTreeDP` を載せると、頂点値の点更新を $O(\log n)$ で
+///          反映しながら木 DP の値を保てる。
+/// @details 分解結果はグラフ表現に依存しないので構築だけを `graph_type` でテンプレート化
+///          している。ノード番号 $[0, n)$ は元の頂点番号（`Type::Vertex` のノード）と一致し、
+///          子の番号は必ず親より小さい（番号の昇順がボトムアップ順になる）。
+/// @note 非連結なグラフを渡した場合、根 `r` を含む連結成分だけが分解される。
+/// @complexity 構築は $O(n)$、ノード参照は $O(1)$
 /// @see https://codeforces.com/blog/entry/103989
 /// @see https://nyaannyaan.github.io/library/tree/static-top-tree-vertex-based.hpp
-template <class Graph>
-struct static_top_tree {
-    /// @brief Top Tree ノードの種類
+struct StaticTopTree {
+    /// @brief Top Tree ノードが表す結合操作の種類
     /// @complexity 列挙型のため実行時コストなし
-    enum Type { Vertex, Compress, Rake, AddEdge, AddVertex };
-
-    /// @brief Top Tree の二分木ノード
-    /// @complexity 各フィールドは $O(1)$ で参照可能
-    struct Node {
-        /// @brief 親・左子・右子のノード番号
-        /// @complexity $O(1)$ で参照可能
-        int p, l, r;
-        /// @brief ノードが表す結合操作
-        /// @complexity $O(1)$ で参照可能
-        Type type;
+    enum class Type {
+        Vertex,     ///< 元の木の頂点そのもの（葉。ノード番号 = 頂点番号）
+        Compress,   ///< 親側パス（左）と子側パス（右）を 1 本のパスへ連結する
+        Rake,       ///< 2 つの軽辺クラスタ（左・右）を並列に合成する
+        AddEdge,    ///< 子部分木のパス値（左）を軽辺クラスタへ変換する単項ノード
+        AddVertex,  ///< 頂点（左）に軽辺クラスタ（右）を付加してパスにする
     };
 
-    /// @brief Top Tree の根ノード番号。空なら `-1`
+    /// @brief Top Tree の二分木ノード
+    /// @complexity 各フィールドの参照は $O(1)$
+    struct Node {
+        /// @brief 親・左子・右子のノード番号（存在しなければ `-1`）
+        /// @complexity $O(1)$ で参照可能
+        int p = -1, l = -1, r = -1;
+        /// @brief このノードが表す結合操作
+        /// @complexity $O(1)$ で参照可能
+        Type type = Type::Vertex;
+    };
+
+    /// @brief Top Tree の根ノード番号。空の木では `-1`
     /// @complexity $O(1)$ で参照可能
-    int root;
-    /// @brief Top Tree の全ノード
+    int root = -1;
+    /// @brief Top Tree の全ノード。先頭 $n$ 個が頂点に対応する `Type::Vertex` ノード
     /// @complexity 1 ノードの参照は $O(1)$
     std::vector<Node> nodes;
 
-    /// @brief 空の Static Top Tree を作る
+    /// @brief 空のStatic Top Treeを構築する
     /// @complexity $O(1)$
-    static_top_tree() : root(-1) {}
+    StaticTopTree() = default;
 
-    /// @brief 木 `g` を `_root` から Static Top Tree へ分解する
-    /// @complexity $O(n\log n)$
-    static_top_tree(const Graph &g, int _root = 0) {
-        int n = g.size();
-        if (n == 0) {
-            root = -1;
-            return;
-        }
+    /// @brief 木gを根rからStatic Top Treeへ分解する
+    /// @complexity $O(n)$
+    template <graph_type G>
+    explicit StaticTopTree(const G &g, int r = 0) : _size(g.size()) {
+        if (_size == 0) return;
+        assert(0 <= r && r < _size);
 
-        auto get_to = [](auto &&e) -> int {
-            if constexpr (requires { e.to(); }) return e.to();
-            else if constexpr (requires { e.to; }) return e.to;
-            else return e;
-        };
-
-        nodes.assign(n, {-1, -1, -1, Vertex});
-        std::vector<int> par(n, -1), sz(n, 1), heavy(n, -1);
-
-        // 反復 DFS（再帰だと深い木でスタックオーバーフローしうる）。
-        // 帰りがけに部分木サイズを集計し、最大の子を heavy に記録する。
-        {
-            std::vector<int> max_sub(n, 0);
-            std::vector<std::pair<int, int>> stk;  // (頂点, 隣接走査位置)
-            stk.reserve(n);
-            par[_root] = -1;
-            stk.emplace_back(_root, 0);
-            while (!stk.empty()) {
-                auto &[u, idx] = stk.back();
-                if (idx < (int)g[u].size()) {
-                    int v = get_to(g[u][idx++]);
-                    if (v == par[u]) continue;
-                    par[v] = u;
-                    stk.emplace_back(v, 0);
-                } else {
-                    int p = par[u];
-                    stk.pop_back();
-                    if (p != -1) {
-                        sz[p] += sz[u];
-                        if (max_sub[p] < sz[u]) {
-                            max_sub[p] = sz[u];
-                            heavy[p] = u;
-                        }
-                    }
-                }
+        // HL 分解: 行きがけ順を作り、その逆順で部分木サイズと heavy child を確定させる。
+        std::vector<int> par(_size, -1), sub(_size, 1), heavy(_size, -1), ord;
+        ord.reserve(_size);
+        ord.emplace_back(r);
+        for (int i = 0; i < (int)ord.size(); ++i) {
+            int v = ord[i];
+            for (auto &&e : g[v]) {
+                int u = e.to();
+                if (u == par[v]) continue;
+                par[u] = v;
+                ord.emplace_back(u);
             }
         }
+        for (int i = (int)ord.size() - 1; i >= 1; --i) {
+            int v = ord[i], p = par[v];
+            sub[p] += sub[v];
+            if (heavy[p] == -1 || sub[heavy[p]] < sub[v]) heavy[p] = v;
+        }
 
-        auto new_node = [&](int l, int r, Type type) -> int {
+        // ノード数は 2n + (heavy path 数) - 2 で、n 頂点なら 3n 以下に収まる。
+        nodes.reserve(3 * _size);
+        nodes.resize(_size);
+        auto new_node = [&](int left, int right, Type type) -> int {
             int id = nodes.size();
-            nodes.push_back({-1, l, r, type});
-            if (l != -1) nodes[l].p = id;
-            if (r != -1) nodes[r].p = id;
+            nodes.push_back({-1, left, right, type});
+            if (left != -1) nodes[left].p = id;
+            if (right != -1) nodes[right].p = id;
             return id;
         };
 
-        auto merge = [&](auto self, const std::vector<std::pair<int, int>> &a, Type type) -> int {
-            if (a.empty()) return -1;
-            if (a.size() == 1) return a[0].first;
-            int sum = 0;
-            for (auto &p : a) sum += p.second;
+        // マージ対象のクラスタ列と、その重みの累積和。再帰しないので使い回せる。
+        std::vector<int> item, pre;
 
-            std::vector<std::pair<int, int>> b, c;
-            int cur = 0;
-            for (auto &p : a) {
-                if (cur * 2 < sum) b.push_back(p);
-                else c.push_back(p);
-                cur += p.second;
-            }
-            if (b.empty()) {
-                b.push_back(c.front());
-                c.erase(c.begin());
-            } else if (c.empty()) {
-                c.push_back(b.back());
-                b.pop_back();
-            }
-            int l = self(self, b, type);
-            int r = self(self, c, type);
-            return new_node(l, r, type);
-        };
-
-        auto build = [&](auto self, int u) -> int {
-            std::vector<std::pair<int, int>> path;
-            int curr = u;
-            while (curr != -1) {
-                std::vector<std::pair<int, int>> lights;
-                for (auto &&e : g[curr]) {
-                    int v = get_to(e);
-                    if (v == par[curr] || v == heavy[curr]) continue;
-                    int light_root = self(self, v);
-                    int en = new_node(light_root, -1, AddEdge);
-                    lights.push_back({en, sz[v]});
+        // 重み二分マージ: item[lo, hi) を左右の重み和がほぼ等しくなる位置で再帰的に分割し、
+        // type ノードの二分木にする。分割位置の探索を累積和への両端からの指数探索にすると
+        // 1 回のコストが短い側の長さの $\log$ で収まり、列全体で $O(hi - lo)$ になる。
+        auto merge = [&](auto self, int lo, int hi, Type type) -> int {
+            if (hi - lo == 1) return item[lo];
+            int target = pre[lo] + pre[hi];  // 2 * pre[m] >= target となる最小の m で分割する
+            int lft = lo, rgt = hi;          // 不変条件: 2 * pre[lft] < target <= 2 * pre[rgt]
+            for (int step = 1; rgt - lft > 1; step *= 2) {
+                int a = lft + step, b = rgt - step;
+                if (a >= rgt) break;  // 残り幅が step 以下になったので二分探索に切り替える
+                if (2 * pre[a] >= target) {
+                    rgt = a;
+                    break;
                 }
-                int rk = merge(merge, lights, Rake);
-                int v_node = curr;
-                if (rk != -1) { v_node = new_node(curr, rk, AddVertex); }
-                path.push_back({v_node, sz[curr] - (heavy[curr] != -1 ? sz[heavy[curr]] : 0)});
-                curr = heavy[curr];
+                if (2 * pre[b] < target) {
+                    lft = b;
+                    break;
+                }
+                lft = a, rgt = b;
             }
-            return merge(merge, path, Compress);
+            while (rgt - lft > 1) {
+                int mid = lft + (rgt - lft) / 2;
+                if (2 * pre[mid] >= target) rgt = mid;
+                else lft = mid;
+            }
+            int mid = std::min(rgt, hi - 1);  // 右が空にならないよう末尾の要素は必ず右へ回す
+            int left = self(self, lo, mid, type);
+            int right = self(self, mid, hi, type);
+            return new_node(left, right, type);
         };
-        root = build(build, _root);
+
+        // 行きがけ順の逆順に走査する。頂点 v を処理する時点で子の結果は揃っているので、
+        // 再帰なしで下から組み上げられる（vertex_node は頂点単体、path_root は heavy path
+        // 全体を表すノード）。
+        std::vector<int> vertex_node(_size, -1), path_root(_size, -1);
+        for (int i = (int)ord.size() - 1; i >= 0; --i) {
+            int v = ord[i];
+            item.clear();
+            pre.assign(1, 0);
+            for (auto &&e : g[v]) {
+                int u = e.to();
+                if (u == par[v] || u == heavy[v]) continue;
+                item.emplace_back(new_node(path_root[u], -1, Type::AddEdge));
+                pre.emplace_back(pre.back() + sub[u]);
+            }
+            vertex_node[v] = v;
+            if (!item.empty()) {
+                int rake = merge(merge, 0, item.size(), Type::Rake);
+                vertex_node[v] = new_node(v, rake, Type::AddVertex);
+            }
+            if (par[v] != -1 && heavy[par[v]] == v) continue;
+            // v は heavy path の先頭なので、パス全体を compress でまとめる。
+            item.clear();
+            pre.assign(1, 0);
+            for (int u = v; u != -1; u = heavy[u]) {
+                item.emplace_back(vertex_node[u]);
+                pre.emplace_back(pre.back() + sub[u] - (heavy[u] == -1 ? 0 : sub[heavy[u]]));
+            }
+            path_root[v] = merge(merge, 0, item.size(), Type::Compress);
+        }
+        root = path_root[r];
     }
+
+    /// @brief 元の木の頂点数を返す（Top Tree のノード数は `nodes.size()`）
+    /// @complexity $O(1)$
+    int size() const { return _size; }
+
+  private:
+    int _size = 0;
 };
 
-/// @brief Static Top Tree 上でDPを行うテンプレート
-/// @details `TreeDP` クラスは以下を持つ必要があります：
-/// ```cpp
-/// struct DP {
-///     using Path = ...; // 重パス上のデータ型
-///     using Light = ...; // 軽辺部分木のデータ型
-///     Path vertex(int u); // 頂点uのPathデータ初期化
-///     Path add_vertex(Path d, Light l); // 頂点を含むパスに軽辺部分木を付加
-///     Light add_edge(Path d); // 部分木のPathデータを親に繋ぐ軽辺のデータに変換
-///     Light rake(Light l, Light r); // 複数の軽辺のデータをマージ
-///     Path compress(Path p, Path c); // 親側のパスpと子側のパスcをマージして1つのパスにする
-/// };
-/// ```
-/// @complexity 構築と全再計算は $O(n)$、点更新は $O(\log n)$、結果取得は $O(1)$
-template <class Graph, class TreeDP>
-struct static_top_tree_dp {
+/// @brief Static Top Tree に載せる木DPの要件
+/// @details 重パス上の集約型 `Path` と軽辺クラスタの集約型 `Light` に対し、頂点の初期値
+///          `vertex`、パスへの軽辺クラスタの付加 `add_vertex`、部分木から軽辺クラスタへの
+///          変換 `add_edge`、軽辺クラスタ同士の合成 `rake`、パス同士の連結 `compress` を
+///          持つこと。`compress(p, c)` の `p` は親側、`c` は子側で、非可換でよい。
+///          `DynamicTopTree` も同じ要件のクラスを受け取る。
+/// @tparam D 判定対象の木DP
+/// @complexity コンパイル時の型制約のため実行時コストなし
+template <class D>
+concept tree_dp = requires(D &d, const typename D::Path &p, const typename D::Light &l, int u) {
+    { d.vertex(u) } -> std::convertible_to<typename D::Path>;
+    { d.add_vertex(p, l) } -> std::convertible_to<typename D::Path>;
+    { d.add_edge(p) } -> std::convertible_to<typename D::Light>;
+    { d.rake(l, l) } -> std::convertible_to<typename D::Light>;
+    { d.compress(p, p) } -> std::convertible_to<typename D::Path>;
+};
+
+/// @brief Static Top Tree 上の木DP（頂点値の点更新に対応）
+/// @details 木 DP の演算を `StaticTopTree` の各ノードで評価し、根の値として木全体の集約値を
+///          保つ。頂点 $u$ の値を変えたら `dp` を書き換えて `update(u)` を呼ぶと、$u$ から
+///          根までの $O(\log n)$ 個のノードだけが再計算される。
+/// @details 使い方は `StaticTopTreeDP<DP> d(g, root, DP{...});` で構築し、頂点 $u$ の値を
+///          変えるときは `d.dp` の頂点データを書き換えて `d.update(u)` を呼び、`d.get()` で
+///          木全体の集約値を読む。同じ形状で別の DP を走らせたいときは `StaticTopTree` を
+///          先に作って共有できる。
+/// @tparam TreeDP 木DPの演算（`tree_dp` を満たすこと）
+/// @complexity 構築と全再計算は $O(n)$、点更新は $O(\log n)$、集約値の取得は $O(1)$
+template <tree_dp TreeDP>
+struct StaticTopTreeDP {
     /// @brief 重パス上の集約値型
     /// @complexity 型エイリアスのため実行時コストなし
     using Path = typename TreeDP::Path;
-    /// @brief 軽辺部分木の集約値型
+    /// @brief 軽辺クラスタの集約値型
     /// @complexity 型エイリアスのため実行時コストなし
     using Light = typename TreeDP::Light;
 
-    /// @brief DP の土台となる Static Top Tree
+    /// @brief DPの土台となるStatic Top Tree
     /// @complexity 1 ノードの参照は $O(1)$
-    static_top_tree<Graph> stt;
-    /// @brief Tree DP の演算オブジェクト
+    StaticTopTree stt;
+    /// @brief 木DPの演算オブジェクト。頂点値の変更はこれを書き換えて `update` を呼ぶ
     /// @complexity 参照は $O(1)$
     TreeDP dp;
-    /// @brief 各 Top Tree ノードの `Path` 集約値
-    /// @complexity 1 要素の参照は $O(1)$
-    std::vector<Path> path_val;
-    /// @brief 各 Top Tree ノードの `Light` 集約値
-    /// @complexity 1 要素の参照は $O(1)$
-    std::vector<Light> light_val;
 
-    /// @brief 空の DP オブジェクトを作る
+    /// @brief 空のDPオブジェクトを構築する
     /// @complexity $O(1)$
-    static_top_tree_dp() = default;
+    StaticTopTreeDP() = default;
 
-    /// @brief Static Top Tree `_stt` 上で `_dp` を使い全 DP 値を計算する
+    /// @brief 木gを根rで分解し、全ノードのDP値を計算する
     /// @complexity $O(n)$
-    static_top_tree_dp(const static_top_tree<Graph> &_stt, const TreeDP &_dp = TreeDP()) : stt(_stt), dp(_dp) {
-        int m = stt.nodes.size();
-        path_val.resize(m);
-        light_val.resize(m);
+    template <graph_type G>
+    explicit StaticTopTreeDP(const G &g, int r = 0, const TreeDP &_dp = TreeDP())
+        : StaticTopTreeDP(StaticTopTree(g, r), _dp) {}
+
+    /// @brief 構築済みのStatic Top Tree上で全DP値を計算する
+    /// @complexity $O(n)$
+    explicit StaticTopTreeDP(StaticTopTree _stt, const TreeDP &_dp = TreeDP())
+        : stt(std::move(_stt)), dp(_dp), path_val(stt.nodes.size()), light_val(stt.nodes.size()) {
         update_all();
     }
 
-    /// @brief 全ての Top Tree ノードの DP 値を再計算する
+    /// @brief 全ノードのDP値を再計算する
     /// @complexity $O(n)$
     void update_all() {
-        if (stt.root == -1) return;
-        auto dfs = [&](auto self, int u) -> void {
-            auto &node = stt.nodes[u];
-            if (node.l != -1) self(self, node.l);
-            if (node.r != -1) self(self, node.r);
-            update_node(u);
-        };
-        dfs(dfs, stt.root);
+        // 子のノード番号は必ず親より小さいので、番号の昇順がボトムアップ順になる。
+        for (int i = 0; i < (int)stt.nodes.size(); ++i) update_node(i);
     }
 
-    /// @brief 頂点 `u` の値を `dp.vertex(u)` から再取得し、根まで更新する
+    /// @brief 頂点uの値を `dp.vertex(u)` から取り直し、根までのノードを更新する
     /// @complexity $O(\log n)$
     void update(int u) {
-        if (u < 0 || u >= (int)stt.nodes.size() || stt.nodes[u].type != static_top_tree<Graph>::Vertex) { return; }
-        while (u != -1) {
-            update_node(u);
-            u = stt.nodes[u].p;
-        }
+        assert(0 <= u && u < stt.size());
+        for (int i = u; i != -1; i = stt.nodes[i].p) update_node(i);
     }
 
     /// @brief 木全体の集約値を返す
     /// @complexity $O(1)$
-    Path get() const { return path_val[stt.root]; }
+    const Path &get() const {
+        assert(stt.root != -1);
+        return path_val[stt.root];
+    }
 
   private:
-    void update_node(int u) {
-        auto &node = stt.nodes[u];
-        if (node.type == static_top_tree<Graph>::Vertex) {
-            path_val[u] = dp.vertex(u);
-        } else if (node.type == static_top_tree<Graph>::Compress) {
-            path_val[u] = dp.compress(path_val[node.l], path_val[node.r]);
-        } else if (node.type == static_top_tree<Graph>::Rake) {
-            light_val[u] = dp.rake(light_val[node.l], light_val[node.r]);
-        } else if (node.type == static_top_tree<Graph>::AddEdge) {
-            light_val[u] = dp.add_edge(path_val[node.l]);
-        } else if (node.type == static_top_tree<Graph>::AddVertex) {
-            path_val[u] = dp.add_vertex(path_val[node.l], light_val[node.r]);
+    std::vector<Path> path_val;    // Vertex / Compress / AddVertex ノードの集約値
+    std::vector<Light> light_val;  // Rake / AddEdge ノードの集約値
+
+    void update_node(int i) {
+        const auto &node = stt.nodes[i];
+        switch (node.type) {
+            case StaticTopTree::Type::Vertex: path_val[i] = dp.vertex(i); break;
+            case StaticTopTree::Type::Compress: path_val[i] = dp.compress(path_val[node.l], path_val[node.r]); break;
+            case StaticTopTree::Type::Rake: light_val[i] = dp.rake(light_val[node.l], light_val[node.r]); break;
+            case StaticTopTree::Type::AddEdge: light_val[i] = dp.add_edge(path_val[node.l]); break;
+            case StaticTopTree::Type::AddVertex:
+                path_val[i] = dp.add_vertex(path_val[node.l], light_val[node.r]);
+                break;
         }
     }
 };

--- a/test/yosupo/tree/point_set_tree_path_composite_sum_fixed_root.test.cpp
+++ b/test/yosupo/tree/point_set_tree_path_composite_sum_fixed_root.test.cpp
@@ -58,9 +58,7 @@ int main() {
         g.add_edges(n + i, v);
     }
 
-    static_top_tree<list_graph<void>> stt(g, 0);
-    DP dp_obj(std::move(val));
-    static_top_tree_dp<list_graph<void>, DP> stt_dp(stt, dp_obj);
+    StaticTopTreeDP<DP> stt_dp(g, 0, DP(std::move(val)));
 
     for (int i = 0; i < q; ++i) {
         int type;


### PR DESCRIPTION
- 命名を PascalCase に統一（`static_top_tree`→`StaticTopTree`、
  `static_top_tree_dp`→`StaticTopTreeDP`、`enum class Type`）。`DynamicTopTree` と揃える。
- 形状はグラフ表現に依存しないので `Graph` をクラステンプレート引数から外し、
  構築だけを `graph_type` でテンプレート化。`e.to()` を使うので `requires` による
  終点取得の場合分けも不要になった。`StaticTopTreeDP` はグラフから直接構築できる。
- 木DPの要件を `tree_dp` concept として明文化し `StaticTopTreeDP` を制約。
- 構築を $O(n\log n)$ から $O(n)$ に改善: 重み二分マージの分割位置を、累積和に対する
  両端からの指数探索で求める（分解結果は従来と完全に同一で、1e6 頂点の構築が 2〜2.7 倍速）。
- 構築から再帰を排除（行きがけ順の逆順で下から組み上げる）。マージ用バッファを
  使い回し、ノード列は上限 3n を先に reserve する。
- ノード番号は常に子 < 親なので `update_all` を番号昇順のループに置換（再帰を排除）。
- `update` / `get` に assert を追加（不正な頂点番号の黙殺と空の木での UB を防ぐ）。
  `get` は参照を返す。`update_node` は switch に。DP 値の配列は private に。
🤖 Generated with [Claude Code](https://claude.com/claude-code)