### PR TITLE
Traced の追加と segment_tree 更新proxyの整理

### DIFF
--- a/docs/dp/traced.md
+++ b/docs/dp/traced.md
@@ -1,0 +1,79 @@
+---
+title: 経路つきDP値 (Traced)
+documentation_of: //lib/dp/traced.hpp
+compile_example: true
+---
+
+DPの値に、そこへ至る経路を相乗りさせる値型。比較は `cost` のみで行い、経路は push が
+$O(1)$ の永続スタックで保持する。経路を持ち回っても比較コストは増えないので、DPの
+時間計算量は変わらない。
+
+遷移のたびに `then(w, label)` でラベルを積み、最後に `to_vector()` で始点から終点の順に
+取り出す。遷移元を記録する配列と、そこを逆向きに辿る復元ループの両方が不要になるので、
+「DP本体は書けたが復元でバグる」「DPと復元で遷移の場合分けが食い違う」を避けたいときに使う。
+
+## 使い方
+
+```cpp
+#include <vector>
+#include "dp/traced.hpp"
+
+// 段 i から i+1 へ a[i]、i+2 へ b[i] のコストで進むときの最小コストと経路
+std::vector<long long> a = {2, 5, 1, 3};
+std::vector<long long> b = {8, 4, 6};
+int n = 5;
+constexpr long long inf = 1'000'000'000'000'000'000;
+
+std::vector<Traced<long long>> dp(n, Traced<long long>(inf));
+dp[0] = Traced<long long>(0);
+for (int i = 0; i < n; ++i) {
+    if (dp[i].cost == inf) continue;
+    if (i + 1 < n) {
+        if (auto cand = dp[i].then(a[i], i + 1); cand < dp[i + 1]) dp[i + 1] = cand;
+    }
+    if (i + 2 < n) {
+        if (auto cand = dp[i].then(b[i], i + 2); cand < dp[i + 2]) dp[i + 2] = cand;
+    }
+}
+
+long long cost = dp[n - 1].cost;                // 最小コスト
+std::vector<int> path = dp[n - 1].to_vector();  // 通った段（始点 0 は含まない）
+```
+
+## API
+
+| API | 内容 | 計算量 |
+| --- | --- | --- |
+| `using value_type = T;` | コストの型 | 型エイリアスで実行時計算量はない |
+| `using label_type = Label;` | ラベルの型 | 型エイリアスで実行時計算量はない |
+| `using path_type = persistent_stack<Label>;` | 経路を保持する永続スタックの型 | 型エイリアスで実行時計算量はない |
+| `T cost;` | 比較に使うコスト | $O(1)$ で参照可能 |
+| `path_type path;` | 積んだラベルの列（先頭が最後に積んだラベル） | $O(1)$ で参照可能 |
+| `constexpr Traced()` | コストを `T()`、経路を空にして構築する | $O(1)$ |
+| `constexpr explicit Traced(T _cost)` | コストを指定し、経路を空にして構築する<br>**備考:** 経路の情報を落とさないよう暗黙変換にはしていない。 | $O(1)$ |
+| `constexpr Traced(T _cost, path_type _path)` | コストと経路を直接指定して構築する<br>`then` では表せない結合（`max(cost, w)` を使うボトルネック最短路など）は `Traced(std::max(dp[i].cost, w), dp[i].path.push(label))` のように直接組む。 | $O(1)$ |
+| `constexpr auto operator<=>(const Traced &rhs) const`<br>`constexpr bool operator==(const Traced &rhs) const` | `cost` のみで比較する | $O(1)$ |
+| `Traced then(const T &w, const Label &label) const` | コストに w を足し、経路に label を積んだ値を返す | $O(1)$ |
+| `constexpr int size() const` | 積んだラベルの個数を返す | $O(1)$ |
+| `std::vector<Label> to_vector() const` | 積んだラベルを積んだ順（始点から終点）に返す | 経路長を $L$ として $O(L)$ |
+
+## 補足
+
+- `T` には `operator<=>` と `operator+` を要求する。`Label` に要求するのはコピー構築のみ。
+- 始点の `Traced` は経路が空なので、`to_vector()` に始点のラベルは含まれない。始点を含めたい
+  ときは呼び出し側で先頭に足す。
+- 空間計算量は `then` の結果を採用した回数 $U$ について $O(U)$。永続スタックのノードは
+  解放しないので、状態数が非常に多いDPでは遷移元を記録する方式のほうがメモリで有利になる。
+  最短路のように「1 頂点あたりの緩和回数が辺数で抑えられる」場合は $O(E)$ で収まる。
+- 単一の値への `explicit` コンストラクタしか持たないため、`dp[i] = 0` のような代入は
+  コンパイルエラーになる。経路を落とす代入を事故で書けないようにするための制約。
+- `then` は `cost + w` でコストを合成する。ボトルネック最短路のように別の合成が必要なときは
+  `Traced(std::max(dp[i].cost, w), dp[i].path.push(label))` のようにメンバから直接組む。
+- 最大化するDPでは比較を反転させるだけでよい（`dp[j] < cand` で更新する）。`cost` に負号を
+  付けて最小化に直す必要はない。
+
+## 検証
+
+- [Library Checker Shortest Path](https://judge.yosupo.jp/problem/shortest_path) — ダイクストラ法の
+  DP値を `Traced` にして経路を出力し、距離が `graph/shortest_path.hpp` と一致すること、
+  出力した経路が実際に辺で繋がっていて重みの和が `cost` と一致することを確認している。

--- a/docs/reference.toml
+++ b/docs/reference.toml
@@ -6,8 +6,8 @@ excluded_directories = ["internal", "template"]
 # 現在値を下限として、説明の削除や文書化されていない公開ヘッダの増加を防ぐ。
 # 詳細ページを追加したら minimum_reference_pages も同じPRで引き上げる。
 minimum_doxygen_headers = 144
-minimum_reference_pages = 165
-minimum_compiled_examples = 165
+minimum_reference_pages = 166
+minimum_compiled_examples = 166
 maximum_undocumented_headers = 0
 
 [style]

--- a/docs/segtree/segment_tree.md
+++ b/docs/segtree/segment_tree.md
@@ -22,6 +22,9 @@ seg.set(2, 10);
 seg[0] = 5;                     // set(0, 5) と同じ
 
 int r = seg.max_right(0, [](long long x) { return x <= 12; });
+
+segment_tree<Max<long long>> mx(4, 0);
+chmax(mx[1], 5);                // v[1] = max(v[1], 5)
 ```
 
 ## API
@@ -53,6 +56,10 @@ int r = seg.max_right(0, [](long long x) { return x <= 12; });
   `f` が真から偽へ一度だけ変わる単調性を仮定する。
 - 非 `const` の `operator[]` は更新用プロキシを返す。読み取り時は値へ変換され、
   代入時は `set` と同じく祖先を更新する。
+- プロキシは `chmax` / `chmin` を hidden friend として持つので、`chmax(seg[k], val)` と
+  書ける（`template/template.hpp` の `chmax(T &, const U &)` はプロキシが右辺値のため
+  束縛できず、ADL でこちらが選ばれる）。比較には `operator<` のみを使い、値が変わらない
+  ときは `set` を呼ばないので $O(1)$ で済む。
 
 ## 検証
 

--- a/docs/segtree/segment_tree.md
+++ b/docs/segtree/segment_tree.md
@@ -31,12 +31,13 @@ chmax(mx[1], 5);                // v[1] = max(v[1], 5)
 
 | API | 内容 | 計算量 |
 | --- | --- | --- |
+| `struct Reference` | k番目の要素として振る舞うproxy。値への変換・代入・`chmax` / `chmin` ができる | 値の取得は $O(1)$、代入は $O(\log n)$ |
 | `segment_tree()` | 空の木を構築する | $O(1)$ |
 | `explicit segment_tree(int n, T e = M::id())` | n要素をeで初期化する | $O(n)$ |
 | `template <class U> explicit segment_tree(const std::vector<U> &v)` | 列vから構築する | $O(n)$ |
 | `void assign(int n, T e = M::id())` | 確保済み領域を保ったままn要素をeで埋め直す | $O(n)$ |
 | `const T &operator[](int k) const` | k番目の値をconst参照で返す | $O(1)$ |
-| `_segment_tree_reference operator[](int k)` | k番目を参照・代入できるproxyを返す | 取得は $O(1)$、代入は $O(\log n)$ |
+| `Reference operator[](int k)` | k番目を参照・代入できるproxyを返す | 取得は $O(1)$、代入は $O(\log n)$ |
 | `T at(int k) const` | k番目の値を返す | $O(1)$ |
 | `T get(int k) const` | k番目の値を返す | $O(1)$ |
 | `void set(int k, T val)` | k番目をvalへ変更する | $O(\log n)$ |
@@ -54,9 +55,10 @@ chmax(mx[1], 5);                // v[1] = max(v[1], 5)
 - 空区間の `prod(l, l)` は `M::id()` を返す。
 - `max_right` / `min_left` では `f(M::id()) == true` が必要。また、区間を伸ばしたとき
   `f` が真から偽へ一度だけ変わる単調性を仮定する。
-- 非 `const` の `operator[]` は更新用プロキシを返す。読み取り時は値へ変換され、
-  代入時は `set` と同じく祖先を更新する。
-- プロキシは `chmax` / `chmin` を hidden friend として持つので、`chmax(seg[k], val)` と
+- 非 `const` の `operator[]` は `Reference` プロキシを返す。読み取り時は値へ変換され、
+  代入時は `set` と同じく祖先を更新する。`seg[i] = seg[j]` は参照の張り替えではなく
+  値の代入（`std::vector<bool>::reference` と同じ）。
+- `Reference` は `chmax` / `chmin` を hidden friend として持つので、`chmax(seg[k], val)` と
   書ける（`template/template.hpp` の `chmax(T &, const U &)` はプロキシが右辺値のため
   束縛できず、ADL でこちらが選ばれる）。比較には `operator<` のみを使い、値が変わらない
   ときは `set` を呼ばないので $O(1)$ で済む。

--- a/lib/dp/traced.hpp
+++ b/lib/dp/traced.hpp
@@ -1,0 +1,77 @@
+#pragma once
+#include <compare>
+#include <utility>
+#include <vector>
+#include "persistent_ds/persistent_stack.hpp"
+
+/// @brief 経路を相乗りさせたDPの値
+/// @details 比較は `cost` のみで行い、経路は push が $O(1)$ の永続スタックで保持する。
+///          そのため経路を持ち回っても比較コストは増えず、DPの時間計算量は変わらない。
+///          遷移のたびに `then(w, label)` でラベルを積み、最後に `to_vector()` で
+///          始点から終点の順に取り出す。遷移元を記録する配列と復元ループが不要になる。
+/// @tparam T コストの型。`operator<=>` と `operator+` を持つこと。
+/// @tparam Label 経路に積むラベルの型（頂点番号・選んだ添字など）
+/// @note メモリは `then` の結果を採用した回数に比例し、永続スタックのノードは解放されない。
+///       状態数が非常に多いDPでは、遷移元を記録する方式のほうがメモリで有利になる。
+template <class T, class Label = int>
+struct Traced {
+    /// @brief コストの型
+    /// @complexity 型エイリアスで実行時計算量はない
+    using value_type = T;
+    /// @brief ラベルの型
+    /// @complexity 型エイリアスで実行時計算量はない
+    using label_type = Label;
+    /// @brief 経路を保持する永続スタックの型
+    /// @complexity 型エイリアスで実行時計算量はない
+    using path_type = persistent_stack<Label>;
+
+    /// @brief 比較に使うコスト
+    /// @complexity $O(1)$ で参照可能
+    T cost;
+    /// @brief 積んだラベルの列（先頭が最後に積んだラベル）
+    /// @complexity $O(1)$ で参照可能
+    path_type path;
+
+    /// @brief コストを `T()`、経路を空にして構築する
+    /// @complexity $O(1)$
+    constexpr Traced() : cost(), path() {}
+
+    /// @brief コストを指定し、経路を空にして構築する
+    /// @note 経路の情報を落とさないよう暗黙変換にはしていない。
+    /// @complexity $O(1)$
+    constexpr explicit Traced(T _cost) : cost(std::move(_cost)), path() {}
+
+    /// @brief コストと経路を直接指定して構築する
+    /// @details `then` では表せない結合（`max(cost, w)` を使うボトルネック最短路など）は
+    ///          `Traced(std::max(dp[i].cost, w), dp[i].path.push(label))` のように直接組む。
+    /// @complexity $O(1)$
+    constexpr Traced(T _cost, path_type _path) : cost(std::move(_cost)), path(std::move(_path)) {}
+
+    /// @brief `cost` のみで比較する
+    /// @complexity $O(1)$
+    constexpr auto operator<=>(const Traced &rhs) const { return cost <=> rhs.cost; }
+
+    /// @brief `cost` のみで比較する
+    /// @complexity $O(1)$
+    constexpr bool operator==(const Traced &rhs) const { return cost == rhs.cost; }
+
+    /// @brief コストに w を足し、経路に label を積んだ値を返す
+    /// @complexity $O(1)$
+    Traced then(const T &w, const Label &label) const { return Traced(cost + w, path.push(label)); }
+
+    /// @brief 積んだラベルの個数を返す
+    /// @complexity $O(1)$
+    constexpr int size() const { return path.size(); }
+
+    /// @brief 積んだラベルを積んだ順（始点から終点）に返す
+    /// @complexity 経路長を $L$ として $O(L)$
+    std::vector<Label> to_vector() const {
+        std::vector<Label> res(path.size());
+        auto cur = path;
+        for (int i = (int)res.size() - 1; i >= 0; --i) {
+            res[i] = cur.top();
+            cur = cur.pop();
+        }
+        return res;
+    }
+};

--- a/lib/segtree/segment_tree.hpp
+++ b/lib/segtree/segment_tree.hpp
@@ -2,6 +2,7 @@
 #include <algorithm>
 #include <bit>
 #include <cassert>
+#include <utility>
 #include <vector>
 #include "segtree/monoid.hpp"
 
@@ -13,30 +14,32 @@ struct segment_tree {
   private:
     using T = typename M::value_type;
 
-    struct _segment_tree_reference {
+  public:
+    /// @brief k番目の要素として振る舞うproxy。値への変換・代入・`chmax` / `chmin` ができる
+    /// @complexity 値の取得は $O(1)$、代入は $O(\log n)$
+    struct Reference {
       private:
         segment_tree<M> &self;
         int k;
 
       public:
-        _segment_tree_reference(segment_tree<M> &self, int k) : self(self), k(k) {}
-        _segment_tree_reference &operator=(const T &x) {
-            self.set(k, x);
-            return *this;
-        }
-        _segment_tree_reference &operator=(T &&x) {
+        Reference(segment_tree<M> &self, int k) : self(self), k(k) {}
+        Reference(const Reference &) = default;
+        // 参照の張り替えではなく値の代入(std::vector<bool>::referenceと同じ)
+        Reference &operator=(const Reference &x) { return *this = T(x); }
+        Reference &operator=(T x) {
             self.set(k, std::move(x));
             return *this;
         }
         operator T() const { return self.get(k); }
         // chmax(seg[k], x) / chmin(seg[k], x) をADLで解決する
         // (proxyは右辺値なのでchmax(T &, const U &)には束縛できない)
-        friend bool chmax(_segment_tree_reference ref, const T &x) {
+        friend bool chmax(Reference ref, const T &x) {
             if (!(ref.self.get(ref.k) < x)) return false;
             ref.self.set(ref.k, x);
             return true;
         }
-        friend bool chmin(_segment_tree_reference ref, const T &x) {
+        friend bool chmin(Reference ref, const T &x) {
             if (!(x < ref.self.get(ref.k))) return false;
             ref.self.set(ref.k, x);
             return true;
@@ -81,7 +84,7 @@ struct segment_tree {
 
     /// @brief k番目を参照・代入できるproxyを返す
     /// @complexity 取得は $O(1)$、代入は $O(\log n)$
-    _segment_tree_reference operator[](int k) { return _segment_tree_reference(*this, k); }
+    Reference operator[](int k) { return Reference(*this, k); }
 
     /// @brief k番目の値を返す
     /// @complexity $O(1)$
@@ -96,7 +99,7 @@ struct segment_tree {
     void set(int k, T val) {
         assert(0 <= k && k < _n);
         k += _size;
-        data[k] = val;
+        data[k] = std::move(val);
         for (int i = 1; i <= _log; ++i) update(k >> i);
     }
 

--- a/lib/segtree/segment_tree.hpp
+++ b/lib/segtree/segment_tree.hpp
@@ -29,6 +29,18 @@ struct segment_tree {
             return *this;
         }
         operator T() const { return self.get(k); }
+        // chmax(seg[k], x) / chmin(seg[k], x) をADLで解決する
+        // (proxyは右辺値なのでchmax(T &, const U &)には束縛できない)
+        friend bool chmax(_segment_tree_reference ref, const T &x) {
+            if (!(ref.self.get(ref.k) < x)) return false;
+            ref.self.set(ref.k, x);
+            return true;
+        }
+        friend bool chmin(_segment_tree_reference ref, const T &x) {
+            if (!(x < ref.self.get(ref.k))) return false;
+            ref.self.set(ref.k, x);
+            return true;
+        }
     };
 
   public:

--- a/test/yosupo/graph/shortest_path_traced.test.cpp
+++ b/test/yosupo/graph/shortest_path_traced.test.cpp
@@ -1,0 +1,80 @@
+// competitive-verifier: PROBLEM https://judge.yosupo.jp/problem/shortest_path
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <functional>
+#include <iostream>
+#include <limits>
+#include <queue>
+#include <utility>
+#include <vector>
+#include "dp/traced.hpp"
+#include "graph/edge_input.hpp"
+#include "graph/graph.hpp"
+#include "graph/shortest_path.hpp"
+
+using Dist = Traced<std::int64_t>;
+
+// DP 値を Traced にしたダイクストラ法。prev 配列も復元ループも持たず、経路は Traced が運ぶ。
+// 比較は cost のみなので、距離だけを求める版と時間計算量は変わらない。
+std::vector<Dist> dijkstra_traced(const csr_graph<std::int64_t> &g, int s, std::int64_t inf) {
+    using node = std::pair<std::int64_t, int>;
+    std::vector<Dist> dp(g.size(), Dist(inf));
+    std::priority_queue<node, std::vector<node>, std::greater<>> que;
+    dp[s] = Dist(0);
+    que.emplace(0, s);
+    while (!que.empty()) {
+        auto [d, v] = que.top();
+        que.pop();
+        if (dp[v].cost < d) continue;
+        for (auto &e : g[v]) {
+            if (auto cand = dp[v].then(e.weight(), e.to()); cand < dp[e.to()]) {
+                dp[e.to()] = cand;
+                que.emplace(cand.cost, e.to());
+            }
+        }
+    }
+    return dp;
+}
+
+int main(void) {
+    int n, m, s, t;
+    std::cin >> n >> m >> s >> t;
+    edge_input<std::int64_t> ei(m, 0);
+    auto g = ei.to_directed(n);
+    constexpr std::int64_t inf = std::numeric_limits<std::int64_t>::max();
+
+    auto dp = dijkstra_traced(g, s, inf);
+    // 距離は verify 済みの shortest_path と完全一致するはず。
+    auto dist = shortest_path(g, s, inf);
+    for (int i = 0; i < n; ++i) assert(dp[i].cost == dist[i]);
+
+    if (dp[t].cost == inf) {
+        std::cout << -1 << '\n';
+        return 0;
+    }
+
+    auto path = dp[t].to_vector();
+    // 経路が実際に辺で繋がっており、重みの和が cost と一致することを確かめる。
+    // 最短路の頂点は互いに異なるので、隣接リストの走査は合計 O(E) で収まる。
+    std::int64_t sum = 0;
+    int from = s;
+    for (int to : path) {
+        std::int64_t weight = inf;
+        for (auto &e : g[from]) {
+            if (e.to() == to) weight = std::min(weight, e.weight());
+        }
+        assert(weight != inf);
+        sum += weight;
+        from = to;
+    }
+    assert(from == t && sum == dp[t].cost);
+
+    std::cout << dp[t].cost << ' ' << path.size() << '\n';
+    from = s;
+    for (int to : path) {
+        std::cout << from << ' ' << to << '\n';
+        from = to;
+    }
+    return 0;
+}


### PR DESCRIPTION
## 経路つきDP値 Traced を追加

- `lib/dp/traced.hpp`: DP 値に経路を持たせる `Traced`（既存コミット `3785756`）。

## segment_tree の更新proxy

- `chmax(seg[k], v)` / `chmin(seg[k], v)` が書けるように、更新proxyの hidden friend として
  `chmax`/`chmin` を定義（proxy は右辺値なので `template.hpp` の `chmax(T &, const U &)` には
  束縛できず、ADL でこちらが選ばれる）。比較は `operator<` のみ、値が変わらなければ `set` を
  呼ばないので $O(1)$。`template/template.hpp` は無変更。
- proxy を規約どおり `Reference` へ改名し、docs の戻り値型として出ているので public に配置。
- `operator=(const T &)` / `operator=(T &&)` を `operator=(T)` 1 本に統合。
- `seg[i] = seg[j]` が暗黙の copy assign (delete) と曖昧になりコンパイルできなかったのを、
  値の代入（`std::vector<bool>::reference` と同じ）として明示定義して解消。
- `set` で `data` へ move し、代入時のコピーを 2 回から 0〜1 回へ削減。`<utility>` を明示 include。

## 検証

- `Max`/`Min` 各 200 ケース × 200 クエリのランダムテストで naive と値・返り値が一致。
- proxy 同士の代入・名前付き proxy 経由の代入・値代入セマンティクス・`ostream` 出力・
  `template.hpp` 無しでの ADL 解決を個別に確認。
- 逆依存テスト 16 本を `-Wall -Wextra -fsyntax-only`、`mise run docs-check`、clang-format 通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)